### PR TITLE
Support AICC OpenAI-compatible providers

### DIFF
--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -86,13 +86,22 @@ const OPENAI_IMAGE_EDIT_OPTION_ALLOWLIST: &[&str] = &[
     "user",
 ];
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct OpenAIInstanceConfig {
     pub provider_instance_name: String,
     pub provider_type: String,
+    pub provider_driver: String,
     pub base_url: String,
     pub auth_mode: String,
+    pub endpoint_style: String,
+    pub api_token: Option<String>,
     pub timeout_ms: u64,
+    pub models: Vec<String>,
+    pub default_model: Option<String>,
+    pub image_models: Vec<String>,
+    pub default_image_model: Option<String>,
+    pub features: Vec<String>,
+    pub alias_map: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -104,12 +113,21 @@ pub struct OpenAIProvider {
     base_url: String,
     provider_type: crate::model_types::ProviderType,
     provider_driver: String,
+    endpoint_style: OpenAIEndpointStyle,
+    refresh_inventory: bool,
 }
 
 #[derive(Debug, Clone)]
 enum OpenAIAuthMode {
     Bearer(String),
     DeviceJwt,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum OpenAIEndpointStyle {
+    Auto,
+    Responses,
+    ChatCompletions,
 }
 
 #[derive(Debug, Deserialize)]
@@ -148,10 +166,21 @@ impl OpenAIProvider {
 
         let provider_type = provider_type_from_settings(cfg.provider_type.as_str());
         let provider_instance_name = cfg.provider_instance_name.clone();
-        let provider_driver = default_provider_driver_for_instance(
-            cfg.provider_instance_name.as_str(),
-            cfg.base_url.as_str(),
-        );
+        let provider_driver = if cfg.provider_driver.trim().is_empty() {
+            default_provider_driver_for_instance(
+                cfg.provider_instance_name.as_str(),
+                cfg.base_url.as_str(),
+            )
+        } else {
+            cfg.provider_driver.trim().to_string()
+        };
+        let endpoint_style =
+            parse_endpoint_style(cfg.endpoint_style.as_str(), provider_driver.as_str())?;
+        let features = if cfg.features.is_empty() {
+            default_features_for_driver(provider_driver.as_str())
+        } else {
+            cfg.features.clone()
+        };
         let instance = ProviderInstance {
             provider_instance_name: provider_instance_name.clone(),
             provider_type: provider_type.clone(),
@@ -160,17 +189,28 @@ impl OpenAIProvider {
             provider_type_trusted_source: ProviderTypeTrustedSource::SystemConfig,
             provider_type_revision: None,
             capabilities: vec![Capability::Llm, Capability::Image],
-            features: default_features(),
+            features: features.clone(),
             endpoint: Some(cfg.base_url.clone()),
             plugin_key: None,
         };
-        let inventory = Self::default_inventory(
-            provider_instance_name.as_str(),
-            provider_type.clone(),
-            provider_driver.as_str(),
-        );
+        let configured_models = !cfg.models.is_empty() || !cfg.image_models.is_empty();
+        let inventory = if configured_models {
+            Self::build_configured_inventory(&cfg, provider_type.clone(), provider_driver.as_str())
+        } else {
+            Self::default_inventory(
+                provider_instance_name.as_str(),
+                provider_type.clone(),
+                provider_driver.as_str(),
+            )
+        };
 
-        let auth_mode = Self::parse_auth_mode(cfg.auth_mode.as_str(), openai_api_token)?;
+        let instance_api_token = cfg
+            .api_token
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(openai_api_token);
+        let auth_mode = Self::parse_auth_mode(cfg.auth_mode.as_str(), instance_api_token)?;
 
         Ok(Self {
             instance,
@@ -180,11 +220,16 @@ impl OpenAIProvider {
             base_url: cfg.base_url.trim_end_matches('/').to_string(),
             provider_type,
             provider_driver,
+            endpoint_style,
+            refresh_inventory: !configured_models,
         })
     }
 
     pub fn start_inventory_refresh(self: Arc<Self>) {
         if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        if !self.refresh_inventory {
             return;
         }
 
@@ -274,16 +319,16 @@ impl OpenAIProvider {
                 normalize_model_list(parse_csv_list(DEFAULT_SN_AI_PROVIDER_MODELS)),
                 normalize_model_list(parse_csv_list(DEFAULT_SN_AI_PROVIDER_IMAGE_MODELS)),
             )
-        } else {
+        } else if is_openai_driver(provider_driver) {
             (
                 normalize_model_list(parse_csv_list(DEFAULT_OPENAI_MODELS)),
                 normalize_model_list(parse_csv_list(DEFAULT_OPENAI_IMAGE_MODELS)),
             )
+        } else {
+            (vec![], vec![])
         };
-        let embedding_models =
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS));
-        let asr_models = normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS));
-        let tts_models = normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS));
+        let (embedding_models, asr_models, tts_models) =
+            openai_builtin_modality_models(provider_driver);
 
         Self::build_inventory(
             provider_instance_name,
@@ -304,15 +349,49 @@ impl OpenAIProvider {
         image_models: &[String],
         revision: Option<String>,
     ) -> ProviderInventory {
+        let (embedding_models, asr_models, tts_models) =
+            openai_builtin_modality_models(self.provider_driver.as_str());
         Self::build_inventory(
             self.instance.provider_instance_name.as_str(),
             self.provider_type.clone(),
             self.provider_driver.as_str(),
             models,
             image_models,
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS)).as_slice(),
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS)).as_slice(),
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS)).as_slice(),
+            embedding_models.as_slice(),
+            asr_models.as_slice(),
+            tts_models.as_slice(),
+            revision,
+        )
+    }
+
+    fn build_configured_inventory(
+        cfg: &OpenAIInstanceConfig,
+        provider_type: crate::model_types::ProviderType,
+        provider_driver: &str,
+    ) -> ProviderInventory {
+        let (embedding_models, asr_models, tts_models) =
+            openai_builtin_modality_models(provider_driver);
+        let revision = Some(configured_inventory_revision(
+            cfg.models.as_slice(),
+            cfg.image_models.as_slice(),
+            cfg.features.as_slice(),
+        ));
+        let features = if cfg.features.is_empty() {
+            default_features_for_driver(provider_driver)
+        } else {
+            cfg.features.clone()
+        };
+
+        Self::build_inventory_with_features(
+            cfg.provider_instance_name.as_str(),
+            provider_type,
+            provider_driver,
+            cfg.models.as_slice(),
+            cfg.image_models.as_slice(),
+            embedding_models.as_slice(),
+            asr_models.as_slice(),
+            tts_models.as_slice(),
+            features.as_slice(),
             revision,
         )
     }
@@ -336,7 +415,8 @@ impl OpenAIProvider {
 
         let response = serde_json::from_value::<OpenAIModelsResponse>(body)
             .context("failed to parse openai models response")?;
-        let (llm_models, image_models) = normalize_remote_model_ids(response.data);
+        let (llm_models, image_models) =
+            normalize_remote_model_ids_for_driver(response.data, self.provider_driver.as_str());
         if llm_models.is_empty() && image_models.is_empty() {
             return Err(anyhow!(
                 "openai inventory refresh returned no supported models"
@@ -401,7 +481,33 @@ impl OpenAIProvider {
         tts_models: &[String],
         revision: Option<String>,
     ) -> ProviderInventory {
-        let features = default_features();
+        let features = default_features_for_driver(provider_driver);
+        Self::build_inventory_with_features(
+            provider_instance_name,
+            provider_type,
+            provider_driver,
+            models,
+            image_models,
+            embedding_models,
+            asr_models,
+            tts_models,
+            features.as_slice(),
+            revision,
+        )
+    }
+
+    fn build_inventory_with_features(
+        provider_instance_name: &str,
+        provider_type: crate::model_types::ProviderType,
+        provider_driver: &str,
+        models: &[String],
+        image_models: &[String],
+        embedding_models: &[String],
+        asr_models: &[String],
+        tts_models: &[String],
+        features: &[String],
+        revision: Option<String>,
+    ) -> ProviderInventory {
         let mut metadata = Vec::new();
         for model in models
             .iter()
@@ -413,7 +519,7 @@ impl OpenAIProvider {
                 model.as_str(),
                 ApiType::LlmChat,
                 openai_llm_logical_mounts(provider_driver, model.as_str()),
-                features.as_slice(),
+                features,
                 Some(0.01),
                 Some(1200),
             );
@@ -449,7 +555,7 @@ impl OpenAIProvider {
                 model.as_str(),
                 api_types,
                 dedupe_strings(mounts),
-                features.as_slice(),
+                features,
                 Some(0.04),
                 Some(5000),
             ));
@@ -461,7 +567,7 @@ impl OpenAIProvider {
                 model.as_str(),
                 vec![ApiType::Embedding],
                 openai_method_mounts(ApiType::Embedding, provider_driver, model),
-                features.as_slice(),
+                features,
                 Some(0.0001),
                 Some(800),
             ));
@@ -473,7 +579,7 @@ impl OpenAIProvider {
                 model.as_str(),
                 vec![ApiType::AudioAsr],
                 openai_method_mounts(ApiType::AudioAsr, provider_driver, model),
-                features.as_slice(),
+                features,
                 Some(0.006),
                 Some(5000),
             ));
@@ -485,7 +591,7 @@ impl OpenAIProvider {
                 model.as_str(),
                 vec![ApiType::AudioTts],
                 openai_method_mounts(ApiType::AudioTts, provider_driver, model),
-                features.as_slice(),
+                features,
                 Some(0.015),
                 Some(3000),
             ));
@@ -1394,9 +1500,23 @@ impl OpenAIProvider {
     }
 
     fn use_chat_completions_endpoint(&self) -> bool {
-        self.base_url
-            .to_ascii_lowercase()
-            .contains("/chat/completions")
+        match self.endpoint_style {
+            OpenAIEndpointStyle::ChatCompletions => true,
+            OpenAIEndpointStyle::Responses => false,
+            OpenAIEndpointStyle::Auto => self
+                .base_url
+                .to_ascii_lowercase()
+                .contains("/chat/completions"),
+        }
+    }
+
+    fn chat_completions_endpoint(&self) -> String {
+        let base_url = self.base_url.trim_end_matches('/');
+        if base_url.to_ascii_lowercase().ends_with("/chat/completions") {
+            base_url.to_string()
+        } else {
+            format!("{}/chat/completions", base_url)
+        }
     }
 
     fn convert_text_format_to_chat_response_format(format: Value) -> Value {
@@ -1459,6 +1579,72 @@ impl OpenAIProvider {
                 request_obj.insert("max_tokens".to_string(), max_output_tokens);
             }
         }
+
+        if let Some(tools) = request_obj.get_mut("tools") {
+            Self::normalize_chat_completions_tools(tools);
+        }
+        if let Some(tool_choice) = request_obj.get_mut("tool_choice") {
+            Self::normalize_chat_completions_tool_choice(tool_choice);
+        }
+    }
+
+    fn normalize_chat_completions_tools(tools: &mut Value) {
+        let Some(items) = tools.as_array_mut() else {
+            return;
+        };
+        for item in items.iter_mut() {
+            let Some(tool_obj) = item.as_object_mut() else {
+                continue;
+            };
+            if tool_obj.get("type").and_then(|value| value.as_str()) != Some("function") {
+                continue;
+            }
+            if tool_obj
+                .get("function")
+                .and_then(|value| value.as_object())
+                .is_some()
+            {
+                continue;
+            }
+
+            let Some(name) = tool_obj.remove("name") else {
+                continue;
+            };
+            let mut function = Map::new();
+            function.insert("name".to_string(), name);
+            if let Some(description) = tool_obj.remove("description") {
+                function.insert("description".to_string(), description);
+            }
+            if let Some(parameters) = tool_obj.remove("parameters") {
+                function.insert("parameters".to_string(), parameters);
+            }
+            if let Some(strict) = tool_obj.remove("strict") {
+                function.insert("strict".to_string(), strict);
+            }
+            tool_obj.insert("function".to_string(), Value::Object(function));
+        }
+    }
+
+    fn normalize_chat_completions_tool_choice(tool_choice: &mut Value) {
+        let Some(choice_obj) = tool_choice.as_object_mut() else {
+            return;
+        };
+        if choice_obj.get("type").and_then(|value| value.as_str()) != Some("function") {
+            return;
+        }
+        if choice_obj
+            .get("function")
+            .and_then(|value| value.as_object())
+            .is_some()
+        {
+            return;
+        }
+        let Some(name) = choice_obj.remove("name") else {
+            return;
+        };
+        let mut function = Map::new();
+        function.insert("name".to_string(), name);
+        choice_obj.insert("function".to_string(), Value::Object(function));
     }
 
     fn extract_legacy_message_text(choice_message: &Value) -> Option<String> {
@@ -2497,7 +2683,7 @@ impl OpenAIProvider {
         );
 
         let url = if self.use_chat_completions_endpoint() {
-            self.base_url.clone()
+            self.chat_completions_endpoint()
         } else {
             format!("{}/responses", self.base_url)
         };
@@ -3320,7 +3506,11 @@ fn normalize_remote_provider_model(
     if api_types.is_empty() {
         if is_text2image_model_name(provider_model_id.as_str()) {
             api_types.push(ApiType::ImageTextToImage);
-        } else if is_supported_llm_model_name(provider_model_id.as_str()) {
+        } else if (is_openai_driver(provider_driver)
+            && is_supported_llm_model_name(provider_model_id.as_str()))
+            || (!is_openai_driver(provider_driver)
+                && is_supported_compatible_llm_model_name(provider_model_id.as_str()))
+        {
             api_types.push(ApiType::LlmChat);
         } else {
             return None;
@@ -3401,15 +3591,84 @@ fn is_llm_api_type(api_type: &ApiType) -> bool {
 fn openai_llm_logical_mounts(provider_driver: &str, provider_model_id: &str) -> Vec<String> {
     let mut mounts = vec![
         format!("llm.{}", logical_mount_segment(provider_driver)),
-        format!("llm.openai.{}", logical_mount_segment(provider_model_id)),
+        format!(
+            "llm.{}.{}",
+            logical_mount_segment(provider_driver),
+            logical_mount_segment(provider_model_id)
+        ),
     ];
-    if classify_openai_gpt_model(provider_model_id).is_none() {
+    if !is_openai_driver(provider_driver) {
+        add_unique_mount(&mut mounts, "llm.chat".to_string());
+    } else if classify_openai_gpt_model(provider_model_id).is_none() {
         add_unique_mount(&mut mounts, "llm.gpt".to_string());
     }
+    add_compatible_llm_family_mounts(&mut mounts, provider_driver, provider_model_id);
     mounts
 }
 
-fn apply_openai_latest_llm_mounts(_provider_driver: &str, models: &mut [ModelMetadata]) {
+fn add_compatible_llm_family_mounts(
+    mounts: &mut Vec<String>,
+    provider_driver: &str,
+    provider_model_id: &str,
+) {
+    let driver = provider_driver
+        .trim()
+        .to_ascii_lowercase()
+        .replace('_', "-");
+    let model = provider_model_id
+        .trim()
+        .to_ascii_lowercase()
+        .replace('_', "-");
+    let combined = format!("{} {}", driver, model);
+
+    if combined.contains("deepseek") {
+        add_unique_mount(mounts, "llm.deepseek".to_string());
+        if combined.contains("reasoner") || combined.contains("-r1") {
+            add_unique_mount(mounts, "llm.deepseek-reasoner".to_string());
+        } else {
+            add_unique_mount(mounts, "llm.deepseek-pro".to_string());
+        }
+    }
+
+    if combined.contains("glm") || combined.contains("zhipu") {
+        add_unique_mount(mounts, "llm.glm".to_string());
+        if combined.contains("flash") || combined.contains("air") {
+            add_unique_mount(mounts, "llm.glm-flash".to_string());
+        }
+    }
+
+    if combined.contains("kimi") || combined.contains("moonshot") {
+        add_unique_mount(mounts, "llm.kimi".to_string());
+        if combined.contains("thinking")
+            || combined.contains("think")
+            || combined.contains("reason")
+        {
+            add_unique_mount(mounts, "llm.kimi-thinking".to_string());
+        }
+    }
+
+    if combined.contains("qwen") || combined.contains("dashscope") {
+        add_unique_mount(mounts, "llm.qwen".to_string());
+        if combined.contains("coder") || combined.contains("code") {
+            add_unique_mount(mounts, "llm.qwen-coder".to_string());
+        }
+        if combined.contains("max") || combined.contains("plus") {
+            add_unique_mount(mounts, "llm.qwen-max".to_string());
+        }
+        if combined.contains("small")
+            || combined.contains("lite")
+            || combined.contains("turbo")
+            || combined.contains("flash")
+        {
+            add_unique_mount(mounts, "llm.qwen-small".to_string());
+        }
+    }
+}
+
+fn apply_openai_latest_llm_mounts(provider_driver: &str, models: &mut [ModelMetadata]) {
+    if !is_openai_driver(provider_driver) {
+        return;
+    }
     let mut latest = HashMap::<OpenAIGptTier, (usize, GptModelRank)>::new();
 
     for (index, model) in models.iter_mut().enumerate() {
@@ -3648,18 +3907,36 @@ struct OpenAISettings {
     instances: Vec<SettingsOpenAIInstanceConfig>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 struct SettingsOpenAIInstanceConfig {
     #[serde(default = "default_instance_id", alias = "instance_id")]
     provider_instance_name: String,
     #[serde(default = "default_provider_type")]
     provider_type: String,
+    #[serde(default)]
+    provider_driver: String,
     #[serde(default = "default_base_url")]
     base_url: String,
     #[serde(default = "default_auth_mode")]
     auth_mode: String,
+    #[serde(default)]
+    endpoint_style: String,
+    #[serde(default, alias = "api_key", alias = "apiKey")]
+    api_token: String,
     #[serde(default = "default_timeout_ms")]
     timeout_ms: u64,
+    #[serde(default)]
+    models: Vec<String>,
+    #[serde(default)]
+    default_model: Option<String>,
+    #[serde(default)]
+    image_models: Vec<String>,
+    #[serde(default)]
+    default_image_model: Option<String>,
+    #[serde(default)]
+    features: Vec<String>,
+    #[serde(default)]
+    alias_map: HashMap<String, String>,
 }
 
 fn default_openai_enabled() -> bool {
@@ -3686,6 +3963,37 @@ fn default_auth_mode() -> String {
     DEFAULT_AUTH_MODE.to_string()
 }
 
+fn default_endpoint_style_for_driver(provider_driver: &str) -> String {
+    if provider_driver.trim().is_empty()
+        || provider_driver.eq_ignore_ascii_case(DEFAULT_OPENAI_PROVIDER_DRIVER)
+        || provider_driver.eq_ignore_ascii_case(SN_AI_PROVIDER_DRIVER)
+    {
+        "auto".to_string()
+    } else {
+        "chat_completions".to_string()
+    }
+}
+
+fn parse_endpoint_style(value: &str, provider_driver: &str) -> Result<OpenAIEndpointStyle> {
+    let value = value.trim().to_ascii_lowercase();
+    let value = if value.is_empty() {
+        default_endpoint_style_for_driver(provider_driver)
+    } else {
+        value
+    };
+    match value.as_str() {
+        "auto" => Ok(OpenAIEndpointStyle::Auto),
+        "responses" | "response" => Ok(OpenAIEndpointStyle::Responses),
+        "chat_completions" | "chat-completions" | "chat" => {
+            Ok(OpenAIEndpointStyle::ChatCompletions)
+        }
+        _ => Err(anyhow!(
+            "unsupported openai endpoint_style '{}', expected auto, responses, or chat_completions",
+            value
+        )),
+    }
+}
+
 fn default_provider_driver_for_instance(provider_instance_name: &str, base_url: &str) -> String {
     let instance = provider_instance_name.to_ascii_lowercase();
     let endpoint = base_url.to_ascii_lowercase();
@@ -3696,13 +4004,30 @@ fn default_provider_driver_for_instance(provider_instance_name: &str, base_url: 
     }
 }
 
-fn default_features() -> Vec<String> {
-    vec![
+fn default_features_for_driver(provider_driver: &str) -> Vec<String> {
+    let mut features = vec![
         features::PLAN.to_string(),
         features::JSON_OUTPUT.to_string(),
         features::TOOL_CALLING.to_string(),
-        features::WEB_SEARCH.to_string(),
-    ]
+    ];
+    if is_openai_driver(provider_driver) {
+        features.push(features::WEB_SEARCH.to_string());
+    }
+    features
+}
+
+fn openai_builtin_modality_models(
+    provider_driver: &str,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    if !is_openai_driver(provider_driver) {
+        return (vec![], vec![], vec![]);
+    }
+
+    (
+        normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS)),
+        normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS)),
+        normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS)),
+    )
 }
 
 fn is_text2image_model_name(model: &str) -> bool {
@@ -3740,11 +4065,51 @@ fn is_supported_llm_model_name(model: &str) -> bool {
         || normalized.starts_with("o4")
 }
 
+fn is_supported_compatible_llm_model_name(model: &str) -> bool {
+    let normalized = model.trim().to_ascii_lowercase();
+    if normalized.is_empty() || is_text2image_model_name(normalized.as_str()) {
+        return false;
+    }
+    if normalized.contains("embedding")
+        || normalized.contains("rerank")
+        || normalized.contains("transcribe")
+        || normalized.contains("-tts")
+        || normalized.contains("-audio")
+        || normalized.contains("-realtime")
+    {
+        return false;
+    }
+
+    normalized.starts_with("deepseek")
+        || normalized.starts_with("glm")
+        || normalized.starts_with("kimi")
+        || normalized.starts_with("moonshot")
+        || normalized.starts_with("qwen")
+        || normalized.starts_with("doubao")
+        || normalized.starts_with("yi-")
+        || normalized.starts_with("abab")
+        || is_supported_llm_model_name(model)
+}
+
+fn is_openai_driver(provider_driver: &str) -> bool {
+    provider_driver.trim().is_empty()
+        || provider_driver.eq_ignore_ascii_case(DEFAULT_OPENAI_PROVIDER_DRIVER)
+        || provider_driver.eq_ignore_ascii_case(SN_AI_PROVIDER_DRIVER)
+}
+
 fn normalize_remote_model_ids(entries: Vec<OpenAIModelEntry>) -> (Vec<String>, Vec<String>) {
+    normalize_remote_model_ids_for_driver(entries, DEFAULT_OPENAI_PROVIDER_DRIVER)
+}
+
+fn normalize_remote_model_ids_for_driver(
+    entries: Vec<OpenAIModelEntry>,
+    provider_driver: &str,
+) -> (Vec<String>, Vec<String>) {
     let mut llm_seen = HashSet::<String>::new();
     let mut image_seen = HashSet::<String>::new();
     let mut llm_models = Vec::new();
     let mut image_models = Vec::new();
+    let openai_driver = is_openai_driver(provider_driver);
 
     for entry in entries.into_iter() {
         let model = entry.id.trim();
@@ -3756,7 +4121,10 @@ fn normalize_remote_model_ids(entries: Vec<OpenAIModelEntry>) -> (Vec<String>, V
             if image_seen.insert(key) {
                 image_models.push(model.to_string());
             }
-        } else if is_supported_llm_model_name(model) && llm_seen.insert(key) {
+        } else if ((openai_driver && is_supported_llm_model_name(model))
+            || (!openai_driver && is_supported_compatible_llm_model_name(model)))
+            && llm_seen.insert(key)
+        {
             llm_models.push(model.to_string());
         }
     }
@@ -3772,6 +4140,24 @@ fn inventory_revision(models: &[String], image_models: &[String]) -> String {
         "models-{}-{}-{:x}",
         models.len(),
         image_models.len(),
+        hasher.finish()
+    )
+}
+
+fn configured_inventory_revision(
+    models: &[String],
+    image_models: &[String],
+    features: &[String],
+) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    models.hash(&mut hasher);
+    image_models.hash(&mut hasher);
+    features.hash(&mut hasher);
+    format!(
+        "configured-models-{}-{}-{}-{:x}",
+        models.len(),
+        image_models.len(),
+        features.len(),
         hasher.finish()
     )
 }
@@ -3835,9 +4221,21 @@ fn build_openai_instances(settings: &OpenAISettings) -> Result<Vec<OpenAIInstanc
         vec![SettingsOpenAIInstanceConfig {
             provider_instance_name: default_instance_id(),
             provider_type: default_provider_type(),
+            provider_driver: default_provider_driver_for_instance(
+                default_instance_id().as_str(),
+                default_base_url().as_str(),
+            ),
             base_url: default_base_url(),
             auth_mode: default_auth_mode(),
+            endpoint_style: "auto".to_string(),
+            api_token: String::new(),
             timeout_ms: default_timeout_ms(),
+            models: vec![],
+            default_model: None,
+            image_models: vec![],
+            default_image_model: None,
+            features: vec![],
+            alias_map: HashMap::new(),
         }]
     } else {
         settings.instances.clone()
@@ -3845,12 +4243,45 @@ fn build_openai_instances(settings: &OpenAISettings) -> Result<Vec<OpenAIInstanc
 
     let mut instances = vec![];
     for raw_instance in raw_instances.into_iter() {
+        let provider_driver = if raw_instance.provider_driver.trim().is_empty() {
+            default_provider_driver_for_instance(
+                raw_instance.provider_instance_name.as_str(),
+                raw_instance.base_url.as_str(),
+            )
+        } else {
+            raw_instance.provider_driver
+        };
+        let endpoint_style = if raw_instance.endpoint_style.trim().is_empty() {
+            default_endpoint_style_for_driver(provider_driver.as_str())
+        } else {
+            raw_instance.endpoint_style
+        };
+        let models = normalize_model_list(raw_instance.models);
+        let image_models = normalize_model_list(raw_instance.image_models);
+        let features = if raw_instance.features.is_empty() {
+            default_features_for_driver(provider_driver.as_str())
+        } else {
+            raw_instance.features
+        };
         instances.push(OpenAIInstanceConfig {
             provider_instance_name: raw_instance.provider_instance_name,
             provider_type: raw_instance.provider_type,
+            provider_driver,
             base_url: raw_instance.base_url,
             auth_mode: raw_instance.auth_mode,
+            endpoint_style,
+            api_token: Some(raw_instance.api_token).filter(|value| !value.trim().is_empty()),
             timeout_ms: raw_instance.timeout_ms,
+            default_model: raw_instance
+                .default_model
+                .or_else(|| models.first().cloned()),
+            default_image_model: raw_instance
+                .default_image_model
+                .or_else(|| image_models.first().cloned()),
+            models,
+            image_models,
+            features,
+            alias_map: raw_instance.alias_map,
         });
     }
 
@@ -3990,6 +4421,15 @@ pub fn register_openai_llm_providers(center: &AIComputeCenter, settings: &Value)
             .map_err(|_| anyhow!("model registry lock poisoned"))?
             .apply_inventory(inventory)
             .map_err(|err| anyhow!("failed to apply openai inventory: {}", err))?;
+        register_default_aliases(
+            center,
+            config.provider_driver.as_str(),
+            config.models.as_slice(),
+            config.default_model.as_deref(),
+            config.image_models.as_slice(),
+            config.default_image_model.as_deref(),
+        );
+        register_custom_aliases(center, config.provider_driver.as_str(), &config.alias_map);
     }
 
     Ok(instances.len())
@@ -4496,7 +4936,7 @@ data: [DONE]
 
     #[test]
     fn default_features_include_web_search() {
-        let all_features = default_features();
+        let all_features = default_features_for_driver(DEFAULT_OPENAI_PROVIDER_DRIVER);
         assert!(
             all_features
                 .iter()
@@ -4516,6 +4956,7 @@ data: [DONE]
                 base_url: default_base_url(),
                 auth_mode: default_auth_mode(),
                 timeout_ms: default_timeout_ms(),
+                ..Default::default()
             }],
         };
 
@@ -4536,12 +4977,202 @@ data: [DONE]
                 base_url: "https://sn.buckyos.ai/v1".to_string(),
                 auth_mode: DEVICE_JWT_AUTH_MODE.to_string(),
                 timeout_ms: default_timeout_ms(),
+                ..Default::default()
             }],
         };
 
         let instances = build_openai_instances(&settings).expect("instances should be built");
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].auth_mode, DEVICE_JWT_AUTH_MODE);
+    }
+
+    #[test]
+    fn build_openai_instances_supports_compatible_provider_fields() {
+        let settings = OpenAISettings {
+            enabled: true,
+            api_token: String::new(),
+            instances: vec![SettingsOpenAIInstanceConfig {
+                provider_instance_name: "deepseek-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "deepseek".to_string(),
+                base_url: "https://api.deepseek.com/v1/chat/completions".to_string(),
+                endpoint_style: "chat_completions".to_string(),
+                api_token: "deepseek-token".to_string(),
+                models: vec!["deepseek-chat".to_string(), "deepseek-reasoner".to_string()],
+                default_model: Some("deepseek-chat".to_string()),
+                features: vec![features::JSON_OUTPUT.to_string()],
+                alias_map: HashMap::from([(
+                    "llm.deepseek-reasoner".to_string(),
+                    "deepseek-reasoner".to_string(),
+                )]),
+                ..Default::default()
+            }],
+        };
+
+        let instances = build_openai_instances(&settings).expect("instances should be built");
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].provider_driver, "deepseek");
+        assert_eq!(instances[0].endpoint_style, "chat_completions");
+        assert_eq!(instances[0].api_token.as_deref(), Some("deepseek-token"));
+        assert_eq!(instances[0].default_model.as_deref(), Some("deepseek-chat"));
+        assert_eq!(instances[0].models.len(), 2);
+        assert_eq!(
+            instances[0].alias_map.get("llm.deepseek-reasoner"),
+            Some(&"deepseek-reasoner".to_string())
+        );
+    }
+
+    #[test]
+    fn compatible_provider_defaults_to_chat_completions() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "glm-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "glm".to_string(),
+                base_url: "https://open.bigmodel.cn/api/paas/v4".to_string(),
+                auth_mode: "bearer".to_string(),
+                models: vec!["glm-4.5".to_string()],
+                ..Default::default()
+            },
+            "token",
+        )
+        .expect("provider should be built");
+        assert!(provider.use_chat_completions_endpoint());
+        assert_eq!(
+            provider.chat_completions_endpoint(),
+            "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+        );
+        assert!(
+            !provider
+                .instance
+                .features
+                .iter()
+                .any(|feature| feature == features::WEB_SEARCH),
+            "compatible provider defaults should not advertise OpenAI web_search"
+        );
+    }
+
+    #[test]
+    fn compatible_provider_without_static_models_starts_empty_inventory() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "deepseek-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "deepseek".to_string(),
+                base_url: "https://api.deepseek.com/v1".to_string(),
+                auth_mode: "bearer".to_string(),
+                ..Default::default()
+            },
+            "token",
+        )
+        .expect("provider should be built");
+
+        let inventory = provider.inventory();
+        assert_eq!(inventory.provider_driver, "deepseek");
+        assert!(
+            inventory.models.is_empty(),
+            "compatible providers must not expose OpenAI default models before static config or discovery"
+        );
+    }
+
+    #[test]
+    fn compatible_provider_remote_inventory_does_not_include_openai_builtin_modalities() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "deepseek-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "deepseek".to_string(),
+                base_url: "https://api.deepseek.com/v1".to_string(),
+                auth_mode: "bearer".to_string(),
+                ..Default::default()
+            },
+            "token",
+        )
+        .expect("provider should be built");
+
+        let inventory = provider
+            .build_inventory_from_remote_value(json!({
+                "object": "list",
+                "data": [
+                    {"id": "deepseek-chat"},
+                    {"id": "embedding-v1"}
+                ]
+            }))
+            .expect("remote inventory should be built");
+
+        assert_eq!(inventory.models.len(), 1);
+        assert_eq!(inventory.models[0].provider_model_id, "deepseek-chat");
+        assert!(inventory.models[0].api_types.contains(&ApiType::LlmChat));
+        assert!(inventory.models.iter().all(|model| {
+            !model.api_types.contains(&ApiType::Embedding)
+                && !model.api_types.contains(&ApiType::AudioAsr)
+                && !model.api_types.contains(&ApiType::AudioTts)
+        }));
+    }
+
+    #[test]
+    fn configured_compatible_inventory_exposes_logical_mounts() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "compatible-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "deepseek".to_string(),
+                base_url: "https://api.deepseek.com/v1/chat/completions".to_string(),
+                auth_mode: "bearer".to_string(),
+                endpoint_style: "chat_completions".to_string(),
+                models: vec![
+                    "deepseek-chat".to_string(),
+                    "deepseek-reasoner".to_string(),
+                    "glm-4.5-flash".to_string(),
+                    "kimi-k2".to_string(),
+                    "qwen-coder-plus".to_string(),
+                ],
+                ..Default::default()
+            },
+            "token",
+        )
+        .expect("provider should be built");
+
+        let inventory = provider.inventory();
+        assert_eq!(inventory.provider_driver, "deepseek");
+        assert!(inventory
+            .models
+            .iter()
+            .all(|model| model.api_types.contains(&ApiType::LlmChat)));
+        assert_model_mount(&inventory, "deepseek-chat", "llm.deepseek-pro", true);
+        assert_model_mount(
+            &inventory,
+            "deepseek-reasoner",
+            "llm.deepseek-reasoner",
+            true,
+        );
+        assert_model_mount(&inventory, "glm-4.5-flash", "llm.glm-flash", true);
+        assert_model_mount(&inventory, "kimi-k2", "llm.kimi", true);
+        assert_model_mount(&inventory, "kimi-k2", "llm.kimi-thinking", false);
+        assert_model_mount(&inventory, "qwen-coder-plus", "llm.qwen-coder", true);
+        assert_model_mount(&inventory, "qwen-coder-plus", "llm.qwen-max", true);
+    }
+
+    #[test]
+    fn kimi_thinking_model_mounts_as_thinking() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "kimi-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "moonshot".to_string(),
+                base_url: "https://api.moonshot.cn/v1".to_string(),
+                auth_mode: "bearer".to_string(),
+                endpoint_style: "chat_completions".to_string(),
+                models: vec!["kimi-thinking".to_string()],
+                ..Default::default()
+            },
+            "token",
+        )
+        .expect("provider should be built");
+
+        let inventory = provider.inventory();
+        assert_model_mount(&inventory, "kimi-thinking", "llm.kimi", true);
+        assert_model_mount(&inventory, "kimi-thinking", "llm.kimi-thinking", true);
     }
 
     #[test]
@@ -4553,6 +5184,7 @@ data: [DONE]
                 base_url: "https://sn.buckyos.ai/api/v1/ai/chat/completions".to_string(),
                 auth_mode: "bearer".to_string(),
                 timeout_ms: default_timeout_ms(),
+                ..Default::default()
             },
             "token",
         )
@@ -4569,6 +5201,7 @@ data: [DONE]
                 base_url: default_base_url(),
                 auth_mode: "bearer".to_string(),
                 timeout_ms: default_timeout_ms(),
+                ..Default::default()
             },
             "token",
         )
@@ -4656,6 +5289,7 @@ data: [DONE]
                 base_url: default_base_url(),
                 auth_mode: "bearer".to_string(),
                 timeout_ms: default_timeout_ms(),
+                ..Default::default()
             },
             "token",
         )
@@ -4826,6 +5460,7 @@ data: [DONE]
                 base_url: default_base_url(),
                 auth_mode: "bearer".to_string(),
                 timeout_ms: default_timeout_ms(),
+                ..Default::default()
             },
             "token",
         )
@@ -4932,6 +5567,84 @@ data: [DONE]
                 .and_then(|v| v.as_str()),
             Some("plan_id")
         );
+    }
+
+    #[test]
+    fn normalize_chat_completions_request_converts_tools_shape() {
+        let mut request = json!({
+            "model": "deepseek-chat",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "workshop_exec_bash",
+                    "description": "Run shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": { "type": "string" }
+                        }
+                    },
+                    "strict": true
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "already_chat_shape",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {}
+                        }
+                    }
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "name": "workshop_exec_bash"
+            }
+        })
+        .as_object()
+        .cloned()
+        .expect("request object");
+
+        OpenAIProvider::normalize_chat_completions_request(&mut request);
+        let request_value = Value::Object(request);
+
+        assert_eq!(
+            request_value
+                .pointer("/tools/0/function/name")
+                .and_then(|value| value.as_str()),
+            Some("workshop_exec_bash")
+        );
+        assert_eq!(
+            request_value.pointer("/tools/0/function/parameters"),
+            Some(&json!({
+                "type": "object",
+                "properties": {
+                    "command": { "type": "string" }
+                }
+            }))
+        );
+        assert_eq!(
+            request_value
+                .pointer("/tools/0/function/strict")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+        assert!(request_value.pointer("/tools/0/name").is_none());
+        assert_eq!(
+            request_value
+                .pointer("/tools/1/function/name")
+                .and_then(|value| value.as_str()),
+            Some("already_chat_shape")
+        );
+        assert_eq!(
+            request_value
+                .pointer("/tool_choice/function/name")
+                .and_then(|value| value.as_str()),
+            Some("workshop_exec_bash")
+        );
+        assert!(request_value.pointer("/tool_choice/name").is_none());
     }
 
     #[test]

--- a/src/frame/aicc/src/sn_ai_provider.rs
+++ b/src/frame/aicc/src/sn_ai_provider.rs
@@ -96,9 +96,18 @@ fn build_sn_ai_provider_instances(
         instances.push(OpenAIInstanceConfig {
             provider_instance_name: raw_instance.provider_instance_name,
             provider_type: raw_instance.provider_type,
+            provider_driver: "sn-ai-provider".to_string(),
             base_url: raw_instance.base_url,
             auth_mode: raw_instance.auth_mode,
+            endpoint_style: "auto".to_string(),
+            api_token: None,
             timeout_ms: raw_instance.timeout_ms,
+            models: vec![],
+            default_model: None,
+            image_models: vec![],
+            default_image_model: None,
+            features: vec![],
+            alias_map: Default::default(),
         });
     }
 

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -17,6 +17,7 @@ fn openai_provider(base_url: String, timeout_ms: u64) -> OpenAIProvider {
             base_url,
             auth_mode: "bearer".to_string(),
             timeout_ms,
+            ..Default::default()
         },
         "token",
     )


### PR DESCRIPTION
Closes #470

在 AICC 的 OpenAI adapter 层，把 OpenAI provider 泛化为 OpenAI-compatible provider。

扩展 settings.openai.instances，使一个实例可以声明 provider_driver、endpoint_style、实例级 api_token/api_key、静态 models/image_models、默认模型、features 和 alias_map。

非 openai/sn 的 provider 默认走 chat_completions。

当 base_url 只配置到 /v1 时，自动使用 /chat/completions 作为调用入口。

静态模型清单不依赖远程 /models 刷新。

支持 DeepSeek、GLM/Zhipu、Kimi/Moonshot、Qwen/DashScope 等主流 OpenAI-compatible 模型族。

为这些模型生成稳定的 llm.chat、llm.<provider>、llm.<provider>.<model> 和模型族 logical mounts。

保留 SN AI provider 现有行为。

补充配置解析、endpoint 选择、logical mounts 的基础测试。

Tests:
- cargo test openai::tests:: --lib
- cargo test (known existing failures remain in protocol_resource_tests named-object cases)