### PR TITLE
control_panel: add mock monitor/files validation flow

### DIFF
--- a/doc/control_panel/files-validation-plan.context.md
+++ b/doc/control_panel/files-validation-plan.context.md
@@ -1,0 +1,147 @@
+# Files Validation Plan
+
+## Purpose
+
+- 为 `control_panel` 第一阶段验证层提供 `files` 范围的执行清单。
+- 当前目标不是重做 Files 架构，而是先把 `pnpm dev:mock` 跑通，并能验证 `desktop -> files` 主流程。
+- 第一阶段以当前 `FileManagerPage` 为准，不把概念型 [FilesPage.tsx](/home/aa/app/base/buckyos/src/frame/control_panel/web/src/ui/pages/FilesPage.tsx) 纳入验证范围。
+
+## Quick Start
+
+```bash
+cd src/frame/control_panel/web
+pnpm install
+pnpm dev:mock
+```
+
+验证入口：
+
+- desktop 窗口模式：`http://127.0.0.1:4020/`
+- 独立页面模式：`http://127.0.0.1:4020/files`
+- 公开分享模式：`http://127.0.0.1:4020/share/share-welcome`
+
+## Current Scope
+
+### In Scope
+
+- 文件浏览
+- recent / starred / trash 切换
+- 搜索
+- 文本预览
+- 图片预览
+- 创建文件夹
+- 重命名
+- 移动到回收站 / restore / delete forever
+- share list / create share / delete share
+- public share 打开与预览
+- upload session mock 流程
+
+### Out Of Scope
+
+- Office 文档在线预览
+- 真实文件系统与真实权限链路
+- 大规模 benchmark
+- 真实 gateway 公开分享链路
+
+## UI DataModel
+
+### FilesShellState
+
+- `mainTab: 'files' | 'shares' | 'editor'`
+- `filesScope: 'browse' | 'recent' | 'starred' | 'trash'`
+- `currentPath: string`
+- `currentPathIsDir: boolean`
+- `selectedPaths: string[]`
+- `message: string`
+
+### BrowseState
+
+- `items: FileEntry[]`
+- `loading: boolean`
+- `searchActive: boolean`
+- `searchResults: FileEntry[]`
+- `searchTruncated: boolean`
+
+### PreviewState
+
+- `previewEntry: FileEntry | null`
+- `previewKind`
+- `previewTextContent`
+- `previewImageSrc`
+- `previewError`
+
+### ShareState
+
+- `shares: ShareItem[]`
+- `shareDialog`
+- `publicShareData: PublicShareResponse | null`
+- `publicShareError: string`
+
+### UploadState
+
+- `uploadProgress: UploadProgressItem[]`
+- `uploadPanelOpen: boolean`
+- `uploadPaused: boolean`
+
+### Required UI States
+
+- `loading`
+- `ready`
+- `empty-directory`
+- `empty-share-list`
+- `empty-trash`
+- `search-no-result`
+- `preview-error`
+- `uploading`
+
+## Mock Runtime Design
+
+- mock 模式通过 `VITE_CP_USE_MOCK=1` 打开
+- 浏览器内 mock server 接管 `/api/*`
+- 不依赖 Vite 代理到 `127.0.0.1:3180`
+- session 由 mock auth 自动注入
+- mock 数据目前是 in-memory state，刷新页面会回到初始 fixture
+
+## Mock Dataset
+
+默认 fixture 包含：
+
+- `/Documents/Welcome.md`
+- `/Documents/Runbook.json`
+- `/Projects/ControlPanel/notes.txt`
+- `/Pictures/nebula.svg`
+- `/Uploads/`
+- favorites 2 条
+- recent 2 条
+- recycle bin 1 条
+- public shares 2 条
+
+## Main Flows
+
+1. 打开 `/`
+2. 在 desktop 打开 `Files` 窗口
+3. 浏览根目录
+4. 进入 `Documents`
+5. 搜索 `welcome`
+6. 切到 `Recent`
+7. 切到 `Starred`
+8. 切到 `Trash`
+9. 返回 `Browse`
+10. 创建 share
+11. 打开 `/share/share-welcome`
+12. 返回 desktop 后执行一次 upload
+
+## Done For This Stage
+
+- `pnpm dev:mock` 可直接启动 Files
+- `/files` 独立页面模式已可访问
+- `desktop -> files` 主路径在 mock 环境下可演示
+- 核心 `/api/*` 已有 mock handler
+- 启动说明与覆盖范围已文档化
+
+## Follow-up
+
+- 将当前 in-memory mock server 逐步收口为 `FilesDataSource`
+- 增加 Playwright mock smoke
+- 给 fixture 增加场景切换
+- 为 search / list / upload 加 benchmark 脚本

--- a/doc/control_panel/monitor-validation-plan.context.md
+++ b/doc/control_panel/monitor-validation-plan.context.md
@@ -1,0 +1,98 @@
+# Monitor Validation Plan
+
+## Purpose
+
+- 为 `control_panel` 第一阶段验证层提供 `monitor` 范围的执行清单。
+- 对齐 Harness 的 Mock-first 要求：`pnpm run dev` 必须可独立运行，并能验证主流程。
+- 当前范围只覆盖 desktop 内的 `monitor` 能力，不扩展到 `network`、`containers`、`storage` 等窗口。
+
+## Quick Start
+
+```bash
+cd src/frame/control_panel/web
+pnpm install
+pnpm dev:mock
+```
+
+- 访问 `http://127.0.0.1:4020/`
+- mock 模式下不依赖 `127.0.0.1:3180`
+- 认证会自动进入 mock 会话
+
+## Current Scope
+
+### In Scope
+
+- desktop 首页启动
+- desktop 中 monitor 窗口的打开与渲染
+- layout / overview / system metrics / system status / network overview / log peek 的 mock 数据驱动
+- mock fallback 文案与错误容忍逻辑
+
+### Out Of Scope
+
+- 真实后端联调
+- container / zone / gateway / AI Models 的深度验证
+- benchmark 与 DV Test
+
+## UI DataModel
+
+### DesktopShellState
+
+- `layout: RootLayoutData`
+- `profile: UserProfile`
+- `systemStatus: SystemStatus`
+- `windows: DesktopWindow[]`
+
+### MonitorState
+
+- `overview: SystemOverview | null`
+- `metrics: SystemMetrics`
+- `status: SystemStatusResponse`
+- `networkOverview: NetworkOverview | null`
+- `logPeek: SystemLogEntry[] | null`
+- `layoutError: string | null`
+- `overviewError: string | null`
+- `networkError: string | null`
+- `logPeekError: string | null`
+
+### Required UI States
+
+- `loading`
+- `ready`
+- `fallback-ready`
+- `empty-log`
+- `degraded-warning`
+
+## Mock Fixtures
+
+当前 monitor mock fixture 由 `src/frame/control_panel/web/src/api/index.ts` 中的 mock payload 提供，并在 `VITE_CP_USE_MOCK=1` 时直接返回。
+
+建议后续拆分为：
+
+- `happy`
+- `warning`
+- `empty-log`
+- `high-load`
+
+## Main Flows
+
+1. 打开 `/`
+2. 自动进入 mock 会话
+3. desktop 渲染成功
+4. 打开 `System Monitor` 窗口
+5. 看见 CPU / memory / disk / network 卡片
+6. 看见 trend 图表
+7. 看见 log preview
+8. 刷新页面后仍可低成本重进
+
+## Done For This Stage
+
+- `pnpm dev:mock` 可直接启动
+- monitor 数据不依赖真实后端
+- desktop + monitor 主流程能人工稳定复现
+- 文档说明足够简洁，团队成员无需翻代码猜启动方式
+
+## Follow-up
+
+- 增加 monitor mock fixture 切换入口
+- 为 monitor 增加 Playwright smoke
+- 为 metrics / logs 增加 benchmark 输入数据梯度

--- a/src/frame/control_panel/web/README.md
+++ b/src/frame/control_panel/web/README.md
@@ -1,6 +1,47 @@
 
 # Control panel
 
+## Quick start
+
+Mock-first local UI loop:
+
+```bash
+cd src/frame/control_panel/web
+pnpm install
+pnpm dev:mock
+```
+
+This starts the control panel on `http://127.0.0.1:4020` with:
+
+- mock auth enabled
+- monitor data served from in-memory fixtures
+- files `/api/*` served by an in-browser mock server
+- no dependency on `127.0.0.1:3180`
+
+Live backend mode:
+
+```bash
+cd src/frame/control_panel/web
+pnpm install
+pnpm dev:live
+```
+
+This keeps the existing Vite proxy to `127.0.0.1:3180`.
+
+Mock smoke tests:
+
+```bash
+cd src/frame/control_panel/web
+pnpm install
+pnpm test:e2e:mock
+```
+
+Current smoke coverage:
+
+- desktop monitor window
+- standalone files route
+- public share route
+
 原型参考：
 https://spray-jargon-85834573.figma.site/
 
@@ -20,3 +61,4 @@ cargo run -p control_panel
 - Files 页面属于 Control Panel Web 的内嵌模块（不是独立前端工程）。
 - Files API 由 `control_panel` 服务统一提供（`/api/*`），并在后端转发到内嵌 file manager。
 - 本地前端开发目录：`src/frame/control_panel/web`。
+- Mock-first 开发模式下，`/api/*` 会被浏览器内 mock handler 接管，用于验证 `monitor + files` 主流程。

--- a/src/frame/control_panel/web/package.json
+++ b/src/frame/control_panel/web/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "VITE_CP_USE_MOCK=1 vite --host 127.0.0.1 --port 4020",
+    "dev:live": "vite --host 127.0.0.1 --port 4020",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test:e2e:mock": "playwright test -c tests/playwright/playwright.config.ts",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -25,6 +28,7 @@
     "swr": "^2.4.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@eslint/js": "^9.36.0",
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",

--- a/src/frame/control_panel/web/src/api/index.ts
+++ b/src/frame/control_panel/web/src/api/index.ts
@@ -1,5 +1,6 @@
 import {buckyos} from 'buckyos'
 import { ensureSessionToken } from '@/auth/authManager'
+import { isMockRuntime, waitForMockLatency } from '@/config/runtime'
 
 const rpcClient = new buckyos.kRPCClient('/kapi/control-panel')
 
@@ -473,7 +474,19 @@ const normalizeAppItem = (item: DappCard | string): DappCard => {
   }
 }
 
+const mockSystemOverview: SystemOverview = {
+  name: 'Mock Node',
+  model: 'BuckyOS Desktop Validation',
+  os: 'Ubuntu 24.04 LTS',
+  version: 'mock-dev',
+  uptime_seconds: 345678,
+}
+
 export const fetchLayout = async (): Promise<{ data: RootLayoutData | null; error: unknown }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockLayoutData, error: null }
+  }
   try {
     const { data, error } = await callRpc<RootLayoutData>('ui.layout', {})
     if (!data) {
@@ -510,6 +523,10 @@ export const fetchDashboard = async (): Promise<{ data: DashboardState | null; e
 }
 
 export const fetchAppsList = async (): Promise<{ data: DappCard[] | null; error: unknown }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockDappStoreData, error: null }
+  }
   const { data, error } = await callRpc<AppsListResponse>('apps.list', {})
   if (!data || !Array.isArray(data.items)) {
     return { data: null, error }
@@ -520,6 +537,15 @@ export const fetchAppsList = async (): Promise<{ data: DappCard[] | null; error:
 export const fetchAppsVersionList = async (
   names: string[] = [],
 ): Promise<{ data: Record<string, string> | null; error: unknown }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    const versions = Object.fromEntries(
+      mockDappStoreData
+        .filter((item) => names.length === 0 || names.includes(item.name))
+        .map((item) => [item.name, item.version ?? '0.0.0']),
+    )
+    return { data: versions, error: null }
+  }
   const params = names.length > 0 ? { names } : {}
   const { data, error } = await callRpc<AppsVersionListResponse>('apps.version.list', params)
   if (!data || !Array.isArray(data.items)) {
@@ -544,7 +570,13 @@ export const fetchAppsVersionList = async (
 export const fetchSystemOverview = async (): Promise<{
   data: SystemOverview | null
   error: unknown
-}> => callRpc<SystemOverview>('system.overview', {})
+}> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockSystemOverview, error: null }
+  }
+  return callRpc<SystemOverview>('system.overview', {})
+}
 
 export const fetchSystemMetrics = async (
   options: { lite?: boolean } = {},
@@ -552,6 +584,11 @@ export const fetchSystemMetrics = async (
   data: SystemMetrics | null
   error: unknown
 }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    void options
+    return { data: mockSystemMetrics, error: null }
+  }
   const { data, error } = await callRpc<SystemMetrics>(
     'system.metrics',
     options.lite ? { lite: true } : {},
@@ -578,6 +615,10 @@ export const fetchNetworkOverview = async (): Promise<{
   data: NetworkOverview | null
   error: unknown
 }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockNetworkOverview, error: null }
+  }
   const { data, error } = await callRpc<NetworkOverview>('network.overview', {})
   if (!data) {
     return { data: mockNetworkOverview, error }
@@ -599,6 +640,10 @@ export const fetchSystemStatus = async (): Promise<{
   data: SystemStatusResponse | null
   error: unknown
 }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockSystemStatus, error: null }
+  }
   const { data, error } = await callRpc<SystemStatusResponse>('system.status', {})
   if (!data) {
     return { data: mockSystemStatus, error }
@@ -616,6 +661,10 @@ export const fetchGatewayOverview = async (): Promise<{
   data: GatewayOverview | null
   error: unknown
 }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockGatewayOverview, error: null }
+  }
   const { data, error } = await callRpc<GatewayOverview>('gateway.overview', {})
   if (!data) {
     return { data: mockGatewayOverview, error }
@@ -651,6 +700,10 @@ export const fetchZoneOverview = async (): Promise<{
   data: ZoneOverview | null
   error: unknown
 }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockZoneOverview, error: null }
+  }
   const { data, error } = await callRpc<ZoneOverview>('zone.overview', {})
   if (!data) {
     return { data: mockZoneOverview, error }
@@ -673,6 +726,10 @@ export const fetchContainerOverview = async (): Promise<{
   data: ContainerOverview | null
   error: unknown
 }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockContainerOverview, error: null }
+  }
   const { data, error } = await callRpc<ContainerOverview>('container.overview', {})
   if (!data) {
     return { data: mockContainerOverview, error }
@@ -734,6 +791,10 @@ export const fetchLogServices = async (): Promise<{
   data: SystemLogService[] | null
   error: unknown
 }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    return { data: mockLogServices, error: null }
+  }
   const { data, error } = await callRpc<{ services: SystemLogService[] }>('system.logs.list', {})
   if (!data?.services?.length) {
     return { data: mockLogServices, error }
@@ -744,6 +805,11 @@ export const fetchLogServices = async (): Promise<{
 export const querySystemLogs = async (
   params: LogQueryParams,
 ): Promise<{ data: SystemLogQueryResponse | null; error: unknown }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    void params
+    return { data: { entries: mockLogEntries }, error: null }
+  }
   const { data, error } = await callRpc<SystemLogQueryResponse>('system.logs.query', params)
   if (!data) {
     return { data: { entries: mockLogEntries }, error }
@@ -754,6 +820,11 @@ export const querySystemLogs = async (
 export const tailSystemLogs = async (
   params: LogTailParams,
 ): Promise<{ data: SystemLogQueryResponse | null; error: unknown }> => {
+  if (isMockRuntime()) {
+    await waitForMockLatency()
+    void params
+    return { data: { entries: mockLogEntries }, error: null }
+  }
   const { data, error } = await callRpc<SystemLogQueryResponse>('system.logs.tail', params)
   if (!data) {
     return { data: { entries: [] }, error }
@@ -1174,6 +1245,7 @@ export {
   mockLayoutData,
   mockDashboardData,
   mockDappStoreData,
+  mockSystemOverview,
   mockSystemMetrics,
   mockSystemStatus,
   mockNetworkOverview,

--- a/src/frame/control_panel/web/src/auth/AuthProvider.tsx
+++ b/src/frame/control_panel/web/src/auth/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { isMockRuntime } from '@/config/runtime'
 import { ensureAuthRuntime, ensureSessionToken, loginWithPassword, signOutSession } from './authManager'
 import { AuthContext, type AuthContextValue, type AuthStatus } from './authContext'
 
@@ -17,6 +18,10 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
     setStatus('loading')
 
     try {
+      if (isMockRuntime()) {
+        setStatus('authenticated')
+        return
+      }
       await ensureAuthRuntime()
       const token = await ensureSessionToken()
       setStatus(token ? 'authenticated' : 'unauthenticated')
@@ -33,7 +38,6 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const signInWithPasswordAction = useCallback(async (username: string, password: string, redirectUrl?: string | null) => {
     setInitError(null)
-    await ensureAuthRuntime()
     await loginWithPassword(username, password, redirectUrl)
     setStatus('authenticated')
   }, [])

--- a/src/frame/control_panel/web/src/auth/authManager.ts
+++ b/src/frame/control_panel/web/src/auth/authManager.ts
@@ -1,4 +1,12 @@
 import { buckyos } from 'buckyos'
+import {
+  CONTROL_PANEL_MOCK_REFRESH_TOKEN,
+  CONTROL_PANEL_MOCK_SESSION_TOKEN,
+  CONTROL_PANEL_MOCK_USER_ID,
+  CONTROL_PANEL_MOCK_USER_TYPE,
+  CONTROL_PANEL_MOCK_USERNAME,
+  isMockRuntime,
+} from '@/config/runtime'
 
 import {
   clearStoredSession,
@@ -75,7 +83,24 @@ const hasValidTokenPair = (accountInfo: StoredAccountInfo | null) =>
 const callAuthRpc = async <T>(method: string, params: Record<string, unknown>) =>
   authRpcClient.call<T, Record<string, unknown>>(method, params)
 
+const seedMockSession = (username = CONTROL_PANEL_MOCK_USERNAME) => {
+  saveStoredAccountInfo({
+    user_name: username,
+    user_id: CONTROL_PANEL_MOCK_USER_ID,
+    user_type: CONTROL_PANEL_MOCK_USER_TYPE,
+    session_token: CONTROL_PANEL_MOCK_SESSION_TOKEN,
+    refresh_token: CONTROL_PANEL_MOCK_REFRESH_TOKEN,
+  })
+  saveSsoSessionCookie(CONTROL_PANEL_MOCK_SESSION_TOKEN)
+  resetVerifyCache()
+}
+
 export const ensureAuthRuntime = async () => {
+  if (isMockRuntime()) {
+    seedMockSession()
+    return
+  }
+
   if (runtimeReady) {
     return
   }
@@ -177,6 +202,11 @@ type EnsureSessionOptions = {
 export const ensureSessionToken = async (options: EnsureSessionOptions = {}) => {
   await ensureAuthRuntime()
 
+  if (isMockRuntime()) {
+    seedMockSession()
+    return CONTROL_PANEL_MOCK_SESSION_TOKEN
+  }
+
   const forceRefresh = options.forceRefresh === true
   const stored = getStoredAccountInfo()
   if (!hasValidTokenPair(stored)) {
@@ -202,6 +232,19 @@ export const ensureSessionToken = async (options: EnsureSessionOptions = {}) => 
 }
 
 export const loginWithPassword = async (username: string, password: string, redirectUrl?: string | null) => {
+  if (isMockRuntime()) {
+    void password
+    void redirectUrl
+    seedMockSession(username.trim() || CONTROL_PANEL_MOCK_USERNAME)
+    return getStoredAccountInfo() ?? {
+      user_name: username.trim() || CONTROL_PANEL_MOCK_USERNAME,
+      user_id: CONTROL_PANEL_MOCK_USER_ID,
+      user_type: CONTROL_PANEL_MOCK_USER_TYPE,
+      session_token: CONTROL_PANEL_MOCK_SESSION_TOKEN,
+      refresh_token: CONTROL_PANEL_MOCK_REFRESH_TOKEN,
+    }
+  }
+
   await ensureAuthRuntime()
 
   const trimmedUsername = username.trim()
@@ -244,6 +287,12 @@ export const loginWithPassword = async (username: string, password: string, redi
 }
 
 export const issueSsoTokenForRedirect = async (redirectUrl: string) => {
+  if (isMockRuntime()) {
+    void redirectUrl
+    seedMockSession()
+    return CONTROL_PANEL_MOCK_SESSION_TOKEN
+  }
+
   await ensureAuthRuntime()
 
   const normalizedRedirectUrl = redirectUrl.trim()
@@ -270,6 +319,12 @@ export const issueSsoTokenForRedirect = async (redirectUrl: string) => {
 }
 
 export const signOutSession = async () => {
+  if (isMockRuntime()) {
+    clearStoredSession()
+    resetVerifyCache()
+    return
+  }
+
   try {
     await callAuthRpc('auth.logout', {})
   } catch {

--- a/src/frame/control_panel/web/src/config/runtime.ts
+++ b/src/frame/control_panel/web/src/config/runtime.ts
@@ -1,0 +1,39 @@
+const MOCK_FLAG_VALUES = new Set(['1', 'true', 'yes', 'mock'])
+
+const readMockFlag = () => {
+  const raw = String(import.meta.env.VITE_CP_USE_MOCK ?? '').trim().toLowerCase()
+  return MOCK_FLAG_VALUES.has(raw)
+}
+
+const encodeBase64Url = (value: string) =>
+  btoa(value)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+
+export const CONTROL_PANEL_USE_MOCK = readMockFlag()
+export const CONTROL_PANEL_MOCK_USERNAME = 'mock.admin'
+export const CONTROL_PANEL_MOCK_USER_ID = 'mock-admin-user'
+export const CONTROL_PANEL_MOCK_USER_TYPE = 'owner'
+export const CONTROL_PANEL_MOCK_REFRESH_TOKEN = 'mock-refresh-token'
+export const CONTROL_PANEL_MOCK_SESSION_TOKEN = (() => {
+  const header = encodeBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = encodeBase64Url(
+    JSON.stringify({
+      sub: CONTROL_PANEL_MOCK_USERNAME,
+      uid: CONTROL_PANEL_MOCK_USER_ID,
+      role: CONTROL_PANEL_MOCK_USER_TYPE,
+      iss: 'control-panel-mock',
+    }),
+  )
+  return `${header}.${payload}.mock-signature`
+})()
+
+export const isMockRuntime = () => CONTROL_PANEL_USE_MOCK
+
+export const waitForMockLatency = async (ms = 80) => {
+  if (ms <= 0) {
+    return
+  }
+  await new Promise((resolve) => window.setTimeout(resolve, ms))
+}

--- a/src/frame/control_panel/web/src/main.tsx
+++ b/src/frame/control_panel/web/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { installFilesMockServer } from './mock/files/mockServer'
+
+installFilesMockServer()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/frame/control_panel/web/src/mock/files/mockServer.ts
+++ b/src/frame/control_panel/web/src/mock/files/mockServer.ts
@@ -1,0 +1,1078 @@
+import {
+  CONTROL_PANEL_MOCK_SESSION_TOKEN,
+  CONTROL_PANEL_MOCK_USERNAME,
+  isMockRuntime,
+  waitForMockLatency,
+} from '@/config/runtime'
+
+type MockDirectoryNode = {
+  kind: 'dir'
+  path: string
+  modified: number
+}
+
+type MockTextFileNode = {
+  kind: 'text'
+  path: string
+  modified: number
+  mime: string
+  content: string
+}
+
+type MockBinaryFileNode = {
+  kind: 'binary'
+  path: string
+  modified: number
+  mime: string
+  bytes: Uint8Array
+}
+
+type MockNode = MockDirectoryNode | MockTextFileNode | MockBinaryFileNode
+
+type MockShare = {
+  id: string
+  owner: string
+  path: string
+  created_at: number
+  expires_at?: number | null
+  password_required: boolean
+  password?: string
+}
+
+type MockRecentEntry = {
+  path: string
+  last_accessed_at: number
+  access_count: number
+}
+
+type MockTrashEntry = {
+  item_id: string
+  path: string
+  original_path: string
+  deleted_at: number
+  node: MockNode
+}
+
+type MockUploadSession = {
+  session: {
+    id: string
+    owner: string
+    path: string
+    size: number
+    chunk_size: number
+    uploaded_size: number
+    override_existing: boolean
+    created_at: number
+    updated_at: number
+  }
+  chunks: Uint8Array[]
+}
+
+type MockFilesState = {
+  nodes: Map<string, MockNode>
+  favorites: Set<string>
+  recent: Map<string, MockRecentEntry>
+  recycleBin: Map<string, MockTrashEntry>
+  shares: Map<string, MockShare>
+  uploads: Map<string, MockUploadSession>
+}
+
+const encoder = new TextEncoder()
+let installed = false
+let state: MockFilesState | null = null
+
+const nowSeconds = () => Math.floor(Date.now() / 1000)
+
+const normalizePath = (path: string) => {
+  if (!path || path.trim() === '') {
+    return '/'
+  }
+  let normalized = path.trim()
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`
+  }
+  normalized = normalized.replace(/\/{2,}/g, '/')
+  if (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1)
+  }
+  return normalized || '/'
+}
+
+const parentPath = (path: string) => {
+  const normalized = normalizePath(path)
+  if (normalized === '/') {
+    return '/'
+  }
+  const index = normalized.lastIndexOf('/')
+  return index <= 0 ? '/' : normalized.slice(0, index)
+}
+
+const fileNameFromPath = (path: string) => {
+  const parts = normalizePath(path).split('/').filter(Boolean)
+  return parts[parts.length - 1] ?? ''
+}
+
+const joinPath = (base: string, name: string) => {
+  const normalizedBase = normalizePath(base)
+  return normalizedBase === '/' ? `/${name}` : `${normalizedBase}/${name}`
+}
+
+const isChildOf = (candidate: string, parent: string) => {
+  const normalizedCandidate = normalizePath(candidate)
+  const normalizedParent = normalizePath(parent)
+  if (normalizedParent === '/') {
+    return normalizedCandidate !== '/' && parentPath(normalizedCandidate) === '/'
+  }
+  return parentPath(normalizedCandidate) === normalizedParent
+}
+
+const isInSubtree = (candidate: string, root: string) => {
+  const normalizedCandidate = normalizePath(candidate)
+  const normalizedRoot = normalizePath(root)
+  if (normalizedRoot === '/') {
+    return normalizedCandidate !== '/'
+  }
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}/`)
+}
+
+const getNodeSize = (node: MockNode) => {
+  if (node.kind === 'dir') {
+    return 0
+  }
+  if (node.kind === 'text') {
+    return encoder.encode(node.content).byteLength
+  }
+  return node.bytes.byteLength
+}
+
+const getNodeMime = (node: MockNode) => {
+  if (node.kind === 'dir') {
+    return 'inode/directory'
+  }
+  return node.mime
+}
+
+const makeFileEntry = (node: MockNode) => ({
+  name: fileNameFromPath(node.path),
+  path: normalizePath(node.path),
+  is_dir: node.kind === 'dir',
+  size: getNodeSize(node),
+  modified: node.modified,
+})
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    },
+  })
+
+const errorResponse = (status: number, message: string) => jsonResponse({ error: message }, status)
+
+const createSvgBytes = (label: string, accent = '#0f766e') =>
+  encoder.encode(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="420" viewBox="0 0 640 420">
+      <defs>
+        <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="#ecfeff" />
+          <stop offset="100%" stop-color="#ccfbf1" />
+        </linearGradient>
+      </defs>
+      <rect width="640" height="420" fill="url(#bg)" rx="28" />
+      <circle cx="140" cy="126" r="64" fill="${accent}" opacity="0.14" />
+      <circle cx="520" cy="308" r="96" fill="${accent}" opacity="0.12" />
+      <rect x="72" y="80" width="496" height="260" rx="24" fill="#ffffff" stroke="#d7e1df" />
+      <text x="102" y="182" fill="#0f172a" font-size="34" font-family="Work Sans, sans-serif" font-weight="700">${label}</text>
+      <text x="102" y="228" fill="#52606d" font-size="20" font-family="Work Sans, sans-serif">BuckyOS mock image preview</text>
+    </svg>`,
+  )
+
+const createInitialState = (): MockFilesState => {
+  const seedTime = nowSeconds()
+  const nodes = new Map<string, MockNode>()
+  const addNode = (node: MockNode) => {
+    nodes.set(normalizePath(node.path), {
+      ...node,
+      path: normalizePath(node.path),
+    })
+  }
+
+  addNode({ kind: 'dir', path: '/', modified: seedTime - 7200 })
+  addNode({ kind: 'dir', path: '/Documents', modified: seedTime - 7200 })
+  addNode({ kind: 'dir', path: '/Projects', modified: seedTime - 5400 })
+  addNode({ kind: 'dir', path: '/Projects/ControlPanel', modified: seedTime - 3600 })
+  addNode({ kind: 'dir', path: '/Pictures', modified: seedTime - 2800 })
+  addNode({ kind: 'dir', path: '/Uploads', modified: seedTime - 1800 })
+
+  addNode({
+    kind: 'text',
+    path: '/Documents/Welcome.md',
+    modified: seedTime - 900,
+    mime: 'text/markdown; charset=utf-8',
+    content: `# Welcome\n\nThis is the mock Files workspace for control_panel.\n\n- Browse folders in desktop mode\n- Open files from the list\n- Create shares and test public preview\n- Upload files without a backend service\n`,
+  })
+  addNode({
+    kind: 'text',
+    path: '/Documents/Runbook.json',
+    modified: seedTime - 1500,
+    mime: 'application/json; charset=utf-8',
+    content: JSON.stringify(
+      {
+        owner: 'mock.admin',
+        services: ['control_panel', 'verify_hub'],
+        checks: ['session bootstrap', 'monitor cards', 'files browse'],
+      },
+      null,
+      2,
+    ),
+  })
+  addNode({
+    kind: 'text',
+    path: '/Projects/ControlPanel/notes.txt',
+    modified: seedTime - 700,
+    mime: 'text/plain; charset=utf-8',
+    content: 'Monitor and Files are the first validation slice.\nNext step: benchmark the frozen UI DataModel.\n',
+  })
+  addNode({
+    kind: 'binary',
+    path: '/Pictures/nebula.svg',
+    modified: seedTime - 500,
+    mime: 'image/svg+xml',
+    bytes: createSvgBytes('Nebula Preview'),
+  })
+
+  const shares = new Map<string, MockShare>([
+    [
+      'share-welcome',
+      {
+        id: 'share-welcome',
+        owner: CONTROL_PANEL_MOCK_USERNAME,
+        path: '/Documents/Welcome.md',
+        created_at: seedTime - 1200,
+        expires_at: seedTime + 7 * 24 * 3600,
+        password_required: false,
+      },
+    ],
+    [
+      'share-pictures',
+      {
+        id: 'share-pictures',
+        owner: CONTROL_PANEL_MOCK_USERNAME,
+        path: '/Pictures',
+        created_at: seedTime - 1500,
+        expires_at: null,
+        password_required: true,
+        password: 'bucky',
+      },
+    ],
+  ])
+
+  const recent = new Map<string, MockRecentEntry>([
+    [
+      '/Documents/Welcome.md',
+      {
+        path: '/Documents/Welcome.md',
+        last_accessed_at: seedTime - 300,
+        access_count: 4,
+      },
+    ],
+    [
+      '/Pictures/nebula.svg',
+      {
+        path: '/Pictures/nebula.svg',
+        last_accessed_at: seedTime - 240,
+        access_count: 2,
+      },
+    ],
+  ])
+
+  const recycleBin = new Map<string, MockTrashEntry>([
+    [
+      'trash-draft',
+      {
+        item_id: 'trash-draft',
+        path: '/.trash/mock-draft.md',
+        original_path: '/Documents/Draft.md',
+        deleted_at: seedTime - 1800,
+        node: {
+          kind: 'text',
+          path: '/Documents/Draft.md',
+          modified: seedTime - 1900,
+          mime: 'text/markdown; charset=utf-8',
+          content: '# Draft\n\nThis file lives in the mock recycle bin.\n',
+        },
+      },
+    ],
+  ])
+
+  return {
+    nodes,
+    favorites: new Set(['/Documents/Welcome.md', '/Pictures/nebula.svg']),
+    recent,
+    recycleBin,
+    shares,
+    uploads: new Map(),
+  }
+}
+
+const getState = () => {
+  if (!state) {
+    state = createInitialState()
+  }
+  return state
+}
+
+const cloneNode = (node: MockNode, nextPath = node.path): MockNode => {
+  if (node.kind === 'dir') {
+    return { ...node, path: normalizePath(nextPath) }
+  }
+  if (node.kind === 'text') {
+    return { ...node, path: normalizePath(nextPath) }
+  }
+  return { ...node, path: normalizePath(nextPath), bytes: node.bytes.slice() }
+}
+
+const setNode = (nextNode: MockNode) => {
+  const current = getState()
+  current.nodes.set(normalizePath(nextNode.path), cloneNode(nextNode))
+}
+
+const getNode = (path: string) => getState().nodes.get(normalizePath(path)) ?? null
+
+const listChildren = (path: string) =>
+  Array.from(getState().nodes.values())
+    .filter((node) => isChildOf(node.path, path))
+    .sort((left, right) => {
+      const leftEntry = makeFileEntry(left)
+      const rightEntry = makeFileEntry(right)
+      if (leftEntry.is_dir !== rightEntry.is_dir) {
+        return leftEntry.is_dir ? -1 : 1
+      }
+      return leftEntry.name.localeCompare(rightEntry.name)
+    })
+
+const updateRecent = (path: string) => {
+  const normalized = normalizePath(path)
+  const current = getState()
+  const existing = current.recent.get(normalized)
+  current.recent.set(normalized, {
+    path: normalized,
+    last_accessed_at: nowSeconds(),
+    access_count: (existing?.access_count ?? 0) + 1,
+  })
+}
+
+const replacePathReferences = (sourcePath: string, targetPath: string) => {
+  const current = getState()
+  const normalizedSource = normalizePath(sourcePath)
+  const normalizedTarget = normalizePath(targetPath)
+
+  const nextFavorites = new Set<string>()
+  for (const path of current.favorites) {
+    if (isInSubtree(path, normalizedSource)) {
+      nextFavorites.add(path.replace(normalizedSource, normalizedTarget))
+    } else {
+      nextFavorites.add(path)
+    }
+  }
+  current.favorites = nextFavorites
+
+  const nextRecent = new Map<string, MockRecentEntry>()
+  for (const item of current.recent.values()) {
+    if (isInSubtree(item.path, normalizedSource)) {
+      const nextPath = item.path.replace(normalizedSource, normalizedTarget)
+      nextRecent.set(nextPath, { ...item, path: nextPath })
+    } else {
+      nextRecent.set(item.path, item)
+    }
+  }
+  current.recent = nextRecent
+
+  for (const share of current.shares.values()) {
+    if (isInSubtree(share.path, normalizedSource)) {
+      share.path = share.path.replace(normalizedSource, normalizedTarget)
+    }
+  }
+}
+
+const removeSubtree = (path: string) => {
+  const current = getState()
+  for (const key of Array.from(current.nodes.keys())) {
+    if (isInSubtree(key, path)) {
+      current.nodes.delete(key)
+    }
+  }
+  current.favorites.delete(normalizePath(path))
+  current.recent.delete(normalizePath(path))
+}
+
+const moveSubtree = (sourcePath: string, targetPath: string, copyOnly: boolean) => {
+  const current = getState()
+  const normalizedSource = normalizePath(sourcePath)
+  const normalizedTarget = normalizePath(targetPath)
+  const items = Array.from(current.nodes.values())
+    .filter((node) => isInSubtree(node.path, normalizedSource))
+    .sort((left, right) => left.path.length - right.path.length)
+
+  for (const item of items) {
+    const nextPath = item.path === normalizedSource
+      ? normalizedTarget
+      : item.path.replace(normalizedSource, normalizedTarget)
+    setNode(cloneNode(item, nextPath))
+  }
+
+  if (!copyOnly) {
+    removeSubtree(normalizedSource)
+    replacePathReferences(normalizedSource, normalizedTarget)
+  }
+}
+
+const contentForInlinePreview = (node: MockNode) => {
+  if (node.kind !== 'text') {
+    return null
+  }
+  if (node.mime.startsWith('text/') || node.mime.includes('json')) {
+    return node.content
+  }
+  return null
+}
+
+const toBlob = (node: MockNode) => {
+  if (node.kind === 'dir') {
+    return null
+  }
+  if (node.kind === 'text') {
+    return new Blob([node.content], { type: node.mime })
+  }
+  return new Blob([new Uint8Array(node.bytes)], { type: node.mime })
+}
+
+const buildDirectoryPayload = (path: string) => ({
+  path: normalizePath(path),
+  is_dir: true,
+  items: listChildren(path).map(makeFileEntry),
+})
+
+const buildFilePayload = (node: MockNode, includeContent = false) => ({
+  path: normalizePath(node.path),
+  is_dir: false,
+  size: getNodeSize(node),
+  modified: node.modified,
+  content: includeContent ? contentForInlinePreview(node) : undefined,
+})
+
+const resolveAuthFailure = () => {
+  const cookie = document.cookie || ''
+  const header = CONTROL_PANEL_MOCK_SESSION_TOKEN
+  return cookie.includes(encodeURIComponent(header)) || cookie.includes(header)
+}
+
+const checkMockAuth = () => resolveAuthFailure()
+
+const handleResourcesGet = async (_request: Request, url: URL, rawResourcePath: string) => {
+  const targetPath = normalizePath(decodeURIComponent(rawResourcePath || '/'))
+  const node = getNode(targetPath)
+  if (!node) {
+    return errorResponse(404, `Path not found: ${targetPath}`)
+  }
+
+  if (node.kind === 'dir') {
+    return jsonResponse(buildDirectoryPayload(targetPath))
+  }
+
+  updateRecent(targetPath)
+  const includeContent = url.searchParams.get('content') === '1'
+  return jsonResponse(buildFilePayload(node, includeContent))
+}
+
+const handleResourcesPost = async (rawResourcePath: string) => {
+  const targetPath = normalizePath(decodeURIComponent(rawResourcePath || '/'))
+  if (getNode(targetPath)) {
+    return errorResponse(409, `Path already exists: ${targetPath}`)
+  }
+
+  const parent = parentPath(targetPath)
+  const parentNode = getNode(parent)
+  if (!parentNode || parentNode.kind !== 'dir') {
+    return errorResponse(404, `Parent directory not found: ${parent}`)
+  }
+
+  setNode({
+    kind: 'dir',
+    path: targetPath,
+    modified: nowSeconds(),
+  })
+  return jsonResponse({ ok: true, path: targetPath }, 201)
+}
+
+const handleResourcesPut = async (request: Request, rawResourcePath: string) => {
+  const targetPath = normalizePath(decodeURIComponent(rawResourcePath || '/'))
+  const payload = (await request.json().catch(() => null)) as { content?: string } | null
+  if (!payload || typeof payload.content !== 'string') {
+    return errorResponse(400, 'Missing file content')
+  }
+
+  const parent = parentPath(targetPath)
+  const parentNode = getNode(parent)
+  if (!parentNode || parentNode.kind !== 'dir') {
+    return errorResponse(404, `Parent directory not found: ${parent}`)
+  }
+
+  setNode({
+    kind: 'text',
+    path: targetPath,
+    modified: nowSeconds(),
+    mime: 'text/plain; charset=utf-8',
+    content: payload.content,
+  })
+  updateRecent(targetPath)
+  return jsonResponse({ ok: true, path: targetPath })
+}
+
+const handleResourcesPatch = async (request: Request, rawResourcePath: string) => {
+  const sourcePath = normalizePath(decodeURIComponent(rawResourcePath || '/'))
+  const sourceNode = getNode(sourcePath)
+  if (!sourceNode) {
+    return errorResponse(404, `Path not found: ${sourcePath}`)
+  }
+
+  const payload = (await request.json().catch(() => null)) as {
+    action?: string
+    destination?: string
+    new_name?: string
+    override_existing?: boolean
+  } | null
+
+  if (!payload?.action) {
+    return errorResponse(400, 'Missing patch action')
+  }
+
+  if (payload.action === 'rename') {
+    const nextName = String(payload.new_name ?? '').trim()
+    if (!nextName || nextName.includes('/')) {
+      return errorResponse(400, 'Invalid new_name')
+    }
+    const targetPath = joinPath(parentPath(sourcePath), nextName)
+    if (getNode(targetPath)) {
+      return errorResponse(409, `Target already exists: ${targetPath}`)
+    }
+    moveSubtree(sourcePath, targetPath, false)
+    return jsonResponse({ ok: true, path: targetPath })
+  }
+
+  if (payload.action === 'move' || payload.action === 'copy') {
+    const targetPath = normalizePath(String(payload.destination ?? ''))
+    if (!targetPath || targetPath === '/') {
+      return errorResponse(400, 'Invalid destination')
+    }
+    if (getNode(targetPath) && !payload.override_existing) {
+      return errorResponse(409, `Target already exists: ${targetPath}`)
+    }
+    if (payload.override_existing) {
+      removeSubtree(targetPath)
+    }
+    moveSubtree(sourcePath, targetPath, payload.action === 'copy')
+    return jsonResponse({ ok: true, path: targetPath })
+  }
+
+  return errorResponse(400, `Unsupported patch action: ${payload.action}`)
+}
+
+const handleResourcesDelete = async (rawResourcePath: string) => {
+  const targetPath = normalizePath(decodeURIComponent(rawResourcePath || '/'))
+  const node = getNode(targetPath)
+  if (!node) {
+    return errorResponse(404, `Path not found: ${targetPath}`)
+  }
+
+  const itemId = `trash-${Date.now()}`
+  getState().recycleBin.set(itemId, {
+    item_id: itemId,
+    path: `/.trash/${fileNameFromPath(targetPath)}`,
+    original_path: targetPath,
+    deleted_at: nowSeconds(),
+    node: cloneNode(node),
+  })
+  removeSubtree(targetPath)
+  return jsonResponse({ ok: true, recycled: true })
+}
+
+const handleFavorites = async (request: Request, url: URL) => {
+  const current = getState()
+  if (request.method === 'GET') {
+    const items = Array.from(current.favorites)
+      .map((path) => getNode(path))
+      .filter((node): node is MockNode => Boolean(node))
+      .map(makeFileEntry)
+    return jsonResponse({ items })
+  }
+
+  if (request.method === 'POST') {
+    const payload = (await request.json().catch(() => null)) as { path?: string } | null
+    const targetPath = normalizePath(String(payload?.path ?? ''))
+    if (!getNode(targetPath)) {
+      return errorResponse(404, `Path not found: ${targetPath}`)
+    }
+    current.favorites.add(targetPath)
+    return jsonResponse({ ok: true, path: targetPath }, 201)
+  }
+
+  if (request.method === 'DELETE') {
+    const targetPath = normalizePath(url.searchParams.get('path') || '')
+    current.favorites.delete(targetPath)
+    return jsonResponse({ ok: true, path: targetPath })
+  }
+
+  return errorResponse(405, 'Unsupported favorites method')
+}
+
+const handleRecent = async () => {
+  const items = Array.from(getState().recent.values())
+    .sort((left, right) => right.last_accessed_at - left.last_accessed_at)
+    .map((item) => {
+      const node = getNode(item.path)
+      if (!node) {
+        return null
+      }
+      return {
+        ...makeFileEntry(node),
+        last_accessed_at: item.last_accessed_at,
+        access_count: item.access_count,
+      }
+    })
+    .filter(Boolean)
+  return jsonResponse({ items })
+}
+
+const handleRecycleBin = async (request: Request, pathname: string) => {
+  const current = getState()
+
+  if (request.method === 'GET' && pathname === '/api/recycle-bin') {
+    const items = Array.from(current.recycleBin.values())
+      .sort((left, right) => right.deleted_at - left.deleted_at)
+      .map((item) => ({
+        item_id: item.item_id,
+        ...makeFileEntry(item.node),
+        original_path: item.original_path,
+        deleted_at: item.deleted_at,
+      }))
+    return jsonResponse({ items })
+  }
+
+  if (request.method === 'POST' && pathname === '/api/recycle-bin/restore') {
+    const payload = (await request.json().catch(() => null)) as { item_id?: string } | null
+    const itemId = String(payload?.item_id ?? '')
+    const target = current.recycleBin.get(itemId)
+    if (!target) {
+      return errorResponse(404, `Recycle item not found: ${itemId}`)
+    }
+    if (getNode(target.original_path)) {
+      return errorResponse(409, `Restore target already exists: ${target.original_path}`)
+    }
+    setNode(cloneNode(target.node, target.original_path))
+    current.recycleBin.delete(itemId)
+    return jsonResponse({ ok: true, path: target.original_path })
+  }
+
+  if (request.method === 'DELETE' && pathname.startsWith('/api/recycle-bin/item/')) {
+    const itemId = decodeURIComponent(pathname.slice('/api/recycle-bin/item/'.length))
+    current.recycleBin.delete(itemId)
+    return jsonResponse({ ok: true, item_id: itemId })
+  }
+
+  return errorResponse(405, 'Unsupported recycle bin method')
+}
+
+const buildShareResponse = (share: MockShare, requestedPath = '/') => {
+  const normalizedPath = normalizePath(requestedPath)
+  const shareRoot = normalizePath(share.path)
+  const targetPath = normalizedPath === '/' ? shareRoot : normalizePath(`${shareRoot}${normalizedPath}`)
+  const node = getNode(targetPath)
+  if (!node) {
+    return null
+  }
+
+  if (node.kind === 'dir') {
+    return {
+      share,
+      is_dir: true,
+      path: normalizedPath,
+      parent_path: normalizedPath === '/' ? null : parentPath(normalizedPath),
+      items: listChildren(targetPath).map((child) => ({
+        ...makeFileEntry(child),
+        path: normalizePath(child.path.replace(shareRoot, '') || '/'),
+      })),
+    }
+  }
+
+  return {
+    share,
+    is_dir: false,
+    path: normalizedPath,
+    parent_path: parentPath(normalizedPath),
+    size: getNodeSize(node),
+    modified: node.modified,
+    content: contentForInlinePreview(node),
+    mime: getNodeMime(node),
+  }
+}
+
+const handleShares = async (request: Request, pathname: string) => {
+  const current = getState()
+
+  if (request.method === 'GET' && pathname === '/api/share') {
+    return jsonResponse({
+      items: Array.from(current.shares.values()).sort((left, right) => right.created_at - left.created_at),
+    })
+  }
+
+  if (request.method === 'POST' && pathname === '/api/share') {
+    const payload = (await request.json().catch(() => null)) as {
+      path?: string
+      password?: string
+      expires_in_seconds?: number
+    } | null
+    const targetPath = normalizePath(String(payload?.path ?? ''))
+    if (!getNode(targetPath)) {
+      return errorResponse(404, `Path not found: ${targetPath}`)
+    }
+    const shareId = `share-${Date.now()}`
+    const expiresIn = Number(payload?.expires_in_seconds ?? 0)
+    const share: MockShare = {
+      id: shareId,
+      owner: CONTROL_PANEL_MOCK_USERNAME,
+      path: targetPath,
+      created_at: nowSeconds(),
+      expires_at: expiresIn > 0 ? nowSeconds() + expiresIn : null,
+      password_required: Boolean(payload?.password?.trim()),
+      password: payload?.password?.trim() || undefined,
+    }
+    current.shares.set(shareId, share)
+    return jsonResponse({ share }, 201)
+  }
+
+  if (request.method === 'DELETE' && pathname.startsWith('/api/share/')) {
+    const shareId = decodeURIComponent(pathname.slice('/api/share/'.length))
+    current.shares.delete(shareId)
+    return jsonResponse({ ok: true, id: shareId })
+  }
+
+  return errorResponse(405, 'Unsupported share method')
+}
+
+const handlePublicShare = async (url: URL, pathname: string) => {
+  const shareId = decodeURIComponent(pathname.slice('/api/public/share/'.length))
+  const share = getState().shares.get(shareId)
+  if (!share) {
+    return errorResponse(404, `Share not found: ${shareId}`)
+  }
+  const password = url.searchParams.get('password')?.trim() || ''
+  if (share.password_required && password !== (share.password ?? '')) {
+    return errorResponse(403, 'Password required or incorrect')
+  }
+  const payload = buildShareResponse(share, url.searchParams.get('path') || '/')
+  if (!payload) {
+    return errorResponse(404, 'Shared target not found')
+  }
+  return jsonResponse(payload)
+}
+
+const handlePublicDownload = async (url: URL, pathname: string) => {
+  const shareId = decodeURIComponent(pathname.slice('/api/public/dl/'.length))
+  const share = getState().shares.get(shareId)
+  if (!share) {
+    return errorResponse(404, `Share not found: ${shareId}`)
+  }
+  const password = url.searchParams.get('password')?.trim() || ''
+  if (share.password_required && password !== (share.password ?? '')) {
+    return errorResponse(403, 'Password required or incorrect')
+  }
+
+  const shareRoot = normalizePath(share.path)
+  const relativePath = normalizePath(url.searchParams.get('path') || '/')
+  const targetPath = relativePath === '/' ? shareRoot : normalizePath(`${shareRoot}${relativePath}`)
+  const node = getNode(targetPath)
+  if (!node || node.kind === 'dir') {
+    return errorResponse(404, 'Shared file not found')
+  }
+
+  return new Response(toBlob(node), {
+    status: 200,
+    headers: {
+      'content-type': getNodeMime(node),
+      'content-length': String(getNodeSize(node)),
+      'content-disposition': `${url.searchParams.get('download') === '1' ? 'attachment' : 'inline'}; filename="${fileNameFromPath(node.path)}"`,
+    },
+  })
+}
+
+const handleSearch = async (url: URL) => {
+  const query = (url.searchParams.get('q') || '').trim().toLowerCase()
+  const basePath = normalizePath(url.searchParams.get('path') || '/')
+  const limit = Math.max(1, Number(url.searchParams.get('limit') || 200))
+  const items = Array.from(getState().nodes.values())
+    .filter((node) => node.path !== '/' && isInSubtree(node.path, basePath))
+    .filter((node) => {
+      if (!query) {
+        return true
+      }
+      return node.path.toLowerCase().includes(query) || fileNameFromPath(node.path).toLowerCase().includes(query)
+    })
+    .map(makeFileEntry)
+    .slice(0, limit)
+
+  return jsonResponse({
+    query,
+    path: basePath,
+    kind: 'all',
+    limit,
+    truncated: false,
+    items,
+  })
+}
+
+const inferMimeFromPath = (path: string) => {
+  const lower = path.toLowerCase()
+  if (lower.endsWith('.svg')) {
+    return 'image/svg+xml'
+  }
+  if (lower.endsWith('.md')) {
+    return 'text/markdown; charset=utf-8'
+  }
+  if (lower.endsWith('.json')) {
+    return 'application/json; charset=utf-8'
+  }
+  if (lower.endsWith('.txt')) {
+    return 'text/plain; charset=utf-8'
+  }
+  return 'application/octet-stream'
+}
+
+const handleUploadSessions = async (request: Request, url: URL, pathname: string) => {
+  const current = getState()
+
+  if (request.method === 'POST' && pathname === '/api/upload/session') {
+    const payload = (await request.json().catch(() => null)) as {
+      path?: string
+      size?: number
+      chunk_size?: number
+      override_existing?: boolean
+    } | null
+    const targetPath = normalizePath(String(payload?.path ?? ''))
+    const size = Math.max(0, Number(payload?.size ?? 0))
+    const chunkSize = Math.max(64 * 1024, Number(payload?.chunk_size ?? 2 * 1024 * 1024))
+    if (!targetPath || targetPath === '/') {
+      return errorResponse(400, 'Invalid upload target path')
+    }
+    if (getNode(targetPath) && !payload?.override_existing) {
+      return errorResponse(409, `Target already exists: ${targetPath}`)
+    }
+    const sessionId = `upload-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const session = {
+      id: sessionId,
+      owner: CONTROL_PANEL_MOCK_USERNAME,
+      path: targetPath,
+      size,
+      chunk_size: chunkSize,
+      uploaded_size: 0,
+      override_existing: payload?.override_existing !== false,
+      created_at: nowSeconds(),
+      updated_at: nowSeconds(),
+    }
+    current.uploads.set(sessionId, { session, chunks: [] })
+    return jsonResponse({ session }, 201)
+  }
+
+  if (!pathname.startsWith('/api/upload/session/')) {
+    return errorResponse(404, 'Upload session not found')
+  }
+
+  if (pathname.endsWith('/complete') && request.method === 'POST') {
+    const sessionId = decodeURIComponent(pathname.slice('/api/upload/session/'.length, -'/complete'.length))
+    const upload = current.uploads.get(sessionId)
+    if (!upload) {
+      return errorResponse(404, `Upload session not found: ${sessionId}`)
+    }
+    const merged = new Uint8Array(upload.chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0))
+    let offset = 0
+    for (const chunk of upload.chunks) {
+      merged.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+    const mime = inferMimeFromPath(upload.session.path)
+    if (mime.startsWith('text/') || mime.includes('json')) {
+      setNode({
+        kind: 'text',
+        path: upload.session.path,
+        modified: nowSeconds(),
+        mime,
+        content: new TextDecoder().decode(merged),
+      })
+    } else {
+      setNode({
+        kind: 'binary',
+        path: upload.session.path,
+        modified: nowSeconds(),
+        mime,
+        bytes: merged,
+      })
+    }
+    current.uploads.delete(sessionId)
+    updateRecent(upload.session.path)
+    return jsonResponse({ ok: true, path: upload.session.path })
+  }
+
+  const sessionId = decodeURIComponent(pathname.slice('/api/upload/session/'.length))
+  const upload = current.uploads.get(sessionId)
+  if (!upload) {
+    return errorResponse(404, `Upload session not found: ${sessionId}`)
+  }
+
+  if (request.method === 'GET') {
+    return jsonResponse({ session: upload.session })
+  }
+
+  if (request.method === 'PUT') {
+    const offset = Math.max(0, Number(url.searchParams.get('offset') || 0))
+    if (offset !== upload.session.uploaded_size) {
+      return jsonResponse(
+        {
+          error: 'Chunk offset mismatch',
+          expected_offset: upload.session.uploaded_size,
+        },
+        409,
+      )
+    }
+    const chunk = new Uint8Array(await request.arrayBuffer())
+    upload.chunks.push(chunk)
+    upload.session.uploaded_size += chunk.byteLength
+    upload.session.updated_at = nowSeconds()
+    return jsonResponse({ uploaded_size: upload.session.uploaded_size })
+  }
+
+  if (request.method === 'DELETE') {
+    current.uploads.delete(sessionId)
+    return jsonResponse({ ok: true, id: sessionId })
+  }
+
+  return errorResponse(405, 'Unsupported upload session method')
+}
+
+const handleRawFile = async (pathname: string) => {
+  const filePath = normalizePath(decodeURIComponent(pathname.slice('/api/raw'.length) || '/'))
+  const node = getNode(filePath)
+  if (!node || node.kind === 'dir') {
+    return errorResponse(404, `File not found: ${filePath}`)
+  }
+  updateRecent(filePath)
+  return new Response(toBlob(node), {
+    status: 200,
+    headers: {
+      'content-type': getNodeMime(node),
+      'content-length': String(getNodeSize(node)),
+      'cache-control': 'no-store',
+    },
+  })
+}
+
+const handleThumbnail = async (pathname: string) => {
+  const filePath = normalizePath(decodeURIComponent(pathname.slice('/api/thumb'.length) || '/'))
+  const node = getNode(filePath)
+  if (!node || node.kind === 'dir' || !getNodeMime(node).startsWith('image/')) {
+    return errorResponse(404, `Thumbnail not found: ${filePath}`)
+  }
+  return new Response(toBlob(node), {
+    status: 200,
+    headers: {
+      'content-type': getNodeMime(node),
+      'content-length': String(getNodeSize(node)),
+      'cache-control': 'no-store',
+    },
+  })
+}
+
+const handleMockRequest = async (request: Request, url: URL) => {
+  const { pathname } = url
+
+  if (!pathname.startsWith('/api/')) {
+    return null
+  }
+
+  await waitForMockLatency()
+
+  if (!pathname.startsWith('/api/public/') && !checkMockAuth()) {
+    return errorResponse(401, 'Mock session missing')
+  }
+
+  if (pathname.startsWith('/api/resources')) {
+    const rawResourcePath = pathname.slice('/api/resources'.length)
+    if (request.method === 'GET') {
+      return handleResourcesGet(request, url, rawResourcePath)
+    }
+    if (request.method === 'POST') {
+      return handleResourcesPost(rawResourcePath)
+    }
+    if (request.method === 'PUT') {
+      return handleResourcesPut(request, rawResourcePath)
+    }
+    if (request.method === 'PATCH') {
+      return handleResourcesPatch(request, rawResourcePath)
+    }
+    if (request.method === 'DELETE') {
+      return handleResourcesDelete(rawResourcePath)
+    }
+  }
+
+  if (pathname === '/api/favorites') {
+    return handleFavorites(request, url)
+  }
+  if (pathname === '/api/recent') {
+    return handleRecent()
+  }
+  if (pathname === '/api/recycle-bin' || pathname === '/api/recycle-bin/restore' || pathname.startsWith('/api/recycle-bin/item/')) {
+    return handleRecycleBin(request, pathname)
+  }
+  if (pathname === '/api/share' || pathname.startsWith('/api/share/')) {
+    return handleShares(request, pathname)
+  }
+  if (pathname.startsWith('/api/public/share/')) {
+    return handlePublicShare(url, pathname)
+  }
+  if (pathname.startsWith('/api/public/dl/')) {
+    return handlePublicDownload(url, pathname)
+  }
+  if (pathname === '/api/search') {
+    return handleSearch(url)
+  }
+  if (pathname === '/api/upload/session' || pathname.startsWith('/api/upload/session/')) {
+    return handleUploadSessions(request, url, pathname)
+  }
+  if (pathname.startsWith('/api/raw')) {
+    return handleRawFile(pathname)
+  }
+  if (pathname.startsWith('/api/thumb')) {
+    return handleThumbnail(pathname)
+  }
+
+  return errorResponse(404, `Mock API route not implemented: ${pathname}`)
+}
+
+export const installFilesMockServer = () => {
+  if (!isMockRuntime() || installed || typeof window === 'undefined') {
+    return
+  }
+
+  const originalFetch = window.fetch.bind(window)
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const url = new URL(request.url, window.location.origin)
+    const response = await handleMockRequest(request, url)
+    if (response) {
+      return response
+    }
+    return originalFetch(input, init)
+  }
+  installed = true
+}

--- a/src/frame/control_panel/web/src/routes/router.tsx
+++ b/src/frame/control_panel/web/src/routes/router.tsx
@@ -33,6 +33,9 @@ const router = createBrowserRouter([
         element: <RequireAuth />,
         children: [
           { index: true, element: <DesktopHomePage /> },
+          { path: 'files', element: <FileManagerPage /> },
+          { path: 'files/shares', element: <FileManagerPage /> },
+          { path: 'files/editor', element: <FileManagerPage /> },
           { path: 'files/detail', element: <FileDetailPage /> },
           { path: 'index', element: <Navigate to="/monitor" replace /> },
           { path: 'index.html', element: <Navigate to="/monitor" replace /> },

--- a/src/frame/control_panel/web/src/ui/pages/DesktopHomePage.tsx
+++ b/src/frame/control_panel/web/src/ui/pages/DesktopHomePage.tsx
@@ -1441,6 +1441,7 @@ const DesktopView = memo((props: DesktopViewProps) => {
               key={app.id}
               type="button"
               onClick={app.onClick}
+              data-testid={`desktop-shortcut-${app.id}`}
               className="group flex w-[104px] flex-col items-center gap-2 rounded-xl p-2 transition-colors hover:bg-white/10 focus-visible:bg-white/15 focus-visible:outline-none"
             >
               <div
@@ -1749,6 +1750,7 @@ const WindowFrame = memo((props: WindowFrameProps) => {
   return (
     <div
       className="pointer-events-auto fixed"
+      data-testid={`desktop-window-${win.id}`}
       style={{
         left: 0,
         top: 0,
@@ -1816,7 +1818,12 @@ const WindowFrame = memo((props: WindowFrameProps) => {
             </div>
             <div className="flex items-center gap-2">
               <Icon name={win.icon} className="size-4 text-[var(--cp-muted)]" />
-              <p className="text-sm font-semibold tracking-tight text-[var(--cp-ink)]">{win.title}</p>
+              <p
+                className="text-sm font-semibold tracking-tight text-[var(--cp-ink)]"
+                data-testid={`desktop-window-title-${win.id}`}
+              >
+                {win.title}
+              </p>
             </div>
           </div>
           {win.id === 'logs' || win.id === 'storage' ? (

--- a/src/frame/control_panel/web/src/ui/pages/FileManagerPage.tsx
+++ b/src/frame/control_panel/web/src/ui/pages/FileManagerPage.tsx
@@ -3865,7 +3865,10 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
 
   if (publicShareId) {
     return (
-      <main className="bucky-file-app min-h-screen bg-[radial-gradient(circle_at_top,#d7ece8,transparent_55%),#f4f8f7] px-4 py-6 md:px-8">
+      <main
+        className="bucky-file-app min-h-screen bg-[radial-gradient(circle_at_top,#d7ece8,transparent_55%),#f4f8f7] px-4 py-6 md:px-8"
+        data-testid="public-share-root"
+      >
         <section className="mx-auto w-full max-w-4xl rounded-3xl border border-slate-200 bg-white shadow-sm">
           <header className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 px-5 py-4">
             <div>
@@ -4234,6 +4237,7 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
       className={`bucky-file-app relative bg-[radial-gradient(circle_at_top,#d9eeea,transparent_58%),#f4f8f7] px-3 py-4 md:px-6 md:py-6 ${
         embedded ? 'h-full min-h-0' : 'min-h-screen'
       }`}
+      data-testid="files-root"
     >
       <div
         className={`mx-auto w-full ${
@@ -4267,6 +4271,7 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
                 <button
                   type="button"
                   onClick={() => navigateToMainTab('files')}
+                  data-testid="files-tab-files"
                   className={`border-b-2 px-1 py-2 text-sm font-semibold transition ${
                     mainTab === 'files'
                       ? 'border-primary text-primary'
@@ -4281,6 +4286,7 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
                 <button
                   type="button"
                   onClick={() => navigateToMainTab('shares')}
+                  data-testid="files-tab-shares"
                   className={`border-b-2 px-1 py-2 text-sm font-semibold transition ${
                     mainTab === 'shares'
                       ? 'border-primary text-primary'
@@ -4306,6 +4312,7 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
                       key={scope.key}
                       type="button"
                       onClick={() => setFilesScope(scope.key)}
+                      data-testid={`files-scope-${scope.key}`}
                       className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold transition ${
                         filesScope === scope.key
                           ? 'border-primary bg-primary text-white'
@@ -4456,6 +4463,7 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
                   <input
                     value={searchKeyword}
                     onChange={(event) => setSearchKeyword(event.target.value)}
+                    data-testid="files-search-input"
                     onKeyDown={(event) => {
                       if (event.key === 'Enter') {
                         event.preventDefault()
@@ -4470,6 +4478,7 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
                       type="button"
                       onClick={() => void onSearch()}
                       disabled={searchLoading && filesScope === 'browse'}
+                      data-testid="files-search-button"
                       className={compactPrimaryToolbarButtonClass}
                       aria-label={searchLoading && filesScope === 'browse' ? t('files.searching', 'Searching...') : t('files.search', 'Search')}
                     >
@@ -4481,6 +4490,7 @@ const FileManagerPage = ({ embedded = false }: FileManagerPageProps) => {
                       <button
                         type="button"
                         onClick={onClearSearch}
+                        data-testid="files-search-clear"
                         className={compactSecondaryToolbarButtonClass}
                         aria-label={t('files.clearSearch', 'Clear search')}
                       >

--- a/src/frame/control_panel/web/tests/playwright/files.spec.ts
+++ b/src/frame/control_panel/web/tests/playwright/files.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+test('files standalone route smoke works in mock mode', async ({ page }) => {
+  await page.goto('/files')
+
+  await expect(page.getByTestId('files-root')).toBeVisible()
+  await expect(page.getByTestId('files-tab-files')).toBeVisible()
+  await expect(page.getByTestId('files-scope-browse')).toBeVisible()
+  await expect(page.getByText('Documents')).toBeVisible()
+
+  await page.getByTestId('files-search-input').fill('welcome.md')
+  await page.getByTestId('files-search-button').click()
+  await expect(page.getByText('Found 1 result(s) in /.')).toBeVisible()
+  await expect(page.getByText('Welcome.md')).toBeVisible()
+
+  await page.getByTestId('files-search-clear').click()
+  await page.getByTestId('files-scope-recent').click()
+  await expect(page.getByText('Welcome.md')).toBeVisible()
+
+  await page.getByTestId('files-scope-starred').click()
+  await expect(page.getByText('nebula.svg')).toBeVisible()
+
+  await page.getByTestId('files-scope-trash').click()
+  await expect(page.getByText('Draft.md')).toBeVisible()
+})
+
+test('public share route smoke works in mock mode', async ({ page }) => {
+  await page.goto('/share/share-welcome')
+
+  await expect(page.getByTestId('public-share-root')).toBeVisible()
+  await expect(page.getByText('Shared with you')).toBeVisible()
+  await expect(page.getByText('Share ID: share-welcome')).toBeVisible()
+  await expect(page.getByText('/Documents/Welcome.md')).toBeVisible()
+  await expect(page.getByText('This is the mock Files workspace for control_panel.')).toBeVisible()
+})

--- a/src/frame/control_panel/web/tests/playwright/monitor.spec.ts
+++ b/src/frame/control_panel/web/tests/playwright/monitor.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+
+test('desktop monitor smoke works in mock mode', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page.getByTestId('desktop-shortcut-monitor')).toBeVisible()
+  await page.getByTestId('desktop-shortcut-monitor').click()
+
+  const monitorWindow = page.getByTestId('desktop-window-monitor')
+  await expect(monitorWindow).toBeVisible()
+  await expect(page.getByTestId('desktop-window-title-monitor')).toContainText('System Monitor')
+  await expect(monitorWindow.getByText('CPU', { exact: true })).toBeVisible()
+  await expect(monitorWindow.getByText('Memory', { exact: true })).toBeVisible()
+  await expect(monitorWindow.getByText('Storage', { exact: true })).toBeVisible()
+  await expect(monitorWindow.getByText('Network', { exact: true })).toBeVisible()
+  await expect(monitorWindow.getByText('CPU / Memory trend')).toBeVisible()
+  await expect(monitorWindow.getByText('Network throughput trend')).toBeVisible()
+  await expect(monitorWindow.getByText('System status')).toBeVisible()
+})

--- a/src/frame/control_panel/web/tests/playwright/playwright.config.ts
+++ b/src/frame/control_panel/web/tests/playwright/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 4020
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${PORT}`
+const webServer = process.env.PLAYWRIGHT_BASE_URL
+  ? undefined
+  : {
+      command: 'pnpm dev:mock',
+      cwd: '/home/aa/app/base/buckyos/src/frame/control_panel/web',
+      url: BASE_URL,
+      reuseExistingServer: true,
+      timeout: 60_000,
+    }
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: ['*.spec.ts'],
+  fullyParallel: false,
+  retries: 0,
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  webServer,
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 960 },
+      },
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
- add mock-first runtime support for control panel monitor/files so `pnpm dev:mock` works without backend services
- add in-browser files mock server, standalone files routes, and stable test ids for desktop/files flows
- add validation planning docs plus Playwright smoke coverage for monitor/files main flows

## Validation
- `pnpm -C src/frame/control_panel/web build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:4020 pnpm -C src/frame/control_panel/web test:e2e:mock`

## Notes
- leaves unrelated untracked workspace files out of this PR (`.codex`, `src/frame/control_panel/web/src/ui/pages/FilesPage.tsx`, `src/frame/control_panel/web/test-results/`)
- Playwright config reuses `PLAYWRIGHT_BASE_URL` when a mock dev server is already running to keep CI/local startup simpler