### PR TITLE
Fix gateway debug mode can't view tokio task by `tokio-console`

### DIFF
--- a/src/cyfs_gateway/cyfs_gateway/src/main.rs
+++ b/src/cyfs_gateway/cyfs_gateway/src/main.rs
@@ -18,18 +18,16 @@ mod socks;
 extern crate log;
 
 use crate::gateway::{Gateway, GatewayParams};
+use buckyos_api::*;
 use buckyos_kit::*;
 use clap::{Arg, ArgAction, Command};
-use console_subscriber::{self, Server};
-use cyfs_dns::start_cyfs_dns_server;
 use cyfs_gateway_lib::*;
 use cyfs_warp::*;
 use log::*;
 use name_client::*;
 use name_lib::*;
+use serde_json::Value;
 use std::path::PathBuf;
-use serde_json::{Value};
-use buckyos_api::*;
 use tokio::task;
 use url::Url;
 
@@ -37,11 +35,12 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 async fn service_main(config_json: serde_json::Value, matches: &clap::ArgMatches) -> Result<()> {
     if matches.get_flag("enable_buckyos") {
-        let mut runtime = init_buckyos_api_runtime("cyfs-gateway",None,BuckyOSRuntimeType::Kernel).await?;
+        let mut runtime =
+            init_buckyos_api_runtime("cyfs-gateway", None, BuckyOSRuntimeType::Kernel).await?;
         let login_result = runtime.login().await;
-        if  login_result.is_err() {
-            warn!("cyfs-gateway service login to buckyossystem failed! err:{:?}", login_result);
-        } 
+        if login_result.is_err() {
+            warn!("cyfs-gateway service login to buckyossystem failed! err:{login_result:?}");
+        }
         set_buckyos_api_runtime(runtime);
         info!("cyfs-gateway init buckyos-api-runtime success!");
     }
@@ -50,7 +49,7 @@ async fn service_main(config_json: serde_json::Value, matches: &clap::ArgMatches
     let load_result = config_loader::GatewayConfig::load_from_json_value(config_json).await;
     if load_result.is_err() {
         let msg = format!("Error loading config: {}", load_result.err().unwrap());
-        error!("{}", msg);
+        error!("{msg}");
         std::process::exit(1);
     }
     let config_loader = load_result.unwrap();
@@ -85,12 +84,13 @@ async fn load_config_from_args(matches: &clap::ArgMatches) -> Result<serde_json:
     }
 
     let config_dir = real_config_file.parent().ok_or_else(|| {
-        let msg = format!("cannot get config dir: {:?}", real_config_file);
-        error!("{}", msg);
+        let msg = format!("cannot get config dir: {real_config_file:?}");
+        error!("{msg}");
         msg
     })?;
-    
-    let config_json = buckyos_kit::ConfigMerger::load_dir_with_root(&config_dir, &real_config_file).await?;
+
+    let config_json =
+        buckyos_kit::ConfigMerger::load_dir_with_root(&config_dir, &real_config_file).await?;
 
     Ok(config_json)
 }
@@ -115,8 +115,7 @@ fn generate_ed25519_key_pair_to_local() {
     println!("Public key saved to: {:?}", pk_file);
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let matches = Command::new("CYFS Gateway Service")
         .version(buckyos_kit::get_version())
         .arg(
@@ -167,31 +166,49 @@ async fn main() {
 
     if matches.get_flag("debug") {
         std::env::set_var("RUST_BACKTRACE", "1");
-        buckyos_tracing::init_tracing("cyfs_gateway", true).await;
-        info!("cyfs_gateway start...");
+        // 1) 在创建 runtime 之前初始化 console 订阅者
+        // _guard 需要活到进程结束, 否则drop掉会导致文件日志丢失
+        let _guard = buckyos_tracing::init_tracing("cyfs_gateway", true);
     } else {
         //std::env::set_var("BUCKY_LOG", "debug");
         init_logging("cyfs_gateway", true);
-        info!("cyfs_gateway start...");
     }
+    info!("cyfs_gateway start...");
 
+    // 2) 手动创建 runtime（多线程或当前线程都行）
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let matches_owned = matches.clone();
+        let _h2 = task::Builder::new()
+            .name("main_task")
+            .spawn(async move { async_main(&matches_owned).await }); // 未命名也能看到
+
+        // // 4) 主任务继续等 Ctrl+C
+        let _ = tokio::signal::ctrl_c().await;
+    });
+}
+
+async fn async_main(matches: &clap::ArgMatches) -> anyhow::Result<()> {
     let config_json: serde_json::Value = load_config_from_args(&matches)
         .await
         .map_err(|e| {
-            error!("Error loading config: {}", e);
+            error!("Error loading config: {e}");
             std::process::exit(1);
         })
         .unwrap();
-
-    //let config_json : Value = config_json.unwrap();
     info!(
         "Gateway config: {}",
         serde_json::to_string_pretty(&config_json).unwrap()
     );
 
     if let Err(e) = service_main(config_json, &matches).await {
-        error!("Gateway run error: {}", e);
+        error!("Gateway run error: {e:?}");
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -218,7 +235,7 @@ mod tests {
     async fn test_dispatcher() {
         //TODO: need fix
         std::env::set_var("BUCKY_LOG", "debug");
-        buckyos_kit::init_logging("test_dispatcher",false);
+        buckyos_kit::init_logging("test_dispatcher", false);
         buckyos_kit::start_tcp_echo_server("127.0.0.1:8888").await;
         buckyos_kit::start_udp_echo_server("127.0.0.1:8889").await;
 
@@ -254,7 +271,7 @@ mod tests {
             .unwrap();
 
         let tunnel_manager = GATEWAY_TUNNEL_MANAGER.get().unwrap();
-        let dispatcher = dispatcher::ServiceDispatcher::new(tunnel_manager.clone(),dispatcher_cfg);
+        let dispatcher = dispatcher::ServiceDispatcher::new(tunnel_manager.clone(), dispatcher_cfg);
         dispatcher.start().await;
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         buckyos_kit::start_tcp_echo_client("127.0.0.1:6001").await;


### PR DESCRIPTION
Call the `tracing_subscriber` and `console_subscriber`  before tokio runtime init, and  manually create tokio  runtime.
Keeping the init_tracing return value(guard) so that the file log would not dropped.


Then the `tokio-console` view are work.

<img width="3813" height="929" alt="image" src="https://github.com/user-attachments/assets/7217a685-0416-4c97-a9b4-f7341f2dcb26" />
