### PR TITLE
scheduler: publish verify-hub in node gateway service info

### DIFF
--- a/src/kernel/buckyos-api/src/verify_hub_client.rs
+++ b/src/kernel/buckyos-api/src/verify_hub_client.rs
@@ -11,7 +11,7 @@ use crate::{AppDoc, AppType, SelectorType, UserInfo};
 pub const VERIFY_HUB_UNIQUE_ID: &str = "verify-hub";
 pub const VERIFY_HUB_SERVICE_NAME: &str = "verify-hub";
 pub const VERIFY_HUB_TOKEN_EXPIRE_TIME: u64 = 60 * 10; //10 minutes
-pub const VERIFY_HUB_SERVICE_PORT: u16 = 3210;
+pub const VERIFY_HUB_SERVICE_PORT: u16 = 3300;
 
 #[allow(dead_code)]
 #[derive(Serialize, Deserialize)]

--- a/src/kernel/scheduler/src/system_config_agent.rs
+++ b/src/kernel/scheduler/src/system_config_agent.rs
@@ -15,7 +15,7 @@ use crate::service::*;
 use buckyos_api::{
     get_buckyos_api_runtime, AppServiceSpec, KernelServiceSpec, NodeConfig,
     ServiceInstanceReportInfo, ServiceState, UserSettings, UserType as ApiUserType,
-    ZoneGatewaySettings, CONTROL_PANEL_SERVICE_PORT,
+    ZoneGatewaySettings, CONTROL_PANEL_SERVICE_PORT, VERIFY_HUB_SERVICE_PORT,
 };
 use buckyos_kit::*;
 use name_client::*;
@@ -983,6 +983,21 @@ pub(crate) async fn update_node_gateway_info(
             "system_config".to_string(),
             NodeGatewayServiceInfoEntry {
                 selector: system_config_selector,
+            },
+        );
+    }
+
+    let verify_hub_selector = node_gateway_info
+        .service_info
+        .get("verify-hub")
+        .map(|entry| entry.selector.clone())
+        .filter(|selector| !selector.is_empty())
+        .unwrap_or_else(|| build_fixed_selector_from_oods(&zone_config, VERIFY_HUB_SERVICE_PORT));
+    if !verify_hub_selector.is_empty() {
+        node_gateway_info.service_info.insert(
+            "verify-hub".to_string(),
+            NodeGatewayServiceInfoEntry {
+                selector: verify_hub_selector,
             },
         );
     }
@@ -2090,6 +2105,9 @@ mod tests {
         let system_config = gateway_info.service_info.get("system_config").unwrap();
         assert_eq!(system_config.selector.get("ood1").unwrap().port, 3200);
         assert_eq!(system_config.selector.get("ood2").unwrap().port, 3200);
+
+        let verify_hub = gateway_info.service_info.get("verify-hub").unwrap();
+        assert_eq!(verify_hub.selector.get("ood1").unwrap().port, VERIFY_HUB_SERVICE_PORT);
 
         let files = match gateway_info.app_info.get("files").unwrap() {
             NodeGatewayAppEntry::App(entry) => entry,

--- a/src/kernel/scheduler/src/system_config_builder.rs
+++ b/src/kernel/scheduler/src/system_config_builder.rs
@@ -11,7 +11,7 @@ use buckyos_api::{
     ServiceInstanceReportInfo, ServiceInstanceState, ServiceNode, ServiceState, SubPkgDesc,
     UserContactSettings, UserSettings, UserState, UserTunnelBinding, UserType,
     OPENDAN_SERVICE_PORT, OPENDAN_SERVICE_UNIQUE_ID, SCHEDULER_SERVICE_UNIQUE_ID,
-    VERIFY_HUB_UNIQUE_ID,
+    VERIFY_HUB_SERVICE_PORT, VERIFY_HUB_UNIQUE_ID,
 };
 use buckyos_api::{
     AICC_SERVICE_SERVICE_PORT, AICC_SERVICE_UNIQUE_ID, CONTROL_PANEL_SERVICE_PORT,
@@ -259,7 +259,13 @@ impl SystemConfigBuilder {
 
         let service_doc = generate_verify_hub_service_doc();
 
-        let config = build_kernel_service_spec(VERIFY_HUB_UNIQUE_ID, 3300, 1, service_doc).await?;
+        let config = build_kernel_service_spec(
+            VERIFY_HUB_UNIQUE_ID,
+            VERIFY_HUB_SERVICE_PORT,
+            1,
+            service_doc,
+        )
+        .await?;
         self.insert_json("services/verify-hub/spec", &config)?;
 
         let settings = VerifyHubSettings { trust_keys: vec![] };


### PR DESCRIPTION
Summary
- add verify-hub to generated nodes/{node}/gateway_info.service_info
- reuse the shared VERIFY_HUB_SERVICE_PORT constant when building the verify-hub spec and gateway info
- add scheduler test coverage for the generated verify-hub entry

Why
control-panel discovers verify-hub through gateway_info.service_info. When verify-hub is missing there, service discovery falls back to 127.0.0.1:3180/kapi/verify-hub instead of the actual local 3300 listener.

Test
- cargo test -p scheduler test_update_node_gateway_info_builds_expected_payload -- --nocapture