### PR TITLE
Add Message Tunnel design docs

### DIFF
--- a/doc/message_hub/Message Tunnel Design.md
+++ b/doc/message_hub/Message Tunnel Design.md
@@ -1,888 +1,867 @@
 # Message Tunnel Design
 
-本文定义 BuckyOS Message Tunnel 的理论完整模型。目标是给人类 review 设计边界、对象语义、流程、兼容性和各平台裁剪方式。给 agent/codegen 使用的最小版本见 `Message Tunnel Minimal Spec.md`。
+## 1. 背景
 
-## 1. 任务确认
+Message Tunnel 是 BuckyOS MessageHub/MessageCenter 面向外部 IM、Email、原生 MessageHub 和未来社交平台的通用适配层。它把“某个平台上的一个账号收发消息”抽象为 BuckyOS 中一个可运行、可审计、可裁剪能力的通道。
 
-Message Tunnel 是一个 IM 通道适配层。它把 Telegram、Lark、Email、MessageHub 等外部或内部会话系统中的消息和会话事件接入 BuckyOS Message Center，并把 Message Center 中的响应消息投递回来源 IM 会话或被授权的其他会话。
+从完整能力上看，如果某个 IM 平台允许机器人完成自然人在会话里能完成的一切行为，那么对应 Message Tunnel 应能把这些行为完整桥接给 BuckyOS Agent：读消息、发消息、参与 1v1、参与群聊、加入/退出、管理会话状态、处理附件、处理引用、处理交互消息、发送状态、使用外部工具入口，并能把 Agent 行为记录下来。实际平台通常会限制 bot 或 user 账号能力，因此每个具体 tunnel 必须声明能力并按平台规则裁剪。
 
-完整流程是：
+本文定义理论上完整的 Message Tunnel。当前实现已经有 `MsgTunnel`、`TgTunnel`、`MsgTunnelInstanceMgr`、`MessageCenter.dispatch/post_send`、`TUNNEL_OUTBOX`、`IngressContext`、`RouteInfo`、`DeliveryReportResult` 等基础能力。本文不替代这些基础类型，只定义它们之上的完整语义边界和后续扩展方向。
 
-1. Tunnel 从 IM 会话中获取消息、状态和平台事件。
-2. Tunnel 将事件标准化，经 `MsgCenter.dispatch()` 投递给消息指定的目标 Agent、人操作的控制组件或其他系统组件。
-3. 目标组件处理消息后，自行按规则存储响应或调用 `MsgCenter.post_send()` 创建响应消息。这一步不需要 Message Tunnel 参与。
-4. Tunnel 从 `MsgCenter` 的 `TunnelOutbox` 取出响应或其他出站消息，按路由投递给来源 IM 会话或授权目标。
+## 2. 目标
 
-## 2. 设计边界
+Message Tunnel 的目标：
 
-### 2.1 Message Tunnel 负责什么
+1. 让外部 IM 会话中的消息、会话事件和状态变化能进入 BuckyOS MessageCenter。
+2. 让 Agent、人操作的控制组件或系统组件生成的响应能回到消息来源 IM 会话。
+3. 保持外部 IM 对象的原始语义，不强制把所有平台账号、群、消息都封装成 BuckyOS DID。
+4. 为 Agent 提供标准化消息视图，使 Agent 不必理解 Telegram、Lark、Email 等平台细节。
+5. 为平台差异提供能力声明、降级策略和错误报告。
+6. 支持去重、顺序、遗漏恢复、重试和幂等。
+7. 支持日志、审计和可观测性，避免一组 Agent 或机器人互相通信时系统不可感知。
+8. 面向未来平台升级保持兼容，未知内容不能导致宕机或数据损坏。
 
-Message Tunnel 负责平台协议边界：
+非目标：
 
-- 连接外部 IM API、Webhook、轮询、长连接或本地 MessageHub。
-- 把平台事件转换为 BuckyOS 可处理的消息对象、状态对象或未知事件对象。
-- 构造 `IngressContext`、`RouteInfo` 和幂等 key。
-- 调用 Message Center 的入站和投递回报 API。
-- 消费 `TunnelOutbox` 并把消息发送回外部平台。
-- 保存平台 offset、checkpoint、账号绑定、外部 ID、健康状态和错误信息。
-- 按平台能力裁剪机器人和自然人账号的行为。
+1. Message Tunnel 不负责 Agent 的推理、记忆、工具调用或任务调度。
+2. Message Tunnel 不负责替 MessageCenter 维护消息真相源。
+3. Message Tunnel 不负责把所有外部身份注册到 BuckyOS DID 系统。
+4. Message Tunnel 不负责绕过平台限制实现平台禁止的机器人行为。
 
-### 2.2 Message Tunnel 不负责什么
+## 3. 基础原则
 
-Message Tunnel 不负责：
+### 3.1 外部对象保持外部语义
 
-- Agent 如何理解消息、选择工具、生成回复。
-- Agent 的工作日志、长期记忆、任务状态和响应消息存储策略。
-- Message Center 的 inbox/outbox 存储模型。
-- ContactMgr 和 GroupMgr 的最终身份、成员、权限管理。
-- 将所有外部概念强行 DID 化。
+外部 IM 系统中的用户账号 ID、chat ID、message ID、thread ID、邮箱地址、Lark open_id、Telegram peer id 等，本质上都是平台侧标识。它们可以：
 
-Tunnel 可以提供足够的来源信息，让 ContactMgr、GroupMgr、Agent 或 UI 决定是否建立 DID 映射。
+- 映射为 ContactMgr 中的联系人绑定。
+- 绑定到某个 BuckyOS User/Agent DID。
+- 仅作为消息来源、路由、回执和审计字段保存。
+- 在没有必要时不映射成任何 BuckyOS 对象。
 
-## 3. 外部语义和 DID 的关系
+只有当某个外部对象需要成为 BuckyOS 内部权限主体、可管理实体、群实体或长期社交对象时，才考虑把它绑定或封装为 DID。
 
-外部 IM 系统中的用户账号 ID、群 ID、会话 ID 和消息 ID 是平台语义下的字符串。它们可能对应 BuckyOS DID，也可能只是一个来源标识或回复地址。
+### 3.2 BuckyOS 基础类型不重复定义
 
-设计原则：
+本文复用 BuckyOS 现有基础类型：
 
-- 默认保留原平台 ID，不强制封装成 DID。
-- 只有当系统需要长期权限、联系人、成员关系、跨平台路由、审计主体或内部群实体时，才创建或绑定 DID。
-- DID 映射是可选的、可变的、可被人工确认或合并的。
-- 原始平台 ID 必须持续保留，避免 DID 映射变化导致无法回信或无法审计历史。
+- `DID`：BuckyOS 内部身份主体。
+- `MsgObject`：标准消息对象，来自 `ndn_lib`。
+- `MsgRecord`：某个 owner 在某个 box 中对 `MsgObject` 的视图。
+- `BoxKind`：`INBOX`、`OUTBOX`、`GROUP_INBOX`、`TUNNEL_OUTBOX`、`REQUEST_BOX`。
+- `IngressContext`：入站来源上下文。
+- `SendContext`：出站发送上下文。
+- `RouteInfo`：投递路由信息。
+- `DeliveryInfo`/`DeliveryReportResult`：投递状态和回报。
+- `MsgReceiptObj`：阅读和处理回执。
 
-示例：
+如果未来这些类型无法表达 Message Tunnel 必需语义，应优先 additive 扩展，例如新增 `extra`、新增可选字段、为 enum 增加未知兜底，而不是破坏旧字段语义。
 
-- Telegram user id 可以只作为 `ExternalActorRef.account_id`。如果用户后来被添加为联系人，再通过 ContactMgr 绑定 DID。
-- Lark open_id 可以只作为某个 Lark tunnel 的投递地址。它不一定是 BuckyOS 用户。
-- Email address 可作为外部账号 ID，也可绑定到某个 Contact DID。
-- MessageHub 内部用户一般已经能解析 DID，但仍应保留 session id 作为 UI 会话语义。
+### 3.3 MessageCenter 是消息域真相源
 
-## 4. 基础类型复用
+入站消息进入 BuckyOS 后，MessageCenter 负责保存 `MsgObject`、创建 box 记录、处理权限和通知。出站消息由 MessageCenter 生成 `TUNNEL_OUTBOX`，tunnel 只消费自己的出站队列并回报结果。
 
-本文使用现有 BuckyOS 基础类型，不重新定义：
+Message Tunnel 可以保存平台断点、session、access token、event 去重表、平台附件缓存和审计日志，但不能成为 BuckyOS 标准消息历史的唯一来源。
 
-- `DID`：内部身份。
-- `ObjId`：NamedObject ID。
-- `MsgObject`：不可变消息对象，来自 `ndn_lib`。
-- `MsgContent`、`MsgContentFormat`：文本、结构化内容、附件引用。
-- `MsgObjKind`：消息业务类型。
-- `MsgRecord`：某个 owner 在某个 box 中对 `MsgObject` 的视图记录。
-- `RouteInfo`：投递路由，包含 tunnel、platform、account、address、chat_id、target_did、ext_ids、extra。
-- `DeliveryInfo`：投递尝试、外部 message id、送达时间、错误和重试信息。
-- `IngressContext` / `SendContext`：入站和出站上下文。
-- `MsgReceiptObj`：阅读或处理回执。
-- `MsgTunnel` / `MsgTunnelInstanceMgr`：当前实现中的 tunnel 运行接口和实例管理器。
+### 3.4 能力先声明，行为按能力裁剪
 
-需要升级基础类型时，应单独说明原因。例如新增 `MsgObjKind::ConversationState` 可以减少状态消息对 `meta` 的依赖，但这属于共享协议升级，不应在 tunnel 文档里直接覆盖现有定义。
+Bot 账号和自然人账号通常能力不同：
 
-## 5. 核心对象定义
+- Bot 可能不能主动给未互动用户发消息。
+- Bot 可能不能读取历史消息或成员列表。
+- User tunnel 可能能做更多自然人行为，但安全和平台合规风险更高。
+- Email 没有在线、typing、群成员实时事件等 IM 语义。
 
-以下是理论完整 Message Tunnel 的关键对象。它们可先作为文档模型和平台 tunnel 内部结构存在，不要求一次性进入公共 API。
+因此每个 tunnel 实例都要声明能力。MessageCenter、UI、Agent runtime 和配置页只能使用它声明支持的能力。
 
-### 5.1 外部引用对象
+## 4. 总体流程
+
+### 4.1 入站到 Agent
+
+```mermaid
+flowchart TD
+    A[External IM Conversation] --> B[Message Tunnel receive/poll/webhook]
+    B --> C[Parse platform event]
+    C --> D[Build TunnelIngressEvent]
+    D --> E{Event duplicate?}
+    E -- yes --> F[Skip but keep checkpoint]
+    E -- no --> G{Event kind}
+    G -- message --> H[Normalize to MsgObject]
+    G -- conversation status --> I[Normalize to Event/Notify/Receipt/SessionState]
+    G -- unknown --> J[Unknown/Quarantine object]
+    H --> K[MessageCenter.dispatch]
+    I --> K
+    J --> K
+    K --> L[Owner/Agent INBOX or REQUEST_BOX]
+    L --> M[Agent/Control Component reads]
+```
+
+自然语言说明：
+
+1. Tunnel 从外部 IM 会话中接收各种消息和事件。
+2. Tunnel 解析平台事件，构造一个包含原始平台上下文的 `TunnelIngressEvent`。
+3. Tunnel 使用平台事件 ID、消息 ID、offset、timestamp 等做入站去重。
+4. 可标准化内容转换为 `MsgObject`；状态事件转换为 `MsgObject.kind=event/notify`、`MsgReceiptObj` 或 `ui_session_states`。
+5. Tunnel 调用 MessageCenter `dispatch`。
+6. MessageCenter 根据目标 DID、群、联系人策略、请求箱策略和权限，把消息投递给 Agent、人操作组件或其他系统组件。
+
+### 4.2 Agent 响应回外部会话
+
+```mermaid
+flowchart TD
+    A[Agent/Control Component] --> B[Generate response MsgObject]
+    B --> C[MessageCenter.post_send]
+    C --> D[Owner OUTBOX]
+    C --> E[TUNNEL_OUTBOX by RouteInfo]
+    E --> F[Message Tunnel egress worker]
+    F --> G[Render to platform payload]
+    G --> H[External IM send API]
+    H --> I{Result}
+    I -- success --> J[report_delivery SENT + external_msg_id]
+    I -- retryable error --> K[report_delivery WAIT/FAILED with retry_after]
+    I -- final error --> L[report_delivery DEAD/FAILED]
+```
+
+自然语言说明：
+
+1. Agent 阅读消息后生成响应。响应如何保存或进入 MessageCenter 不是 Message Tunnel 的职责。
+2. MessageCenter 根据 ContactMgr、`SendContext`、原入站 `RouteInfo` 或显式目标构造投递计划。
+3. Tunnel 从自己的 `TUNNEL_OUTBOX` 拉取待投递记录。
+4. Tunnel 把标准 `MsgObject` 渲染成平台 payload。
+5. Tunnel 调用平台发送 API。
+6. Tunnel 使用 `report_delivery` 把结果写回 MessageCenter。
+
+## 5. 理论完整功能集
+
+### 5.1 消息内容
+
+Message Tunnel 应能表达或降级处理：
+
+- 文本、符号、表情、reaction。
+- 富文本、Markdown、HTML、平台专有富文本。
+- 回复、引用、转发、thread/topic。
+- 图片、音频、视频、文件、位置、联系人卡片等附件。
+- 多段消息和组合消息。
+- @mention、特殊命令符、平台特有触发符。
+- 系统消息和通知。
+- 可操作消息，例如红包、投票、审批卡片、按钮卡片。
+- 依赖第三方应用的消息，例如小程序、Lark 卡片、外部 app payload。
+- AI 流式消息，包括 delta、status、final、cancel。
+- 未知平台消息。
+
+处理原则：
+
+- 能转换为标准 `MsgContent` 的内容直接转换。
+- 附件优先导入对象存储并通过 `RefItem` 引用；不能导入时保留 `uri_hint` 和平台 file id。
+- 平台私有对象使用 `PlatformObject` 或 `extra/raw` 保存。
+- 未知内容要保留、降级展示或隔离，不得丢失已知字段。
+
+### 5.2 会话
+
+Message Tunnel 需要覆盖：
+
+- 1v1 会话。
+- 多人会话。
+- 群聊。
+- 群聊内 thread/topic/subgroup/sub-conversation。
+- 频道、广播、邮件线程。
+- 机器人与机器人会话。
+- 自然人与机器人混合会话。
+- 仅由系统组件操作的控制会话。
+
+群聊里的子群不一定是 BuckyOS self-host group。外部平台 thread/topic 可以只是 `ExternalConversationRef.parent_conversation_id` 加 `MsgObject.thread`；只有当它需要成为 BuckyOS 可管理群实体时，才映射到 group DID。
+
+### 5.3 会话状态和成员事件
+
+Message Tunnel 应尽量表达：
+
+- 加入/退出会话。
+- 邀请、移除、成员角色变化。
+- 成员上线/下线。
+- 禁言、屏蔽、解除屏蔽。
+- 会话授权、bot 被授予/撤销权限。
+- 新消息、已投递、已读、撤回、编辑、删除。
+- typing、recording、processing、status line。
+- 平台 API 限流、会话不可达、用户已阻止 bot。
+
+这些状态不都适合进入普通聊天时间线。建议：
+
+- 与消息处理强相关的状态写 `MsgReceiptObj` 或 `MsgRecord.delivery`。
+- 与 UI 会话运行态相关的状态写 `ui_session_states`。
+- 对用户可见且需要留痕的状态写 `MsgObjKind::Notify/Event`。
+- 对权限有影响的状态同步到 ContactMgr 或 GroupMgr。
+
+### 5.4 Agent 行为
+
+理论完整 Agent 作为 IM 用户时，应能在平台允许的范围内完成自然人能完成的行为：
+
+- 阅读会话消息和上下文。
+- 回复、引用、转发、编辑、撤回。
+- 发送文本、富文本、附件、状态。
+- 被 @ 后按规则响应。
+- 参与群聊和子会话。
+- 使用被授权的外部工具，例如发 Email、向其他会话发送消息、触发 Lark 通知。
+- 识别需要人工确认的动作，向 MessageHub 或控制组件发确认请求。
+- 记录自身行为日志，使 owner 能审计它为什么发了某条消息、用了哪个工具、触发了什么外部投递。
+
+如果 IM 平台对机器人有限制，对应 tunnel 子类必须在能力声明和出站错误中体现限制。
+
+## 6. 对象模型
+
+### 6.1 TunnelPlatform
 
 ```rust
-/// 外部 IM 平台 ID。稳定小写字符串，例如 "telegram"、"lark"、"email"、"messagehub"。
-pub type PlatformId = String;
-
-/// 外部平台账号 ID。只在某个平台或某个租户范围内有意义。
-pub type ExternalAccountId = String;
-
-/// 外部平台会话 ID。可表示私聊、群聊、频道、邮件 thread 或 MessageHub session。
-pub type ExternalConversationId = String;
-
-/// 外部平台消息 ID。通常只在平台 + 账号 + 会话范围内唯一。
-pub type ExternalMessageId = String;
-
-/// 外部平台参与者。它保持原平台语义，并可选绑定 BuckyOS DID。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalActorRef {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// 平台账号 ID。
-    pub account_id: ExternalAccountId,
-    /// 平台显示名。
-    pub display_name: Option<String>,
-    /// 平台可读 ID，例如 @name、email address、open_id。
-    pub display_id: Option<String>,
-    /// 可选内部 DID。未解析、未知或不需要映射时为空。
-    pub mapped_did: Option<DID>,
-    /// 原始平台扩展字段。实现必须容忍未知字段。
-    pub extra: serde_json::Value,
-}
-
-/// 外部会话引用。它不是 BuckyOS 会话实体本身。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalConversationRef {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// 外部会话 ID。
-    pub conversation_id: ExternalConversationId,
-    /// 会话类型。
-    pub kind: ExternalConversationKind,
-    /// 可选内部 DID，例如 self-host group DID。
-    pub mapped_did: Option<DID>,
-    /// 可选父会话，用于群内 thread、topic、子群。
-    pub parent: Option<Box<ExternalConversationRef>>,
-    /// 原始平台扩展字段。
-    pub extra: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ExternalConversationKind {
-    /// 1v1 会话。
-    Direct,
-    /// 多人会话或群聊。
-    Group,
-    /// 群内子群、topic、thread、临时议题空间。
-    Subgroup,
-    /// 邮件 thread、频道、工单等线程型会话。
-    Thread,
-    /// 平台升级带来的未知类型。旧系统必须保留并降级。
-    Unknown(String),
+/// 外部消息平台。未知平台用 Custom，避免升级时旧系统无法解析。
+pub enum TunnelPlatform {
+    Telegram,
+    Lark,
+    Email,
+    MessageHub,
+    Custom(String),
 }
 ```
 
-### 5.2 外部消息和内容
+属性说明：
+
+- `Telegram`：Telegram bot 或 user session。
+- `Lark`：Lark/飞书机器人、应用或用户授权通道。
+- `Email`：邮箱账号、SMTP/IMAP/API 通道。
+- `MessageHub`：BuckyOS 原生 MessageHub 跨 Zone 或内部 tunnel。
+- `Custom(String)`：未来平台。
+
+### 6.2 TunnelAccountKind
 
 ```rust
-/// 外部消息的标准中间形态，进入 MsgObject 前使用。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalMessage {
-    /// 平台和账号范围内的消息引用。
-    pub message_ref: ExternalMessageRef,
-    /// 发送者。可能是自然人、机器人、群系统账号或未知 actor。
-    pub sender: ExternalActorRef,
-    /// 所属会话。
-    pub conversation: ExternalConversationRef,
-    /// 可选目标。平台未显式给出时为空，由 conversation 决定。
-    pub targets: Vec<ExternalActorRef>,
-    /// 规范化内容片段。
-    pub parts: Vec<ExternalMessagePart>,
-    /// 引用、回复、转发等关系。
-    pub relations: Vec<ExternalMessageRelation>,
-    /// 外部平台时间。没有可靠时间时由 tunnel 接收时间补齐。
-    pub created_at_ms: u64,
-    /// 原始 payload 摘要或完整 JSON。大 payload 可只保存引用。
-    pub raw: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalMessageRef {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// tunnel 绑定的外部账号 ID。
-    pub tunnel_account_id: ExternalAccountId,
-    /// 外部会话 ID。
-    pub conversation_id: ExternalConversationId,
-    /// 外部消息 ID。
-    pub message_id: ExternalMessageId,
-    /// 平台 offset 或 sequence，用于顺序和恢复。
-    pub sequence: Option<i64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ExternalMessagePart {
-    /// 纯文本。
-    Text { text: String },
-    /// 富文本，format 可为 markdown、html、platform-specific。
-    RichText { format: String, body: String },
-    /// 表情、reaction、贴纸。
-    Symbol { kind: String, value: String },
-    /// @、mention、频道引用等特殊语义字符。
-    Mention {
-        raw: String,
-        target: Option<ExternalActorRef>,
-        meaning: MentionMeaning,
-    },
-    /// 附件或媒体。data_ref 可指向 NamedObject，也可先保存外部 URI。
-    Attachment {
-        name: Option<String>,
-        mime_type: Option<String>,
-        size: Option<u64>,
-        data_ref: AttachmentDataRef,
-    },
-    /// 平台可操作对象，例如红包、投票、小程序。
-    Interactive(ExternalInteractiveObject),
-    /// 平台升级带来的未知内容。
-    Unknown(UnknownExternalContent),
-}
-
-/// 未知外部内容片段。旧版本无法理解时至少应展示 fallback_text。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UnknownExternalContent {
-    /// 平台原始内容类型。
-    pub content_kind: String,
-    /// 降级展示文本。
-    pub fallback_text: String,
-    /// 原始 payload 或引用。
-    pub raw: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum MentionMeaning {
-    /// 普通提及人或机器人。
-    AddressActor,
-    /// 指令、slash command 或平台命令入口。
-    Command,
-    /// 频道、群、话题或外部资源引用。
-    Reference,
-    /// 未知语义，保留原始字符。
-    Unknown(String),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum AttachmentDataRef {
-    /// 已导入 BuckyOS NamedObject。
-    NamedObject { obj_id: ObjId, uri_hint: Option<String> },
-    /// 尚未导入，只保留外部下载地址或 file id。
-    External { uri: Option<String>, file_id: Option<String> },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ExternalMessageRelation {
-    ReplyTo(ExternalMessageRef),
-    Quote(ExternalMessageRef),
-    ForwardFrom(ExternalMessageRef),
-    EditOf(ExternalMessageRef),
-    DeleteOf(ExternalMessageRef),
-    ReactionTo(ExternalMessageRef),
-    Unknown { kind: String, payload: serde_json::Value },
-}
-```
-
-### 5.3 会话状态和可操作对象
-
-```rust
-/// 外部会话状态事件。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalConversationEvent {
-    /// 事件所属会话。
-    pub conversation: ExternalConversationRef,
-    /// 事件发起者。系统事件可为空。
-    pub actor: Option<ExternalActorRef>,
-    /// 事件类型。
-    pub kind: ExternalConversationEventKind,
-    /// 事件时间。
-    pub occurred_at_ms: u64,
-    /// 原始 payload。
-    pub raw: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ExternalConversationEventKind {
-    MemberJoined { member: ExternalActorRef },
-    MemberLeft { member: ExternalActorRef },
-    MemberAdded { member: ExternalActorRef },
-    MemberRemoved { member: ExternalActorRef },
-    MemberOnline { member: ExternalActorRef },
-    MemberOffline { member: ExternalActorRef },
-    Muted { target: ExternalActorRef, until_ms: Option<u64> },
-    Blocked { target: ExternalActorRef },
-    PermissionChanged { target: ExternalActorRef, permission: String },
-    MessageRead { reader: ExternalActorRef, message: ExternalMessageRef },
-    MessageDelivered { target: ExternalActorRef, message: ExternalMessageRef },
-    Typing { actor: ExternalActorRef, active: bool },
-    TitleChanged { title: String },
-    Unknown { kind: String },
-}
-
-/// 第三方应用或平台可操作对象。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalInteractiveObject {
-    /// 对象类型，例如 "wechat.red_packet"、"lark.vote"。
-    pub object_type: String,
-    /// 展示文本。旧系统至少可显示它。
-    pub fallback_text: String,
-    /// 允许的操作。未知或无权操作时可为空。
-    pub actions: Vec<ExternalActionDescriptor>,
-    /// 原始 payload 或引用。
-    pub payload: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalActionDescriptor {
-    /// 操作名，例如 "open"、"vote"、"claim"。
-    pub name: String,
-    /// 是否需要用户或 Agent 额外授权。
-    pub requires_authorization: bool,
-    /// 平台原始操作 payload。
-    pub payload: serde_json::Value,
-}
-```
-
-### 5.4 未知事件和归一化结果
-
-```rust
-/// 未知外部事件。必须可持久化、可审计、可被新版本重放分析。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UnknownExternalEvent {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// tunnel 绑定的外部账号。
-    pub tunnel_account_id: ExternalAccountId,
-    /// 平台原始事件类型。
-    pub event_kind: String,
-    /// tunnel 观察到该事件的时间。
-    pub observed_at_ms: u64,
-    /// 降级展示文本。
-    pub fallback_text: String,
-    /// 原始 payload 或引用。
-    pub raw: serde_json::Value,
-}
-
-/// Tunnel 入站归一化后的结果。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NormalizedIngress {
-    /// 原平台事件类型。
-    pub event_kind: String,
-    /// 可提交给 MsgCenter.dispatch 的消息对象。
-    pub msg: Option<MsgObject>,
-    /// 入站上下文，包含来源平台、外部会话、外部账号、contact owner 等。
-    pub ingress_ctx: IngressContext,
-    /// 入站幂等 key。
-    pub idempotency_key: String,
-    /// 不能直接表达成 MsgObject 的状态更新或审计记录。
-    pub side_effects: Vec<NormalizedIngressSideEffect>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum NormalizedIngressSideEffect {
-    /// 更新 UI session、typing、在线等临时状态。
-    UpdateSessionState { key: String, value: serde_json::Value },
-    /// 写入阅读、送达、处理等回执。
-    WriteReceipt { receipt: MsgReceiptObj },
-    /// 保存未知事件，供人工排查或新版本重放。
-    StoreUnknown { event: UnknownExternalEvent },
-}
-```
-
-### 5.5 Tunnel 配置、能力和健康状态
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Tunnel 使用的平台账号类型。
 pub enum TunnelAccountKind {
-    /// 平台机器人账号。通常受 Bot API 限制。
-    Bot,
-    /// 用户授权账号。能力接近自然人，但风险更高。
-    User,
-    /// BuckyOS 内部系统通道。
-    System,
+    Bot,    // 平台机器人账号，通常有 API 能力限制。
+    User,   // 自然人账号授权通道，权限更大，安全要求也更高。
+    System, // 系统级通道，例如 MessageHub native 或通知邮箱。
 }
+```
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TunnelCapabilities {
-    /// 可读取外部消息。
+### 6.3 TunnelCapability
+
+```rust
+/// 运行时能力声明。调用方必须按能力裁剪行为。
+pub struct TunnelCapability {
     pub ingress: bool,
-    /// 可发送外部消息。
     pub egress: bool,
-    /// 可同步成员、加入退出、禁言、权限等会话状态。
-    pub conversation_state: bool,
-    /// 可同步已读、送达、失败等回执。
-    pub receipts: bool,
-    /// 可同步 typing、在线等临时状态。
-    pub ephemeral_state: bool,
-    /// 可导入或导出附件。
-    pub attachments: bool,
-    /// 可识别或操作平台特殊对象。
-    pub interactive_objects: bool,
-    /// 可主动加入会话。
-    pub join_conversation: bool,
-    /// 可向非来源会话发送消息。
-    pub cross_conversation_send: bool,
+    pub receive_history: bool,
+    pub direct_chat: bool,
+    pub group_chat: bool,
+    pub sub_conversation: bool,
+    pub channel: bool,
+    pub attachments_in: bool,
+    pub attachments_out: bool,
+    pub rich_text_in: bool,
+    pub rich_text_out: bool,
+    pub mention: bool,
+    pub reaction: bool,
+    pub edit_message: bool,
+    pub delete_message: bool,
+    pub read_receipt_in: bool,
+    pub read_receipt_out: bool,
+    pub typing_in: bool,
+    pub typing_out: bool,
+    pub interactive_message: bool,
+    pub app_dependent_message: bool,
+    pub streaming_out: bool,
+    pub proactive_send: bool,
 }
+```
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MessageTunnelConfig {
-    /// BuckyOS 内部 tunnel DID。
-    pub tunnel_did: DID,
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// Bot/User/System。
-    pub account_kind: TunnelAccountKind,
-    /// tunnel 绑定的外部账号。
-    pub account_id: ExternalAccountId,
-    /// 是否启用入站。
-    pub ingress_enabled: bool,
-    /// 是否启用出站。
-    pub egress_enabled: bool,
-    /// ContactMgr owner scope。
-    pub contact_mgr_owner: Option<DID>,
-    /// 账号密钥、token、租户等配置引用。不得直接明文写入日志。
-    pub secret_refs: Vec<String>,
-    /// 平台特有配置。
+方法建议：
+
+```rust
+impl TunnelCapability {
+    /// 判断某种标准动作是否允许执行。
+    pub fn allows(&self, action: TunnelAction) -> bool;
+
+    /// 返回不支持时的降级策略。
+    pub fn fallback_for(&self, action: TunnelAction) -> TunnelFallback;
+}
+```
+
+### 6.4 ExternalAccountRef
+
+```rust
+/// 外部平台账号引用。它不是 DID。
+pub struct ExternalAccountRef {
+    pub platform: TunnelPlatform,
+    pub account_id: String,
+    pub display_id: Option<String>,
+    pub display_name: Option<String>,
+    pub account_kind: Option<TunnelAccountKind>,
+    pub avatar_uri: Option<String>,
+    pub extra: serde_json::Value,
+}
+```
+
+字段说明：
+
+- `account_id`：平台稳定账号 ID、open_id、邮箱地址等。
+- `display_id`：用户可见 ID，例如 @handle、邮箱地址。
+- `extra`：平台字段，不能作为跨平台核心逻辑依赖。
+
+### 6.5 ExternalConversationRef
+
+```rust
+/// 外部平台会话引用。它不是 BuckyOS Group 的替代品。
+pub struct ExternalConversationRef {
+    pub platform: TunnelPlatform,
+    pub conversation_id: String,
+    pub parent_conversation_id: Option<String>,
+    pub conversation_kind: ExternalConversationKind,
+    pub title: Option<String>,
     pub extra: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TunnelHealthReport {
-    /// tunnel DID。
-    pub tunnel_did: DID,
-    /// 当前实例状态。
-    pub state: MsgTunnelInstanceState,
-    /// 最近一次入站 checkpoint。
-    pub ingress_checkpoint: Option<String>,
-    /// 最近一次成功出站时间。
-    pub last_egress_at_ms: Option<u64>,
-    /// 最近错误。
-    pub last_error: Option<String>,
-    /// 当前能力缺口或降级原因。
-    pub degraded_reasons: Vec<String>,
-    /// 更新时间。
-    pub updated_at_ms: u64,
+pub enum ExternalConversationKind {
+    Direct,
+    Group,
+    SubConversation,
+    Channel,
+    EmailThread,
+    System,
+    Unknown(String),
 }
 ```
 
-### 5.6 出站发送请求
+字段说明：
+
+- `conversation_id`：平台原始会话 ID。
+- `parent_conversation_id`：thread/topic/subgroup 所属父会话。
+- `Unknown`：平台升级后旧系统仍可保留数据。
+
+### 6.6 TunnelIngressEvent
 
 ```rust
-/// 标准出站发送请求。具体平台 tunnel 再把它转成平台 SDK/API 请求。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSendRequest {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// 发送账号。
-    pub sender_account_id: ExternalAccountId,
-    /// 目标会话或目标 actor。
-    pub target: ExternalSendTarget,
-    /// 内容片段。
-    pub parts: Vec<ExternalMessagePart>,
-    /// 是否替换、编辑或补全某条外部消息。
-    pub replace_message_id: Option<ExternalMessageId>,
-    /// 对应 MsgCenter record。
-    pub record_id: String,
-    /// 平台特有发送参数，例如 parse_mode、tenant_id、reply_to。
+/// 入站平台事件。是平台事件到 BuckyOS MsgObject 之间的中间层。
+pub struct TunnelIngressEvent {
+    pub event_id: String,
+    pub tunnel_did: DID,
+    pub platform: TunnelPlatform,
+    pub account: ExternalAccountRef,
+    pub conversation: ExternalConversationRef,
+    pub sender: ExternalAccountRef,
+    pub occurred_at_ms: u64,
+    pub received_at_ms: u64,
+    pub payload: TunnelPayload,
+    pub raw: serde_json::Value,
+}
+
+pub enum TunnelPayload {
+    Message(TunnelMessage),
+    ConversationEvent(TunnelConversationEvent),
+    MessageState(TunnelMessageStateEvent),
+    CapabilityEvent(TunnelCapabilityEvent),
+    Unknown(serde_json::Value),
+}
+```
+
+方法建议：
+
+```rust
+impl TunnelIngressEvent {
+    /// 构造平台级幂等 key。优先使用平台 event id；没有时用 platform/account/conversation/message/time 派生。
+    pub fn idempotency_key(&self) -> String;
+
+    /// 构造 MessageCenter 入站上下文。
+    pub fn to_ingress_context(&self) -> IngressContext;
+}
+```
+
+### 6.7 TunnelMessage
+
+```rust
+pub struct TunnelMessage {
+    pub external_message_id: String,
+    pub kind: TunnelMessageKind,
+    pub parts: Vec<TunnelMessagePart>,
+    pub reply_to: Option<String>,
+    pub mentions: Vec<TunnelMention>,
+    pub stream: Option<TunnelStreamInfo>,
     pub extra: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ExternalSendTarget {
-    /// 发送到外部会话。
-    Conversation(ExternalConversationRef),
-    /// 发送给单个外部参与者。
-    Actor(ExternalActorRef),
+pub enum TunnelMessageKind {
+    Text,
+    RichText,
+    Media,
+    Attachment,
+    Reaction,
+    Interactive,
+    AppDependent,
+    AiStreamDelta,
+    AiStreamComplete,
+    Unknown(String),
+}
+
+pub enum TunnelMessagePart {
+    Text { text: String },
+    RichText { format: String, content: String },
+    Emoji { code: String, text: Option<String> },
+    Attachment {
+        object_ref: Option<ObjId>,
+        uri_hint: Option<String>,
+        name: Option<String>,
+        mime: Option<String>,
+        size: Option<u64>,
+    },
+    PlatformObject {
+        object_type: String,
+        payload: serde_json::Value,
+    },
+    Unknown {
+        payload: serde_json::Value,
+    },
 }
 ```
 
-## 6. 与 MsgObject 的映射
+### 6.8 TunnelRoute
 
-### 6.1 基本映射
-
-入站 `ExternalMessage` 应映射为 `MsgObject`：
-
-- `MsgObject.from`：逻辑发送方 DID。若发送方无法映射 DID，可使用 ContactMgr 创建 shadow contact，或使用代表该外部 actor 的临时 DID。是否创建由策略决定。
-- `MsgObject.to`：目标 DID 列表。私聊通常是目标 Agent/User；群聊可指向 group DID 或订阅该会话的 Agent DID。
-- `MsgObject.kind`：普通私聊使用 `Chat`；群消息优先使用 `GroupMsg`；状态和可操作对象在现有类型不足时通过 `meta` 表达。
-- `MsgObject.content.content`：可读 fallback 文本。
-- `MsgObject.content.format`：文本格式，例如 `TextPlain`、`TextMarkdown`、`TextHtml`。
-- `MsgObject.content.refs`：附件、引用文件、外部资源导入后的 NamedObject 引用。
-- `MsgObject.content.machine`：结构化 machine-readable 内容，例如 mention、button、vote、red packet。
-- `MsgObject.meta`：平台 payload、外部 ID、会话 ID、未知字段、能力降级信息。
-- `MsgObject.thread`：会话、topic、reply thread 或 UI session 归类。
-
-### 6.2 不可丢失的信息
-
-以下信息必须保留在 `IngressContext`、`RouteInfo` 或 `msg.meta`：
-
-- platform。
-- tunnel DID。
-- tunnel account id。
-- external conversation id。
-- external message id。
-- external sender account id。
-- external sender display id/name。
-- source sequence/offset。
-- raw event kind。
-- attachment file id 或 NamedObject id。
-- unknown payload 引用或摘要。
-
-## 7. 入站流程
-
-### 7.1 自然语言流程
-
-Tunnel 启动后加载配置和 checkpoint，然后通过平台 API 接收事件。每个事件先被解析为 `TunnelIngressEvent`。已知消息转换为 `ExternalMessage`，状态变化转换为 `ExternalConversationEvent`，未知事件转换为 `UnknownExternalEvent`。
-
-Tunnel 接着按策略解析外部 actor 和 conversation。解析可以返回已有 DID、创建 shadow contact，也可以完全不映射 DID，只把外部 ID 放进上下文。然后构造 `MsgObject`、`IngressContext` 和幂等 key，调用 `MsgCenter.dispatch()`。
-
-只有当 `dispatch()` 成功或确认该事件已幂等处理后，Tunnel 才推进平台 checkpoint。这样进程崩溃时可能重复提交，但不会丢消息。
-
-### 7.2 流程图
-
-```mermaid
-flowchart TD
-    A[Load tunnel config and checkpoint] --> B[Receive external event]
-    B --> C{Event type known?}
-    C -- known message --> D[Build ExternalMessage]
-    C -- known state --> E[Build ExternalConversationEvent]
-    C -- unknown --> F[Build UnknownExternalEvent]
-    D --> G[Resolve optional DID mapping]
-    E --> G
-    F --> G
-    G --> H[Build MsgObject / state MsgObject]
-    H --> I[Build IngressContext]
-    I --> J[Build idempotency key]
-    J --> K[MsgCenter.dispatch]
-    K --> L{Dispatch accepted or duplicate?}
-    L -- yes --> M[Persist checkpoint]
-    L -- no --> N[Log and retry or quarantine]
-```
-
-### 7.3 入站关键方法
+当前实现已有 `RouteInfo`，建议不新增并行基础类型。理论完整 tunnel 需要的路由信息应通过 `RouteInfo` 表达：
 
 ```rust
-impl MessageTunnelRuntime {
-    /// 接收并处理一个平台事件。该方法必须幂等可重试。
-    pub async fn handle_external_event(
-        &self,
-        raw_event: serde_json::Value,
-    ) -> anyhow::Result<DispatchResult> {
-        let event = self.parse_event(raw_event).await?;
-        let normalized = self.normalize_ingress(event).await?;
-        let (msg, ingress_ctx, idempotency_key) = self.build_dispatch_request(normalized).await?;
-        let result = self.msg_center.dispatch(msg, Some(ingress_ctx), Some(idempotency_key)).await?;
-        self.commit_checkpoint_if_safe(&result).await?;
-        Ok(result)
-    }
-
-    /// 将外部事件解析为 tunnel 中间对象。
-    async fn parse_event(&self, raw: serde_json::Value) -> anyhow::Result<TunnelIngressEvent>;
-
-    /// 将中间对象转换成 BuckyOS 可 dispatch 的对象。
-    async fn normalize_ingress(&self, event: TunnelIngressEvent) -> anyhow::Result<NormalizedIngress>;
-
-    /// 生成 MsgCenter 入站请求。
-    async fn build_dispatch_request(
-        &self,
-        normalized: NormalizedIngress,
-    ) -> anyhow::Result<(MsgObject, IngressContext, String)>;
+pub struct RouteInfo {
+    pub tunnel_did: Option<DID>,
+    pub platform: Option<String>,
+    pub account_id: Option<String>,
+    pub address: Option<String>,
+    pub chat_id: Option<String>,
+    pub target_did: Option<DID>,
+    pub mode: Option<String>,
+    pub priority: Option<i32>,
+    pub ext_ids: HashMap<String, String>,
+    pub extra: Option<serde_json::Value>,
 }
 ```
 
-## 8. 出站流程
+使用约定：
 
-### 8.1 自然语言流程
+- `tunnel_did`：出站必须存在，否则无法选择 tunnel。
+- `platform`：平台名，用于诊断和多 tunnel 选择。
+- `account_id`：tunnel 使用的本方平台账号。
+- `address`：Email 地址、webhook URL 或平台目标地址。
+- `chat_id`：IM 会话 ID。
+- `target_did`：已映射到 BuckyOS 联系人时填写。
+- `ext_ids`：外部 message id、thread id、tenant id、open id、reply target 等。
+- `extra`：平台专有出站参数，例如 parse_mode、card template、SMTP header。
 
-Agent、人类 UI 或系统服务生成响应后调用 `MsgCenter.post_send()`。Message Center 使用 ContactMgr 选择投递路径，创建 `TunnelOutbox` 记录。Tunnel 的发送循环从自己的 `TunnelOutbox` 拉取 `Wait` 记录，将 `MsgRecordWithObject` 转换为平台发送请求。
+## 7. MsgObject 映射
 
-发送成功后，Tunnel 通过 `MsgCenter.report_delivery()` 写入外部 message id、送达时间和状态。发送失败时，Tunnel 必须区分可重试失败和最终失败。可重试失败应保留原因和下次重试时间；最终失败进入 `Dead` 或等价状态，供 UI 和审计发现。
-
-### 8.2 流程图
-
-```mermaid
-flowchart TD
-    A[Agent/Human/Service creates reply] --> B[MsgCenter.post_send]
-    B --> C[Delivery plan by ContactMgr]
-    C --> D[TunnelOutbox record WAIT]
-    D --> E[Tunnel send loop get_next lock_on_take]
-    E --> F[Record state SENDING]
-    F --> G[Build ExternalSendRequest]
-    G --> H{Capability and route valid?}
-    H -- no --> I[report_delivery final failure]
-    H -- yes --> J[Call external IM API]
-    J --> K{Result}
-    K -- success --> L[report_delivery SENT with external_msg_id]
-    K -- retryable --> M[report_delivery WAIT/FAILED retry info]
-    K -- final failure --> N[report_delivery DEAD]
-```
-
-### 8.3 出站关键方法
+### 7.1 普通聊天消息
 
 ```rust
-impl MessageTunnelRuntime {
-    /// 持续消费当前 tunnel 的出站队列。
-    pub async fn run_send_loop(&self) -> anyhow::Result<()> {
-        loop {
-            let record = self.next_tunnel_outbox_record().await?;
-            if let Some(record) = record {
-                let result = self.send_record_to_platform(record.clone()).await;
-                self.report_delivery(record.record.record_id, result).await?;
-            } else {
-                self.wait_for_outbox_event_or_timeout().await;
-            }
-        }
+fn tunnel_message_to_msg_object(event: &TunnelIngressEvent, target: Vec<DID>) -> MsgObject {
+    MsgObject {
+        from: resolve_sender_did_or_tunnel_shadow(event),
+        to: target,
+        kind: MsgObjKind::Chat,
+        thread: build_thread(event),
+        workspace: None,
+        created_at_ms: event.occurred_at_ms,
+        expires_at_ms: None,
+        nonce: None,
+        content: build_msg_content(event),
+        proof: None,
+        // meta/extra should preserve platform ids and unknown fields.
     }
+}
+```
 
-    /// 把 MsgCenter 记录转换成平台发送请求，并执行发送。
-    async fn send_record_to_platform(
+说明：
+
+- 如果外部发送者已绑定 DID，`from` 可使用该 DID。
+- 如果没有 DID，当前基础 `MsgObject.from` 仍需要 DID。实现可以使用 tunnel DID、owner 配置的 shadow DID、ContactMgr 自动创建的联系人 DID，或把消息送入 REQUEST_BOX 等待确认。不能把任意外部字符串伪装成可信 DID。
+- 原始外部账号必须保存在 `IngressContext`、`RouteInfo` 或 `MsgObject` meta 中，用于回复路由和审计。
+
+### 7.2 群消息
+
+BuckyOS self-host group 的规范是 `from=group_did, source=author_did`。外部 IM 群不一定拥有 BuckyOS group DID，因此分两种：
+
+1. 已映射为 BuckyOS group：使用 group DID 语义，MessageCenter 写 `GROUP_INBOX`。
+2. 未映射外部群：作为某个 Agent/User 的外部会话消息处理，保留 `conversation_id`，不要强行创建 group DID。
+
+### 7.3 @ 和特殊符号
+
+@ 只是平台特殊符号的一个例子。不同平台可能使用不同提及、命令或 bot trigger 规则。
+
+建议表达：
+
+```rust
+pub struct TunnelMention {
+    pub raw: String,
+    pub account: Option<ExternalAccountRef>,
+    pub did: Option<DID>,
+    pub role: MentionRole,
+}
+
+pub enum MentionRole {
+    User,
+    Bot,
+    All,
+    Here,
+    Command,
+    Unknown(String),
+}
+```
+
+进入 `MsgObject` 时：
+
+- 可解析 DID 的 mention 写入结构化 metadata。
+- 不可解析的 mention 保留原始文本和平台账号。
+- Agent 是否被 @ 唤醒由 tunnel 子类或 MessageCenter/Agent runtime 策略决定。
+
+### 7.4 附件
+
+附件处理策略：
+
+1. 小附件或允许下载的文件，导入 BuckyOS object store，`MsgContent.refs` 指向 `ObjId`。
+2. 大附件或权限受限附件，保留 `uri_hint`、平台 file id、mime、size，按需拉取。
+3. 无法读取附件时，生成可展示的占位信息并保留错误。
+4. 附件导入失败不应阻止文本部分入站，除非平台消息只有附件且策略要求完整性。
+
+### 7.5 可操作和第三方应用消息
+
+红包、投票、小程序、审批卡片等消息有平台内操作语义。通用 Message Tunnel 不应假装自己能执行所有操作。
+
+处理方式：
+
+- 能安全转换为 BuckyOS `operation` 的，转为 `MsgObjKind::Operation` 并带权限确认。
+- 只能展示的，降级为 `MsgObjKind::Notify` 或 chat 文本说明。
+- 完全未知的，作为 `PlatformObject` 保存并进入 unknown/quarantine 流程。
+
+### 7.6 AI 流式消息
+
+如果 Message Tunnel 对接聊天 AI 或 Agent 运行状态，可能需要发送流式响应：
+
+- 支持编辑消息的平台：先发送 placeholder，再不断 edit。
+- 支持 typing/status 的平台：用 typing 或 status line 表达处理中。
+- 支持多条消息的平台：发送 delta 消息，但要用同一个 `correlation_id` 关联。
+- 不支持流式的平台：只发送 final。
+
+流式状态不应破坏最终消息幂等。最终内容应有明确完成事件或 final message。
+
+## 8. 关键接口
+
+### 8.1 理论完整 trait
+
+当前代码中的 `MsgTunnel` 是最小运行 trait。理论完整接口可按下面方向扩展，但实现时应优先兼容现有 trait：
+
+```rust
+#[async_trait::async_trait]
+pub trait MessageTunnel: Send + Sync {
+    fn tunnel_did(&self) -> DID;
+    fn name(&self) -> &str;
+    fn platform(&self) -> TunnelPlatform;
+    fn account_kind(&self) -> TunnelAccountKind;
+    fn capability(&self) -> TunnelCapability;
+
+    /// 启动连接、webhook、poller 或 watcher。
+    async fn start(&self) -> anyhow::Result<()>;
+
+    /// 停止接收和发送，保存 checkpoint。
+    async fn stop(&self) -> anyhow::Result<()>;
+
+    /// 拉取或接收外部事件。Webhook 型 tunnel 可在内部 callback 后返回空。
+    async fn pull_or_receive(&self) -> anyhow::Result<Vec<TunnelIngressEvent>>;
+
+    /// 处理单个入站事件，通常会调用 MessageCenter.dispatch。
+    async fn handle_ingress(&self, event: TunnelIngressEvent) -> anyhow::Result<()>;
+
+    /// 投递 MessageCenter TUNNEL_OUTBOX 记录。
+    async fn send_record(
         &self,
         record: MsgRecordWithObject,
     ) -> anyhow::Result<DeliveryReportResult>;
 
-    /// 校验 route、账号绑定、平台能力和目标会话。
-    fn validate_egress_route(&self, record: &MsgRecordWithObject) -> anyhow::Result<()>;
+    /// 可选：同步平台联系人、会话或群成员。
+    async fn sync_contacts(&self) -> anyhow::Result<TunnelSyncReport>;
+
+    /// 可选：查询平台侧会话能力。
+    async fn describe_conversation(
+        &self,
+        conversation: &ExternalConversationRef,
+    ) -> anyhow::Result<TunnelConversationInfo>;
 }
 ```
 
-## 9. Agent 最大功能集
+### 8.2 BotMsgTunnel 和 UserMsgTunnel
 
-理论上，如果 IM 平台对机器人没有任何限制，一个 Agent 作为 Message Tunnel 背后的账号，应能完成真实自然人在会话中可完成的一切行为：
+```rust
+pub struct BotMsgTunnel<T> {
+    pub inner: T,
+    pub bot_account: ExternalAccountRef,
+    pub allowed_scopes: Vec<String>,
+}
 
-- 阅读私聊、群聊、子群、thread、频道和历史上下文。
-- 发送文本、富文本、表情、引用回复、附件、编辑、删除和 reaction。
-- 收发会话状态，例如加入、退出、成员变化、已读、typing、禁言和权限变化。
-- 处理平台特殊消息，例如红包、投票、小程序、审批卡片。
-- 在授权范围内加入或退出会话。
-- 在授权范围内给其他会话、其他人、Email、Lark 等渠道发送消息。
-- 使用被授予的工具，例如发送 email、访问 B 站关注列表、向 Lark 发送通知。
-- 记录行为日志，使一组机器人之间的对话和动作可观测、可追溯。
-
-如果某个平台限制 Bot API，例如不能读取某些群成员、不能主动私聊、不能操作红包，则该限制属于平台子类能力裁剪，不应收缩通用 Message Tunnel 的最大定义。
-
-## 10. 平台子类
-
-### 10.1 Telegram
-
-Telegram Tunnel 应区分：
-
-- `TelegramBotMsgTunnel`：使用 Bot API 或 bot session，受 Telegram 对 bot 的群、私聊、成员信息限制。
-- `TelegramUserMsgTunnel`：使用用户授权 session，能力更接近自然人，但需要更严格安全策略。
-
-能力关注点：
-
-- 私聊、群聊、频道、topic。
-- message_id、chat_id、sender id 可构成稳定幂等 key。
-- 附件需要下载并导入 NamedObject，或保留 file id。
-- Bot 通常不能主动给未开始对话的用户发消息。
-- parse mode、Markdown/HTML 转换需要平台专用处理。
-
-### 10.2 Lark
-
-Lark Tunnel 应区分：
-
-- `LarkBotMsgTunnel`：企业应用机器人，适合群消息、卡片、审批和通知。
-- `LarkUserMsgTunnel`：用户授权模式，适合代表用户操作，但权限范围更敏感。
-
-能力关注点：
-
-- open_id、union_id、chat_id、tenant_id 共同定义身份范围。
-- 富文本、卡片、按钮、审批、投票等可操作对象较多，应优先进入 `InteractiveObject`。
-- 企业权限和租户边界必须进入 `RouteInfo.extra` 或平台配置。
-- 机器人能否加入群、读取历史和私聊取决于应用权限。
-
-### 10.3 Email
-
-Email Tunnel 通常不是实时 IM，但仍是 Message Tunnel：
-
-- 入站通过 IMAP、SMTP webhook、邮件服务 API 或本地 maildir。
-- 会话模型是 thread。
-- actor 是 email address，可选映射 Contact DID。
-- 附件天然重要，应导入 NamedObject 或保留外部引用。
-- 出站需要处理 reply-to、cc、bcc、subject、message-id、in-reply-to。
-- 已读、typing、在线等临时状态通常不支持。
-
-### 10.4 MessageHub
-
-MessageHub 是 BuckyOS 内部或 Web UI 消息通道：
-
-- 大多数 actor 可直接解析 DID。
-- session id 是 UI 和 Agent 上下文的重要语义。
-- 它不一定需要外部平台账号映射，但仍应保留 tunnel、session、record id 以统一观测。
-- 可作为实现其他 tunnel 的参考基线。
-
-## 11. 消息顺序、去重和遗漏
-
-### 11.1 顺序性
-
-要求：
-
-- 同一外部会话内应尽量按平台 sequence 或时间顺序 dispatch。
-- 同一 tunnel 账号内的多个会话不要求全局顺序。
-- 如果平台只提供乱序 webhook，Tunnel 应保留 sequence 并允许 Message Center 或 UI 按 sort_key 重排。
-- 出站同一会话的响应应尽量串行发送，避免平台显示顺序反转。
-
-### 11.2 去重
-
-入站幂等 key 建议：
-
-```text
-{platform}:{tunnel_account_id}:{conversation_id}:{external_message_id}:{event_kind}
+pub struct UserMsgTunnel<T> {
+    pub inner: T,
+    pub user_account: ExternalAccountRef,
+    pub delegated_by: Option<DID>,
+    pub allowed_scopes: Vec<String>,
+}
 ```
 
-出站幂等依赖：
+区别：
 
-- `MsgObject` 的对象 ID。
-- `MsgRecord.record_id`。
-- `post_send` 的 idempotency key。
-- 外部平台成功后的 `external_msg_id`。
+- `BotMsgTunnel` 默认权限窄，适合长期运行和公开接入。
+- `UserMsgTunnel` 可以代表自然人执行更强操作，必须有清晰授权、审计和撤销路径。
+- 同一平台通常要分别实现 bot/user 两个子类或在同一实现中声明不同能力 profile。
 
-重复发送风险处理：
+## 9. 持久状态
 
-- 如果发送请求超时但平台可能已发送成功，应优先查询外部 message id 或使用平台提供的 client token。
-- 如果平台不支持查询或 client token，只能按 `DeliveryInfo` 标记不确定状态，并避免无限重试。
+Message Tunnel 自身可能需要持久化以下数据：
 
-### 11.3 遗漏恢复
+| 数据 | 所属组件 | 持久性 | 说明 |
+|---|---|---|---|
+| 平台 access token/session | Tunnel 子类 | Durable | 需要安全存储和可撤销 |
+| 入站 checkpoint/offset | Tunnel 子类 | Durable | 防止重启后遗漏或重复 |
+| 入站 event 去重表 | Tunnel 子类或 MessageCenter | Durable/TTL | 至少覆盖平台重投窗口 |
+| 平台账号绑定 | system-config/ContactMgr | Durable | 已有 `UserTunnelBinding`/`AccountBinding` |
+| 标准消息历史 | MessageCenter/named_store/RDB | Durable | 不由 tunnel 私有保存 |
+| 出站投递状态 | MessageCenter `MsgRecord.delivery` | Durable | tunnel 通过 `report_delivery` 更新 |
+| 临时附件缓存 | Tunnel 子类 | Disposable | 可重建或重新下载 |
+| 运行中 typing/status | ui_session_states/内存 | Disposable/Durable by policy | 可过期 |
+| 审计日志 | Tunnel 子类/系统日志 | Durable by policy | 用于追踪 Agent 行为 |
 
-Tunnel 必须持久化：
+如果未来把这些状态落入 RDB，应使用平台 RDB instance，不直接绑定 sqlite 或 Postgres。新字段采用 additive-only 策略，未知字段保存在 JSON `extra` 中。
 
-- 入站 checkpoint 或 offset。
-- 已处理 idempotency key 缓存，至少覆盖平台可能重放窗口。
-- 出站 `TunnelOutbox` 状态由 Message Center 持久化。
-- 发送中崩溃后，`Sending` 状态需要租约恢复或重新置为 `Wait`。
+## 10. 幂等、顺序和遗漏
 
-实时通知只是加速信号。任何消费者都必须能通过重新扫描 inbox/outbox 恢复。
+### 10.1 入站幂等
 
-## 12. 兼容性和未来升级
+入站去重使用三层：
 
-### 12.1 外部 IM 平台升级
+1. 平台 event id 或 update id。
+2. 平台 message id + chat id + account id。
+3. 标准 `MsgObject` canonical id。
 
-平台升级可能增加：
+重复事件不应产生重复用户可见消息。若平台允许同一消息编辑，应创建状态更新或新版本事件，而不是重复 chat 消息。
 
-- 新消息类型。
-- 新会话类型。
-- 新成员状态。
-- 新可操作对象。
-- 新权限或限制。
-- payload 字段类型变化。
+### 10.2 出站幂等
 
-处理要求：
+出站去重以 `MsgRecord.record_id` 和平台 `external_msg_id` 为核心：
 
-- 未知 enum 使用 `Unknown(String)`。
-- 未知 payload 存入 `extra`、`raw` 或 `msg.meta.platform_payload`。
-- 生成 fallback 文本，例如 `[Unsupported Telegram story]`。
-- 记录 capability gap，不让 tunnel 崩溃。
-- 关键转换失败时进入 quarantine/request box，而不是丢弃。
+- `SENT` 且已有 `external_msg_id` 的记录不能再次发送。
+- 网络超时但平台可能已发送成功时，优先查询平台状态；无法查询时按平台风险策略处理。
+- 重试必须更新 `DeliveryInfo.attempts`、`next_retry_at_ms`、`last_error`。
 
-### 12.2 BuckyOS 新旧版本互通
+### 10.3 顺序
 
-新版本可能写入旧版本不理解的数据。旧版本应：
+Message Tunnel 不承诺所有平台全局有序，只承诺在可得信息范围内尽量维持会话内顺序：
 
-- 忽略未知字段。
-- 保留未知字段，避免读写后丢失。
-- 对未知消息内容展示 fallback text。
-- 对未知状态不执行危险操作。
-- 对未知投递 route 返回明确失败，不能误投递。
+- 使用平台 sequence/update id。
+- 使用平台 message timestamp。
+- 使用接收时间作为兜底。
+- 对乱序到达的消息，可以短暂 buffer；超时后按已知顺序入站。
 
-### 12.3 数据损坏防护
+Agent 和 UI 不能假设所有消息严格连续，应能处理迟到消息、编辑消息和缺失消息。
 
-禁止以下行为：
+### 10.4 遗漏恢复
 
-- 解析未知事件时 panic。
-- 因单条坏消息停止整个 tunnel。
-- 出站 route 缺失时猜测目标并发送。
-- 发送失败时静默删除 `TunnelOutbox` 记录。
-- 覆盖或丢弃原始外部 ID。
+每个 tunnel 子类应实现：
 
-## 13. 安全和授权
+- 启动时从 checkpoint 后恢复。
+- 定期 reconcile 最近窗口。
+- 检测 offset gap 后触发补拉或报警。
+- 无法补拉时写审计事件，避免静默遗漏。
 
-Message Tunnel 是高风险边界，必须遵守：
+## 11. 安全和权限
 
-- 入站消息进入 inbox 前由 ContactMgr/策略决定是否进入 `Inbox`、`RequestBox` 或丢弃。
-- 出站消息必须有明确 route 和授权来源。
-- User tunnel 代表自然人操作，默认权限更高，必须有更严格审计和撤销机制。
-- Agent 使用工具发送跨会话消息、Email 或 Lark 通知时，应有可解释授权来源。
-- secret、token、session 文件不得写入普通日志。
-- 任何平台可操作对象默认不可自动执行，除非策略明确授权。
+### 11.1 入站安全
 
-## 14. 可观测性
+- Webhook 必须校验签名或 token。
+- User tunnel session 必须加密存储。
+- Bot token 不应写入普通日志。
+- 入站消息进入普通 inbox 前应经过 ContactMgr/GroupMgr 策略。
+- 低信任或未知来源可进入 `REQUEST_BOX`，等待人工确认。
 
-每条入站事件至少能追踪：
+### 11.2 出站安全
 
-- tunnel DID。
-- platform。
-- external account id。
-- external conversation id。
-- external message id。
-- idempotency key。
-- generated msg_id。
-- dispatch result。
+- Agent 主动向其他会话发消息属于外部副作用，应受权限控制。
+- 代表用户发 Email、加入群聊、通知 Lark 等动作必须有可审计授权。
+- 对风险动作可先生成确认消息，由人操作控制组件确认后再出站。
+- 出站失败必须显式可见，不能静默吞掉。
 
-每条出站投递至少能追踪：
+### 11.3 审计
 
-- record_id。
-- msg_id。
-- route.tunnel_did。
-- route.platform。
-- route.chat_id/address。
-- attempts。
-- external_msg_id。
-- final state。
-- error_code/error_message。
+至少记录：
 
-Agent 行为日志不属于 Message Tunnel 责任，但 Message Tunnel 需要提供足够关联 ID，让审计系统能把外部消息、Message Center record、Agent session、响应消息和外部投递串起来。
+- 入站事件 ID、平台、账号、会话、外部消息 ID。
+- 标准 `MsgObjectId` 和 MessageCenter `record_id`。
+- Agent 读取、处理、响应的关联 ID。
+- 出站 `record_id`、平台发送结果、外部消息 ID。
+- 权限拒绝、能力降级、未知消息、重试和最终失败。
 
-## 15. 配置会话示例的解释
+审计日志中的敏感内容应按系统日志策略脱敏。
 
-用户在机器人配置会话窗口输入：
+## 12. 未来兼容
+
+### 12.1 平台升级
+
+平台升级可能新增消息类型、字段、状态或限制。兼容规则：
+
+- enum 保留 `Unknown(String)` 或 `Custom(String)`。
+- payload 保留 `raw/extra`。
+- 未知消息进入可展示降级或 quarantine。
+- 未知字段忽略但尽量保留。
+- 新能力默认关闭，只有 tunnel 声明支持后才启用。
+
+### 12.2 BuckyOS 版本互通
+
+旧系统可能收到新系统产生的数据：
+
+- 新字段必须可忽略。
+- 旧系统不认识的新 `kind` 应按 `event/notify/unknown` 展示。
+- 新系统不能要求旧系统理解平台私有 extra 才能保持数据完整。
+- 破坏性协议升级必须新建版本字段或新对象类型。
+
+### 12.3 数据保护
+
+兼容失败时的优先级：
+
+1. 不宕机。
+2. 不损坏已有数据。
+3. 不误发外部消息。
+4. 不丢弃原始平台 payload。
+5. 给用户或管理员可观察错误。
+
+## 13. 典型 Tunnel
+
+### 13.1 Telegram
+
+Telegram tunnel 需要区分：
+
+- Bot API tunnel：适合公开机器人，能力受 Telegram bot 限制。
+- User session tunnel：接近自然人账号能力，但授权、安全和合规要求更高。
+
+关键字段：
+
+- `chat_id`
+- `message_id`
+- `peer_id`
+- `bot_account_id`
+- `reply_to_message_id`
+- `thread/topic id`
+- `file_id`
+
+典型能力：
+
+- 支持 1v1、群聊、附件、reply、typing、编辑消息。
+- bot 是否能读历史、主动私聊、获取成员，取决于平台权限和配置。
+- 当前实现中的 `TgTunnel` 已提供 Telegram 方向的最小运行路径。
+
+### 13.2 Lark
+
+Lark tunnel 需要保留企业和应用上下文：
+
+- `tenant_key`
+- `app_id`
+- `open_id/user_id`
+- `chat_id`
+- `message_id`
+- 卡片消息 payload
+
+典型能力：
+
+- 机器人入站/出站。
+- 富文本和卡片消息。
+- 群聊和企业权限控制。
+- 审批、投票、按钮等交互消息可映射为 operation 或降级展示。
+
+Lark 的权限边界强，缺少 scope 时应明确失败。
+
+### 13.3 Email
+
+Email tunnel 是异步消息通道，不是完整 IM：
+
+- 入站来自 IMAP、POP3、provider API 或 webhook。
+- 出站通过 SMTP 或 provider API。
+- 会话通常是 email thread。
+- 没有 typing、在线、实时已读等 IM 状态。
+
+关键字段：
+
+- mailbox/account
+- `Message-ID`
+- `In-Reply-To`
+- `References`
+- from/to/cc/bcc
+- subject
+- MIME parts
+
+降级规则：
+
+- Email HTML 可转为 `text/html` 或提取纯文本。
+- 附件导入对象存储或保留 provider attachment id。
+- 群聊语义按多收件人或 thread 表达，不强行创建 BuckyOS group。
+
+### 13.4 MessageHub
+
+MessageHub tunnel 是 BuckyOS 原生消息通道：
+
+- 参与方可直接使用 DID。
+- 消息对象可直接使用 `MsgObject`。
+- 可用于跨 Zone、Agent-to-Agent、Group-to-Group 或系统内部桥接。
+- 平台私有语义最少，但需要严格遵守 DID、MessageCenter、GroupMgr 权限模型。
+
+MessageHub tunnel 是最接近理论完整模型的实现，应作为其他平台 tunnel 的标准参照。
+
+## 14. 示例
+
+用户在机器人配置会话输入：
 
 ```text
 你可以翻阅我在B站关注的主播，如果他们有内容更新就发EMAIL告诉我(email: xxx)
 你可以加入我Telegram的好友群，如果发现他们出去浪，通过Lark告诉我(ID: xxx)
 ```
 
-这里涉及多个边界：
+可能流程：
 
-- 配置会话本身通过某个 Message Tunnel 入站。
-- Agent 理解用户授权，生成工具授权或任务配置。
-- B 站更新检查不是 Message Tunnel，属于 Agent tool 或外部服务 connector。
-- Email 通知通过 `EmailMsgTunnel` 出站。
-- Telegram 好友群加入能力取决于 Telegram tunnel 类型和授权。
-- Lark 通知通过 `LarkBotMsgTunnel` 或 `LarkUserMsgTunnel` 出站。
-- 所有跨会话、跨平台发送都应留下授权来源、任务 ID、record_id 和投递结果。
+1. Telegram tunnel 收到配置会话消息。
+2. MessageCenter 把消息投递给 Jarvis Agent。
+3. Agent 判断需要使用 B 站观察工具、Email tunnel、Telegram tunnel、Lark tunnel。
+4. Agent 请求或检查 owner 授权。
+5. 授权后 Agent 保存规则。
+6. 未来触发时，Agent 通过 MessageCenter `post_send` 生成 Email 或 Lark 出站消息。
+7. 对应 tunnel 从 `TUNNEL_OUTBOX` 投递并回报结果。
+8. 所有行为都能通过审计日志串联：配置消息、授权、工具运行、外部投递。
 
-## 16. 典型端到端流程
+## 15. 验收标准
 
-### 16.1 Telegram 群消息触发 Agent 回复
+一个 Message Tunnel 实现可以认为满足基础要求，当它能做到：
 
-```mermaid
-sequenceDiagram
-    participant TG as Telegram
-    participant T as TelegramBotMsgTunnel
-    participant MC as MsgCenter
-    participant A as Agent
+1. 启动、停止、重启后恢复 checkpoint。
+2. 从至少一种外部会话接收入站消息。
+3. 把入站消息转换为标准 `MsgObject` 并调用 `dispatch`。
+4. 从 `TUNNEL_OUTBOX` 拉取响应并投递回平台。
+5. 报告成功、可重试失败、最终失败。
+6. 对重复入站和重复出站保持幂等。
+7. 对未知消息保留原始数据并降级，不宕机。
+8. 声明能力，并按能力拒绝或降级不支持动作。
+9. 记录足够日志以追踪一次完整消息链路。
+10. 不强制把外部账号或会话映射为 DID。
 
-    TG->>T: group message
-    T->>T: normalize ExternalMessage
-    T->>MC: dispatch(MsgObject, IngressContext, idempotency_key)
-    MC->>A: Inbox/GroupInbox record available
-    A->>MC: get_next(owner, Inbox)
-    A->>A: process and generate reply
-    A->>MC: post_send(reply MsgObject, SendContext)
-    MC->>T: TunnelOutbox record
-    T->>TG: send message
-    T->>MC: report_delivery(record_id, SENT, external_msg_id)
-```
+完整实现还应覆盖：
 
-### 16.2 Email 入站和 Lark 出站
+1. 附件导入和导出。
+2. 群聊和 thread/topic。
+3. 读取状态、typing、消息编辑/撤回。
+4. 可操作消息和第三方 app 消息的安全降级。
+5. AI 流式输出。
+6. 用户授权、撤销和审计。
+7. 多平台联系人绑定和路由选择。
 
-```mermaid
-sequenceDiagram
-    participant Mail as Email Server
-    participant ET as EmailMsgTunnel
-    participant MC as MsgCenter
-    participant A as Agent
-    participant LT as LarkMsgTunnel
-    participant Lark as Lark
+## 16. 与当前实现的关系
 
-    Mail->>ET: new email in thread
-    ET->>MC: dispatch(email MsgObject)
-    MC->>A: RequestBox or Inbox
-    A->>MC: post_send(notification MsgObject, preferred_tunnel=Lark)
-    MC->>LT: TunnelOutbox
-    LT->>Lark: send card/text
-    LT->>MC: report_delivery
-```
+当前代码已经具备的基础：
 
-## 17. 实现入口建议
+- `src/frame/msg_center/src/msg_tunnel.rs` 定义了 `MsgTunnel` 和 `MsgTunnelInstanceMgr`。
+- `src/frame/msg_center/src/tg_tunnel.rs` 是 Telegram tunnel 实现。
+- `src/kernel/buckyos-api/src/msg_center_client.rs` 定义了 `IngressContext`、`SendContext`、`RouteInfo`、`DeliveryInfo`、`MsgRecord`、`DeliveryReportResult` 等共享类型。
+- MessageCenter 已有 `dispatch`、`post_send`、`get_next`、`report_delivery`、`set_read_state` 等接口。
 
-当前仓库已有：
-
-- `src/frame/msg_center/src/msg_tunnel.rs`：`MsgTunnel` trait 和实例管理。
-- `src/frame/msg_center/src/tg_tunnel.rs`：Telegram tunnel 参考实现。
-- `src/frame/msg_center/src/msg_center.rs`：`dispatch`、`post_send`、`get_next`、`report_delivery` 等核心流程。
-- `src/kernel/buckyos-api/src/msg_center_client.rs`：共享 API 类型。
-- `src/frame/opendan/src/msg_center_pump.rs`：Agent 消费 MsgCenter inbox 的参考流程。
-
-后续实现应优先复用这些入口。新增平台 tunnel 应先实现现有 `MsgTunnel` trait，再在平台内部逐步补齐完整对象模型、能力声明和未知事件降级。
-
-## 18. 验收标准
-
-设计可接受的标准：
-
-- 能解释 Message Tunnel 和 MsgCenter、Agent、ContactMgr、GroupMgr 的边界。
-- 能表达 1v1、群聊、子群、thread 和机器人群聊。
-- 能表示文本、富文本、附件、mention、状态事件、可操作对象和未知消息。
-- 能明确外部 ID 何时只是字符串，何时才需要映射 DID。
-- 能支持 Bot/User 两类 tunnel 的能力裁剪。
-- 能覆盖入站、出站、幂等、顺序、重试、遗漏恢复。
-- 能在平台和 BuckyOS 升级时兼容未知字段和未知类型。
-- 能给 Telegram、Lark、Email、MessageHub 四类典型 tunnel 提供实现方向。
+本文建议的新增对象主要是设计层中间模型，用于让未来 Telegram/Lark/Email/MessageHub tunnel 的实现保持一致。实现时应优先复用现有类型，只有当中间模型确实能减少平台适配重复代码时再落地为共享 Rust 类型。

--- a/doc/message_hub/Message Tunnel Design.md
+++ b/doc/message_hub/Message Tunnel Design.md
@@ -1,0 +1,888 @@
+# Message Tunnel Design
+
+本文定义 BuckyOS Message Tunnel 的理论完整模型。目标是给人类 review 设计边界、对象语义、流程、兼容性和各平台裁剪方式。给 agent/codegen 使用的最小版本见 `Message Tunnel Minimal Spec.md`。
+
+## 1. 任务确认
+
+Message Tunnel 是一个 IM 通道适配层。它把 Telegram、Lark、Email、MessageHub 等外部或内部会话系统中的消息和会话事件接入 BuckyOS Message Center，并把 Message Center 中的响应消息投递回来源 IM 会话或被授权的其他会话。
+
+完整流程是：
+
+1. Tunnel 从 IM 会话中获取消息、状态和平台事件。
+2. Tunnel 将事件标准化，经 `MsgCenter.dispatch()` 投递给消息指定的目标 Agent、人操作的控制组件或其他系统组件。
+3. 目标组件处理消息后，自行按规则存储响应或调用 `MsgCenter.post_send()` 创建响应消息。这一步不需要 Message Tunnel 参与。
+4. Tunnel 从 `MsgCenter` 的 `TunnelOutbox` 取出响应或其他出站消息，按路由投递给来源 IM 会话或授权目标。
+
+## 2. 设计边界
+
+### 2.1 Message Tunnel 负责什么
+
+Message Tunnel 负责平台协议边界：
+
+- 连接外部 IM API、Webhook、轮询、长连接或本地 MessageHub。
+- 把平台事件转换为 BuckyOS 可处理的消息对象、状态对象或未知事件对象。
+- 构造 `IngressContext`、`RouteInfo` 和幂等 key。
+- 调用 Message Center 的入站和投递回报 API。
+- 消费 `TunnelOutbox` 并把消息发送回外部平台。
+- 保存平台 offset、checkpoint、账号绑定、外部 ID、健康状态和错误信息。
+- 按平台能力裁剪机器人和自然人账号的行为。
+
+### 2.2 Message Tunnel 不负责什么
+
+Message Tunnel 不负责：
+
+- Agent 如何理解消息、选择工具、生成回复。
+- Agent 的工作日志、长期记忆、任务状态和响应消息存储策略。
+- Message Center 的 inbox/outbox 存储模型。
+- ContactMgr 和 GroupMgr 的最终身份、成员、权限管理。
+- 将所有外部概念强行 DID 化。
+
+Tunnel 可以提供足够的来源信息，让 ContactMgr、GroupMgr、Agent 或 UI 决定是否建立 DID 映射。
+
+## 3. 外部语义和 DID 的关系
+
+外部 IM 系统中的用户账号 ID、群 ID、会话 ID 和消息 ID 是平台语义下的字符串。它们可能对应 BuckyOS DID，也可能只是一个来源标识或回复地址。
+
+设计原则：
+
+- 默认保留原平台 ID，不强制封装成 DID。
+- 只有当系统需要长期权限、联系人、成员关系、跨平台路由、审计主体或内部群实体时，才创建或绑定 DID。
+- DID 映射是可选的、可变的、可被人工确认或合并的。
+- 原始平台 ID 必须持续保留，避免 DID 映射变化导致无法回信或无法审计历史。
+
+示例：
+
+- Telegram user id 可以只作为 `ExternalActorRef.account_id`。如果用户后来被添加为联系人，再通过 ContactMgr 绑定 DID。
+- Lark open_id 可以只作为某个 Lark tunnel 的投递地址。它不一定是 BuckyOS 用户。
+- Email address 可作为外部账号 ID，也可绑定到某个 Contact DID。
+- MessageHub 内部用户一般已经能解析 DID，但仍应保留 session id 作为 UI 会话语义。
+
+## 4. 基础类型复用
+
+本文使用现有 BuckyOS 基础类型，不重新定义：
+
+- `DID`：内部身份。
+- `ObjId`：NamedObject ID。
+- `MsgObject`：不可变消息对象，来自 `ndn_lib`。
+- `MsgContent`、`MsgContentFormat`：文本、结构化内容、附件引用。
+- `MsgObjKind`：消息业务类型。
+- `MsgRecord`：某个 owner 在某个 box 中对 `MsgObject` 的视图记录。
+- `RouteInfo`：投递路由，包含 tunnel、platform、account、address、chat_id、target_did、ext_ids、extra。
+- `DeliveryInfo`：投递尝试、外部 message id、送达时间、错误和重试信息。
+- `IngressContext` / `SendContext`：入站和出站上下文。
+- `MsgReceiptObj`：阅读或处理回执。
+- `MsgTunnel` / `MsgTunnelInstanceMgr`：当前实现中的 tunnel 运行接口和实例管理器。
+
+需要升级基础类型时，应单独说明原因。例如新增 `MsgObjKind::ConversationState` 可以减少状态消息对 `meta` 的依赖，但这属于共享协议升级，不应在 tunnel 文档里直接覆盖现有定义。
+
+## 5. 核心对象定义
+
+以下是理论完整 Message Tunnel 的关键对象。它们可先作为文档模型和平台 tunnel 内部结构存在，不要求一次性进入公共 API。
+
+### 5.1 外部引用对象
+
+```rust
+/// 外部 IM 平台 ID。稳定小写字符串，例如 "telegram"、"lark"、"email"、"messagehub"。
+pub type PlatformId = String;
+
+/// 外部平台账号 ID。只在某个平台或某个租户范围内有意义。
+pub type ExternalAccountId = String;
+
+/// 外部平台会话 ID。可表示私聊、群聊、频道、邮件 thread 或 MessageHub session。
+pub type ExternalConversationId = String;
+
+/// 外部平台消息 ID。通常只在平台 + 账号 + 会话范围内唯一。
+pub type ExternalMessageId = String;
+
+/// 外部平台参与者。它保持原平台语义，并可选绑定 BuckyOS DID。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalActorRef {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// 平台账号 ID。
+    pub account_id: ExternalAccountId,
+    /// 平台显示名。
+    pub display_name: Option<String>,
+    /// 平台可读 ID，例如 @name、email address、open_id。
+    pub display_id: Option<String>,
+    /// 可选内部 DID。未解析、未知或不需要映射时为空。
+    pub mapped_did: Option<DID>,
+    /// 原始平台扩展字段。实现必须容忍未知字段。
+    pub extra: serde_json::Value,
+}
+
+/// 外部会话引用。它不是 BuckyOS 会话实体本身。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalConversationRef {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// 外部会话 ID。
+    pub conversation_id: ExternalConversationId,
+    /// 会话类型。
+    pub kind: ExternalConversationKind,
+    /// 可选内部 DID，例如 self-host group DID。
+    pub mapped_did: Option<DID>,
+    /// 可选父会话，用于群内 thread、topic、子群。
+    pub parent: Option<Box<ExternalConversationRef>>,
+    /// 原始平台扩展字段。
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExternalConversationKind {
+    /// 1v1 会话。
+    Direct,
+    /// 多人会话或群聊。
+    Group,
+    /// 群内子群、topic、thread、临时议题空间。
+    Subgroup,
+    /// 邮件 thread、频道、工单等线程型会话。
+    Thread,
+    /// 平台升级带来的未知类型。旧系统必须保留并降级。
+    Unknown(String),
+}
+```
+
+### 5.2 外部消息和内容
+
+```rust
+/// 外部消息的标准中间形态，进入 MsgObject 前使用。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalMessage {
+    /// 平台和账号范围内的消息引用。
+    pub message_ref: ExternalMessageRef,
+    /// 发送者。可能是自然人、机器人、群系统账号或未知 actor。
+    pub sender: ExternalActorRef,
+    /// 所属会话。
+    pub conversation: ExternalConversationRef,
+    /// 可选目标。平台未显式给出时为空，由 conversation 决定。
+    pub targets: Vec<ExternalActorRef>,
+    /// 规范化内容片段。
+    pub parts: Vec<ExternalMessagePart>,
+    /// 引用、回复、转发等关系。
+    pub relations: Vec<ExternalMessageRelation>,
+    /// 外部平台时间。没有可靠时间时由 tunnel 接收时间补齐。
+    pub created_at_ms: u64,
+    /// 原始 payload 摘要或完整 JSON。大 payload 可只保存引用。
+    pub raw: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalMessageRef {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// tunnel 绑定的外部账号 ID。
+    pub tunnel_account_id: ExternalAccountId,
+    /// 外部会话 ID。
+    pub conversation_id: ExternalConversationId,
+    /// 外部消息 ID。
+    pub message_id: ExternalMessageId,
+    /// 平台 offset 或 sequence，用于顺序和恢复。
+    pub sequence: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExternalMessagePart {
+    /// 纯文本。
+    Text { text: String },
+    /// 富文本，format 可为 markdown、html、platform-specific。
+    RichText { format: String, body: String },
+    /// 表情、reaction、贴纸。
+    Symbol { kind: String, value: String },
+    /// @、mention、频道引用等特殊语义字符。
+    Mention {
+        raw: String,
+        target: Option<ExternalActorRef>,
+        meaning: MentionMeaning,
+    },
+    /// 附件或媒体。data_ref 可指向 NamedObject，也可先保存外部 URI。
+    Attachment {
+        name: Option<String>,
+        mime_type: Option<String>,
+        size: Option<u64>,
+        data_ref: AttachmentDataRef,
+    },
+    /// 平台可操作对象，例如红包、投票、小程序。
+    Interactive(ExternalInteractiveObject),
+    /// 平台升级带来的未知内容。
+    Unknown(UnknownExternalContent),
+}
+
+/// 未知外部内容片段。旧版本无法理解时至少应展示 fallback_text。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnknownExternalContent {
+    /// 平台原始内容类型。
+    pub content_kind: String,
+    /// 降级展示文本。
+    pub fallback_text: String,
+    /// 原始 payload 或引用。
+    pub raw: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MentionMeaning {
+    /// 普通提及人或机器人。
+    AddressActor,
+    /// 指令、slash command 或平台命令入口。
+    Command,
+    /// 频道、群、话题或外部资源引用。
+    Reference,
+    /// 未知语义，保留原始字符。
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AttachmentDataRef {
+    /// 已导入 BuckyOS NamedObject。
+    NamedObject { obj_id: ObjId, uri_hint: Option<String> },
+    /// 尚未导入，只保留外部下载地址或 file id。
+    External { uri: Option<String>, file_id: Option<String> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExternalMessageRelation {
+    ReplyTo(ExternalMessageRef),
+    Quote(ExternalMessageRef),
+    ForwardFrom(ExternalMessageRef),
+    EditOf(ExternalMessageRef),
+    DeleteOf(ExternalMessageRef),
+    ReactionTo(ExternalMessageRef),
+    Unknown { kind: String, payload: serde_json::Value },
+}
+```
+
+### 5.3 会话状态和可操作对象
+
+```rust
+/// 外部会话状态事件。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalConversationEvent {
+    /// 事件所属会话。
+    pub conversation: ExternalConversationRef,
+    /// 事件发起者。系统事件可为空。
+    pub actor: Option<ExternalActorRef>,
+    /// 事件类型。
+    pub kind: ExternalConversationEventKind,
+    /// 事件时间。
+    pub occurred_at_ms: u64,
+    /// 原始 payload。
+    pub raw: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExternalConversationEventKind {
+    MemberJoined { member: ExternalActorRef },
+    MemberLeft { member: ExternalActorRef },
+    MemberAdded { member: ExternalActorRef },
+    MemberRemoved { member: ExternalActorRef },
+    MemberOnline { member: ExternalActorRef },
+    MemberOffline { member: ExternalActorRef },
+    Muted { target: ExternalActorRef, until_ms: Option<u64> },
+    Blocked { target: ExternalActorRef },
+    PermissionChanged { target: ExternalActorRef, permission: String },
+    MessageRead { reader: ExternalActorRef, message: ExternalMessageRef },
+    MessageDelivered { target: ExternalActorRef, message: ExternalMessageRef },
+    Typing { actor: ExternalActorRef, active: bool },
+    TitleChanged { title: String },
+    Unknown { kind: String },
+}
+
+/// 第三方应用或平台可操作对象。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalInteractiveObject {
+    /// 对象类型，例如 "wechat.red_packet"、"lark.vote"。
+    pub object_type: String,
+    /// 展示文本。旧系统至少可显示它。
+    pub fallback_text: String,
+    /// 允许的操作。未知或无权操作时可为空。
+    pub actions: Vec<ExternalActionDescriptor>,
+    /// 原始 payload 或引用。
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalActionDescriptor {
+    /// 操作名，例如 "open"、"vote"、"claim"。
+    pub name: String,
+    /// 是否需要用户或 Agent 额外授权。
+    pub requires_authorization: bool,
+    /// 平台原始操作 payload。
+    pub payload: serde_json::Value,
+}
+```
+
+### 5.4 未知事件和归一化结果
+
+```rust
+/// 未知外部事件。必须可持久化、可审计、可被新版本重放分析。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnknownExternalEvent {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// tunnel 绑定的外部账号。
+    pub tunnel_account_id: ExternalAccountId,
+    /// 平台原始事件类型。
+    pub event_kind: String,
+    /// tunnel 观察到该事件的时间。
+    pub observed_at_ms: u64,
+    /// 降级展示文本。
+    pub fallback_text: String,
+    /// 原始 payload 或引用。
+    pub raw: serde_json::Value,
+}
+
+/// Tunnel 入站归一化后的结果。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizedIngress {
+    /// 原平台事件类型。
+    pub event_kind: String,
+    /// 可提交给 MsgCenter.dispatch 的消息对象。
+    pub msg: Option<MsgObject>,
+    /// 入站上下文，包含来源平台、外部会话、外部账号、contact owner 等。
+    pub ingress_ctx: IngressContext,
+    /// 入站幂等 key。
+    pub idempotency_key: String,
+    /// 不能直接表达成 MsgObject 的状态更新或审计记录。
+    pub side_effects: Vec<NormalizedIngressSideEffect>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum NormalizedIngressSideEffect {
+    /// 更新 UI session、typing、在线等临时状态。
+    UpdateSessionState { key: String, value: serde_json::Value },
+    /// 写入阅读、送达、处理等回执。
+    WriteReceipt { receipt: MsgReceiptObj },
+    /// 保存未知事件，供人工排查或新版本重放。
+    StoreUnknown { event: UnknownExternalEvent },
+}
+```
+
+### 5.5 Tunnel 配置、能力和健康状态
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TunnelAccountKind {
+    /// 平台机器人账号。通常受 Bot API 限制。
+    Bot,
+    /// 用户授权账号。能力接近自然人，但风险更高。
+    User,
+    /// BuckyOS 内部系统通道。
+    System,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelCapabilities {
+    /// 可读取外部消息。
+    pub ingress: bool,
+    /// 可发送外部消息。
+    pub egress: bool,
+    /// 可同步成员、加入退出、禁言、权限等会话状态。
+    pub conversation_state: bool,
+    /// 可同步已读、送达、失败等回执。
+    pub receipts: bool,
+    /// 可同步 typing、在线等临时状态。
+    pub ephemeral_state: bool,
+    /// 可导入或导出附件。
+    pub attachments: bool,
+    /// 可识别或操作平台特殊对象。
+    pub interactive_objects: bool,
+    /// 可主动加入会话。
+    pub join_conversation: bool,
+    /// 可向非来源会话发送消息。
+    pub cross_conversation_send: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageTunnelConfig {
+    /// BuckyOS 内部 tunnel DID。
+    pub tunnel_did: DID,
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// Bot/User/System。
+    pub account_kind: TunnelAccountKind,
+    /// tunnel 绑定的外部账号。
+    pub account_id: ExternalAccountId,
+    /// 是否启用入站。
+    pub ingress_enabled: bool,
+    /// 是否启用出站。
+    pub egress_enabled: bool,
+    /// ContactMgr owner scope。
+    pub contact_mgr_owner: Option<DID>,
+    /// 账号密钥、token、租户等配置引用。不得直接明文写入日志。
+    pub secret_refs: Vec<String>,
+    /// 平台特有配置。
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelHealthReport {
+    /// tunnel DID。
+    pub tunnel_did: DID,
+    /// 当前实例状态。
+    pub state: MsgTunnelInstanceState,
+    /// 最近一次入站 checkpoint。
+    pub ingress_checkpoint: Option<String>,
+    /// 最近一次成功出站时间。
+    pub last_egress_at_ms: Option<u64>,
+    /// 最近错误。
+    pub last_error: Option<String>,
+    /// 当前能力缺口或降级原因。
+    pub degraded_reasons: Vec<String>,
+    /// 更新时间。
+    pub updated_at_ms: u64,
+}
+```
+
+### 5.6 出站发送请求
+
+```rust
+/// 标准出站发送请求。具体平台 tunnel 再把它转成平台 SDK/API 请求。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalSendRequest {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// 发送账号。
+    pub sender_account_id: ExternalAccountId,
+    /// 目标会话或目标 actor。
+    pub target: ExternalSendTarget,
+    /// 内容片段。
+    pub parts: Vec<ExternalMessagePart>,
+    /// 是否替换、编辑或补全某条外部消息。
+    pub replace_message_id: Option<ExternalMessageId>,
+    /// 对应 MsgCenter record。
+    pub record_id: String,
+    /// 平台特有发送参数，例如 parse_mode、tenant_id、reply_to。
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExternalSendTarget {
+    /// 发送到外部会话。
+    Conversation(ExternalConversationRef),
+    /// 发送给单个外部参与者。
+    Actor(ExternalActorRef),
+}
+```
+
+## 6. 与 MsgObject 的映射
+
+### 6.1 基本映射
+
+入站 `ExternalMessage` 应映射为 `MsgObject`：
+
+- `MsgObject.from`：逻辑发送方 DID。若发送方无法映射 DID，可使用 ContactMgr 创建 shadow contact，或使用代表该外部 actor 的临时 DID。是否创建由策略决定。
+- `MsgObject.to`：目标 DID 列表。私聊通常是目标 Agent/User；群聊可指向 group DID 或订阅该会话的 Agent DID。
+- `MsgObject.kind`：普通私聊使用 `Chat`；群消息优先使用 `GroupMsg`；状态和可操作对象在现有类型不足时通过 `meta` 表达。
+- `MsgObject.content.content`：可读 fallback 文本。
+- `MsgObject.content.format`：文本格式，例如 `TextPlain`、`TextMarkdown`、`TextHtml`。
+- `MsgObject.content.refs`：附件、引用文件、外部资源导入后的 NamedObject 引用。
+- `MsgObject.content.machine`：结构化 machine-readable 内容，例如 mention、button、vote、red packet。
+- `MsgObject.meta`：平台 payload、外部 ID、会话 ID、未知字段、能力降级信息。
+- `MsgObject.thread`：会话、topic、reply thread 或 UI session 归类。
+
+### 6.2 不可丢失的信息
+
+以下信息必须保留在 `IngressContext`、`RouteInfo` 或 `msg.meta`：
+
+- platform。
+- tunnel DID。
+- tunnel account id。
+- external conversation id。
+- external message id。
+- external sender account id。
+- external sender display id/name。
+- source sequence/offset。
+- raw event kind。
+- attachment file id 或 NamedObject id。
+- unknown payload 引用或摘要。
+
+## 7. 入站流程
+
+### 7.1 自然语言流程
+
+Tunnel 启动后加载配置和 checkpoint，然后通过平台 API 接收事件。每个事件先被解析为 `TunnelIngressEvent`。已知消息转换为 `ExternalMessage`，状态变化转换为 `ExternalConversationEvent`，未知事件转换为 `UnknownExternalEvent`。
+
+Tunnel 接着按策略解析外部 actor 和 conversation。解析可以返回已有 DID、创建 shadow contact，也可以完全不映射 DID，只把外部 ID 放进上下文。然后构造 `MsgObject`、`IngressContext` 和幂等 key，调用 `MsgCenter.dispatch()`。
+
+只有当 `dispatch()` 成功或确认该事件已幂等处理后，Tunnel 才推进平台 checkpoint。这样进程崩溃时可能重复提交，但不会丢消息。
+
+### 7.2 流程图
+
+```mermaid
+flowchart TD
+    A[Load tunnel config and checkpoint] --> B[Receive external event]
+    B --> C{Event type known?}
+    C -- known message --> D[Build ExternalMessage]
+    C -- known state --> E[Build ExternalConversationEvent]
+    C -- unknown --> F[Build UnknownExternalEvent]
+    D --> G[Resolve optional DID mapping]
+    E --> G
+    F --> G
+    G --> H[Build MsgObject / state MsgObject]
+    H --> I[Build IngressContext]
+    I --> J[Build idempotency key]
+    J --> K[MsgCenter.dispatch]
+    K --> L{Dispatch accepted or duplicate?}
+    L -- yes --> M[Persist checkpoint]
+    L -- no --> N[Log and retry or quarantine]
+```
+
+### 7.3 入站关键方法
+
+```rust
+impl MessageTunnelRuntime {
+    /// 接收并处理一个平台事件。该方法必须幂等可重试。
+    pub async fn handle_external_event(
+        &self,
+        raw_event: serde_json::Value,
+    ) -> anyhow::Result<DispatchResult> {
+        let event = self.parse_event(raw_event).await?;
+        let normalized = self.normalize_ingress(event).await?;
+        let (msg, ingress_ctx, idempotency_key) = self.build_dispatch_request(normalized).await?;
+        let result = self.msg_center.dispatch(msg, Some(ingress_ctx), Some(idempotency_key)).await?;
+        self.commit_checkpoint_if_safe(&result).await?;
+        Ok(result)
+    }
+
+    /// 将外部事件解析为 tunnel 中间对象。
+    async fn parse_event(&self, raw: serde_json::Value) -> anyhow::Result<TunnelIngressEvent>;
+
+    /// 将中间对象转换成 BuckyOS 可 dispatch 的对象。
+    async fn normalize_ingress(&self, event: TunnelIngressEvent) -> anyhow::Result<NormalizedIngress>;
+
+    /// 生成 MsgCenter 入站请求。
+    async fn build_dispatch_request(
+        &self,
+        normalized: NormalizedIngress,
+    ) -> anyhow::Result<(MsgObject, IngressContext, String)>;
+}
+```
+
+## 8. 出站流程
+
+### 8.1 自然语言流程
+
+Agent、人类 UI 或系统服务生成响应后调用 `MsgCenter.post_send()`。Message Center 使用 ContactMgr 选择投递路径，创建 `TunnelOutbox` 记录。Tunnel 的发送循环从自己的 `TunnelOutbox` 拉取 `Wait` 记录，将 `MsgRecordWithObject` 转换为平台发送请求。
+
+发送成功后，Tunnel 通过 `MsgCenter.report_delivery()` 写入外部 message id、送达时间和状态。发送失败时，Tunnel 必须区分可重试失败和最终失败。可重试失败应保留原因和下次重试时间；最终失败进入 `Dead` 或等价状态，供 UI 和审计发现。
+
+### 8.2 流程图
+
+```mermaid
+flowchart TD
+    A[Agent/Human/Service creates reply] --> B[MsgCenter.post_send]
+    B --> C[Delivery plan by ContactMgr]
+    C --> D[TunnelOutbox record WAIT]
+    D --> E[Tunnel send loop get_next lock_on_take]
+    E --> F[Record state SENDING]
+    F --> G[Build ExternalSendRequest]
+    G --> H{Capability and route valid?}
+    H -- no --> I[report_delivery final failure]
+    H -- yes --> J[Call external IM API]
+    J --> K{Result}
+    K -- success --> L[report_delivery SENT with external_msg_id]
+    K -- retryable --> M[report_delivery WAIT/FAILED retry info]
+    K -- final failure --> N[report_delivery DEAD]
+```
+
+### 8.3 出站关键方法
+
+```rust
+impl MessageTunnelRuntime {
+    /// 持续消费当前 tunnel 的出站队列。
+    pub async fn run_send_loop(&self) -> anyhow::Result<()> {
+        loop {
+            let record = self.next_tunnel_outbox_record().await?;
+            if let Some(record) = record {
+                let result = self.send_record_to_platform(record.clone()).await;
+                self.report_delivery(record.record.record_id, result).await?;
+            } else {
+                self.wait_for_outbox_event_or_timeout().await;
+            }
+        }
+    }
+
+    /// 把 MsgCenter 记录转换成平台发送请求，并执行发送。
+    async fn send_record_to_platform(
+        &self,
+        record: MsgRecordWithObject,
+    ) -> anyhow::Result<DeliveryReportResult>;
+
+    /// 校验 route、账号绑定、平台能力和目标会话。
+    fn validate_egress_route(&self, record: &MsgRecordWithObject) -> anyhow::Result<()>;
+}
+```
+
+## 9. Agent 最大功能集
+
+理论上，如果 IM 平台对机器人没有任何限制，一个 Agent 作为 Message Tunnel 背后的账号，应能完成真实自然人在会话中可完成的一切行为：
+
+- 阅读私聊、群聊、子群、thread、频道和历史上下文。
+- 发送文本、富文本、表情、引用回复、附件、编辑、删除和 reaction。
+- 收发会话状态，例如加入、退出、成员变化、已读、typing、禁言和权限变化。
+- 处理平台特殊消息，例如红包、投票、小程序、审批卡片。
+- 在授权范围内加入或退出会话。
+- 在授权范围内给其他会话、其他人、Email、Lark 等渠道发送消息。
+- 使用被授予的工具，例如发送 email、访问 B 站关注列表、向 Lark 发送通知。
+- 记录行为日志，使一组机器人之间的对话和动作可观测、可追溯。
+
+如果某个平台限制 Bot API，例如不能读取某些群成员、不能主动私聊、不能操作红包，则该限制属于平台子类能力裁剪，不应收缩通用 Message Tunnel 的最大定义。
+
+## 10. 平台子类
+
+### 10.1 Telegram
+
+Telegram Tunnel 应区分：
+
+- `TelegramBotMsgTunnel`：使用 Bot API 或 bot session，受 Telegram 对 bot 的群、私聊、成员信息限制。
+- `TelegramUserMsgTunnel`：使用用户授权 session，能力更接近自然人，但需要更严格安全策略。
+
+能力关注点：
+
+- 私聊、群聊、频道、topic。
+- message_id、chat_id、sender id 可构成稳定幂等 key。
+- 附件需要下载并导入 NamedObject，或保留 file id。
+- Bot 通常不能主动给未开始对话的用户发消息。
+- parse mode、Markdown/HTML 转换需要平台专用处理。
+
+### 10.2 Lark
+
+Lark Tunnel 应区分：
+
+- `LarkBotMsgTunnel`：企业应用机器人，适合群消息、卡片、审批和通知。
+- `LarkUserMsgTunnel`：用户授权模式，适合代表用户操作，但权限范围更敏感。
+
+能力关注点：
+
+- open_id、union_id、chat_id、tenant_id 共同定义身份范围。
+- 富文本、卡片、按钮、审批、投票等可操作对象较多，应优先进入 `InteractiveObject`。
+- 企业权限和租户边界必须进入 `RouteInfo.extra` 或平台配置。
+- 机器人能否加入群、读取历史和私聊取决于应用权限。
+
+### 10.3 Email
+
+Email Tunnel 通常不是实时 IM，但仍是 Message Tunnel：
+
+- 入站通过 IMAP、SMTP webhook、邮件服务 API 或本地 maildir。
+- 会话模型是 thread。
+- actor 是 email address，可选映射 Contact DID。
+- 附件天然重要，应导入 NamedObject 或保留外部引用。
+- 出站需要处理 reply-to、cc、bcc、subject、message-id、in-reply-to。
+- 已读、typing、在线等临时状态通常不支持。
+
+### 10.4 MessageHub
+
+MessageHub 是 BuckyOS 内部或 Web UI 消息通道：
+
+- 大多数 actor 可直接解析 DID。
+- session id 是 UI 和 Agent 上下文的重要语义。
+- 它不一定需要外部平台账号映射，但仍应保留 tunnel、session、record id 以统一观测。
+- 可作为实现其他 tunnel 的参考基线。
+
+## 11. 消息顺序、去重和遗漏
+
+### 11.1 顺序性
+
+要求：
+
+- 同一外部会话内应尽量按平台 sequence 或时间顺序 dispatch。
+- 同一 tunnel 账号内的多个会话不要求全局顺序。
+- 如果平台只提供乱序 webhook，Tunnel 应保留 sequence 并允许 Message Center 或 UI 按 sort_key 重排。
+- 出站同一会话的响应应尽量串行发送，避免平台显示顺序反转。
+
+### 11.2 去重
+
+入站幂等 key 建议：
+
+```text
+{platform}:{tunnel_account_id}:{conversation_id}:{external_message_id}:{event_kind}
+```
+
+出站幂等依赖：
+
+- `MsgObject` 的对象 ID。
+- `MsgRecord.record_id`。
+- `post_send` 的 idempotency key。
+- 外部平台成功后的 `external_msg_id`。
+
+重复发送风险处理：
+
+- 如果发送请求超时但平台可能已发送成功，应优先查询外部 message id 或使用平台提供的 client token。
+- 如果平台不支持查询或 client token，只能按 `DeliveryInfo` 标记不确定状态，并避免无限重试。
+
+### 11.3 遗漏恢复
+
+Tunnel 必须持久化：
+
+- 入站 checkpoint 或 offset。
+- 已处理 idempotency key 缓存，至少覆盖平台可能重放窗口。
+- 出站 `TunnelOutbox` 状态由 Message Center 持久化。
+- 发送中崩溃后，`Sending` 状态需要租约恢复或重新置为 `Wait`。
+
+实时通知只是加速信号。任何消费者都必须能通过重新扫描 inbox/outbox 恢复。
+
+## 12. 兼容性和未来升级
+
+### 12.1 外部 IM 平台升级
+
+平台升级可能增加：
+
+- 新消息类型。
+- 新会话类型。
+- 新成员状态。
+- 新可操作对象。
+- 新权限或限制。
+- payload 字段类型变化。
+
+处理要求：
+
+- 未知 enum 使用 `Unknown(String)`。
+- 未知 payload 存入 `extra`、`raw` 或 `msg.meta.platform_payload`。
+- 生成 fallback 文本，例如 `[Unsupported Telegram story]`。
+- 记录 capability gap，不让 tunnel 崩溃。
+- 关键转换失败时进入 quarantine/request box，而不是丢弃。
+
+### 12.2 BuckyOS 新旧版本互通
+
+新版本可能写入旧版本不理解的数据。旧版本应：
+
+- 忽略未知字段。
+- 保留未知字段，避免读写后丢失。
+- 对未知消息内容展示 fallback text。
+- 对未知状态不执行危险操作。
+- 对未知投递 route 返回明确失败，不能误投递。
+
+### 12.3 数据损坏防护
+
+禁止以下行为：
+
+- 解析未知事件时 panic。
+- 因单条坏消息停止整个 tunnel。
+- 出站 route 缺失时猜测目标并发送。
+- 发送失败时静默删除 `TunnelOutbox` 记录。
+- 覆盖或丢弃原始外部 ID。
+
+## 13. 安全和授权
+
+Message Tunnel 是高风险边界，必须遵守：
+
+- 入站消息进入 inbox 前由 ContactMgr/策略决定是否进入 `Inbox`、`RequestBox` 或丢弃。
+- 出站消息必须有明确 route 和授权来源。
+- User tunnel 代表自然人操作，默认权限更高，必须有更严格审计和撤销机制。
+- Agent 使用工具发送跨会话消息、Email 或 Lark 通知时，应有可解释授权来源。
+- secret、token、session 文件不得写入普通日志。
+- 任何平台可操作对象默认不可自动执行，除非策略明确授权。
+
+## 14. 可观测性
+
+每条入站事件至少能追踪：
+
+- tunnel DID。
+- platform。
+- external account id。
+- external conversation id。
+- external message id。
+- idempotency key。
+- generated msg_id。
+- dispatch result。
+
+每条出站投递至少能追踪：
+
+- record_id。
+- msg_id。
+- route.tunnel_did。
+- route.platform。
+- route.chat_id/address。
+- attempts。
+- external_msg_id。
+- final state。
+- error_code/error_message。
+
+Agent 行为日志不属于 Message Tunnel 责任，但 Message Tunnel 需要提供足够关联 ID，让审计系统能把外部消息、Message Center record、Agent session、响应消息和外部投递串起来。
+
+## 15. 配置会话示例的解释
+
+用户在机器人配置会话窗口输入：
+
+```text
+你可以翻阅我在B站关注的主播，如果他们有内容更新就发EMAIL告诉我(email: xxx)
+你可以加入我Telegram的好友群，如果发现他们出去浪，通过Lark告诉我(ID: xxx)
+```
+
+这里涉及多个边界：
+
+- 配置会话本身通过某个 Message Tunnel 入站。
+- Agent 理解用户授权，生成工具授权或任务配置。
+- B 站更新检查不是 Message Tunnel，属于 Agent tool 或外部服务 connector。
+- Email 通知通过 `EmailMsgTunnel` 出站。
+- Telegram 好友群加入能力取决于 Telegram tunnel 类型和授权。
+- Lark 通知通过 `LarkBotMsgTunnel` 或 `LarkUserMsgTunnel` 出站。
+- 所有跨会话、跨平台发送都应留下授权来源、任务 ID、record_id 和投递结果。
+
+## 16. 典型端到端流程
+
+### 16.1 Telegram 群消息触发 Agent 回复
+
+```mermaid
+sequenceDiagram
+    participant TG as Telegram
+    participant T as TelegramBotMsgTunnel
+    participant MC as MsgCenter
+    participant A as Agent
+
+    TG->>T: group message
+    T->>T: normalize ExternalMessage
+    T->>MC: dispatch(MsgObject, IngressContext, idempotency_key)
+    MC->>A: Inbox/GroupInbox record available
+    A->>MC: get_next(owner, Inbox)
+    A->>A: process and generate reply
+    A->>MC: post_send(reply MsgObject, SendContext)
+    MC->>T: TunnelOutbox record
+    T->>TG: send message
+    T->>MC: report_delivery(record_id, SENT, external_msg_id)
+```
+
+### 16.2 Email 入站和 Lark 出站
+
+```mermaid
+sequenceDiagram
+    participant Mail as Email Server
+    participant ET as EmailMsgTunnel
+    participant MC as MsgCenter
+    participant A as Agent
+    participant LT as LarkMsgTunnel
+    participant Lark as Lark
+
+    Mail->>ET: new email in thread
+    ET->>MC: dispatch(email MsgObject)
+    MC->>A: RequestBox or Inbox
+    A->>MC: post_send(notification MsgObject, preferred_tunnel=Lark)
+    MC->>LT: TunnelOutbox
+    LT->>Lark: send card/text
+    LT->>MC: report_delivery
+```
+
+## 17. 实现入口建议
+
+当前仓库已有：
+
+- `src/frame/msg_center/src/msg_tunnel.rs`：`MsgTunnel` trait 和实例管理。
+- `src/frame/msg_center/src/tg_tunnel.rs`：Telegram tunnel 参考实现。
+- `src/frame/msg_center/src/msg_center.rs`：`dispatch`、`post_send`、`get_next`、`report_delivery` 等核心流程。
+- `src/kernel/buckyos-api/src/msg_center_client.rs`：共享 API 类型。
+- `src/frame/opendan/src/msg_center_pump.rs`：Agent 消费 MsgCenter inbox 的参考流程。
+
+后续实现应优先复用这些入口。新增平台 tunnel 应先实现现有 `MsgTunnel` trait，再在平台内部逐步补齐完整对象模型、能力声明和未知事件降级。
+
+## 18. 验收标准
+
+设计可接受的标准：
+
+- 能解释 Message Tunnel 和 MsgCenter、Agent、ContactMgr、GroupMgr 的边界。
+- 能表达 1v1、群聊、子群、thread 和机器人群聊。
+- 能表示文本、富文本、附件、mention、状态事件、可操作对象和未知消息。
+- 能明确外部 ID 何时只是字符串，何时才需要映射 DID。
+- 能支持 Bot/User 两类 tunnel 的能力裁剪。
+- 能覆盖入站、出站、幂等、顺序、重试、遗漏恢复。
+- 能在平台和 BuckyOS 升级时兼容未知字段和未知类型。
+- 能给 Telegram、Lark、Email、MessageHub 四类典型 tunnel 提供实现方向。

--- a/doc/message_hub/Message Tunnel Minimal Spec.md
+++ b/doc/message_hub/Message Tunnel Minimal Spec.md
@@ -1,256 +1,176 @@
 # Message Tunnel Minimal Spec
 
-本文是给 agent/codegen 使用的最小实现说明。详细设计见 `Message Tunnel Design.md`。
+本文是给 Agent/codegen 使用的最小实现规格。详细设计见 `Message Tunnel Design.md`。
 
 ## 1. 定义
 
-Message Tunnel 是外部 IM 系统和 BuckyOS Message Center 之间的双向适配通道。它代表 IM 系统中的一个特定账号或访问通道，负责：
+Message Tunnel 是外部 IM 系统与 BuckyOS MessageCenter 之间的会话级双向适配层。它代表某个平台上的一个特定账号或访问通道，负责：
 
-1. 从外部 IM 会话读取消息、会话状态和可操作事件。
-2. 将外部事件标准化为 BuckyOS `MsgObject`，附带 `IngressContext`，调用 `MsgCenter.dispatch()`。
-3. 从 `MsgCenter` 的 `TunnelOutbox` 拉取待投递 `MsgRecordWithObject`。
-4. 将标准消息反向转换为外部 IM 可接受的消息或操作，发送后调用 `MsgCenter.report_delivery()`。
+1. 从外部 IM 会话接收消息、会话状态和平台事件。
+2. 尽量保留外部 IM 原始语义，把可标准化内容转换为 BuckyOS `MsgObject`。
+3. 调用 MessageCenter `dispatch(msg, ingress_ctx)`，把入站消息交给目标 Agent、人操作的控制组件或其他系统组件。
+4. 从 MessageCenter 的 `TUNNEL_OUTBOX` 拉取响应消息。
+5. 按平台规则把响应投递回来源 IM 会话或指定外部目标。
+6. 调用 `report_delivery()` 回报外部消息 ID、成功、失败、重试和错误。
 
-Message Tunnel 不负责 Agent 如何思考、回复和保存响应。Agent 处理完消息后，应通过 `MsgCenter.post_send()` 创建出站投递任务。
+Message Tunnel 不负责 Agent 如何思考、如何保存响应、如何调用工具。Agent 生成响应后，应通过 MessageCenter `post_send(msg, send_ctx)` 或等价接口进入出站流程。
 
-## 2. 现有基础类型
+## 2. 边界
 
-以下类型已在 BuckyOS 中定义，本文只使用，不重新定义：
+Message Tunnel 必须做：
 
-- `DID`：BuckyOS 内部身份标识。
-- `ObjId`：NamedObject ID。
-- `MsgObject`：不可变消息对象，来自 `ndn_lib`。
-- `MsgContent`、`MsgContentFormat`：消息正文、附件引用和机器可读内容。
-- `MsgObjKind`：消息类型，例如 `Chat`、`GroupMsg` 等。
-- `BoxKind`：`Inbox`、`Outbox`、`GroupInbox`、`TunnelOutbox`、`RequestBox`。
-- `MsgState`：`Unread`、`Reading`、`Readed`、`Wait`、`Sending`、`Sent`、`Failed`、`Dead`、`Deleted`、`Archived`。
-- `IngressContext`、`SendContext`、`RouteInfo`、`DeliveryInfo`、`MsgRecord`、`MsgRecordWithObject`、`MsgReceiptObj`。
-- `MsgTunnel` trait 和 `MsgTunnelInstanceMgr`。
+- 平台连接、认证、收发消息。
+- 入站去重、顺序恢复、断点续拉。
+- 外部会话、用户、消息、附件、状态事件到标准 envelope 的转换。
+- 构造 `IngressContext`、`RouteInfo` 和 `DeliveryReportResult`。
+- 能力裁剪：机器人账号、自然人账号、Email、MessageHub 等平台能力不同，不能假装支持不存在的动作。
+- 审计日志：至少记录入站、出站、失败、重试、权限裁剪和未知消息降级。
 
-若实现需要升级上述基础类型，应先明确原因并单独提交协议变更文档。
+Message Tunnel 不应做：
 
-## 3. 新增或扩展概念
+- 不应绕过 MessageCenter 直接写 Agent 会话。
+- 不应要求所有外部账号强制映射为 BuckyOS DID。
+- 不应把平台私有字段扩散成 BuckyOS 基础类型。
+- 不应在无法理解新平台消息时宕机或损坏已有状态。
 
-### 3.1 外部引用
+## 3. 已有基础类型
 
-外部 IM 的账号、会话、消息 ID 默认保留为外部语义，不强制映射成 DID。只有当 BuckyOS 需要对它们做权限、路由、持久身份或群实体管理时，才通过 ContactMgr 或 GroupMgr 绑定到 DID。
+下面类型已经由 BuckyOS 或 NDN 层定义，实现时复用，不在本文重新定义：
 
-```rust
-/// 外部 IM 平台标识。建议使用稳定小写字符串，例如 "telegram"、"lark"、"email"、"messagehub"。
-pub type PlatformId = String;
+- `DID`
+- `ObjId`
+- `MsgObject`
+- `MsgContent`
+- `MsgObjKind`
+- `RefItem`
+- `BoxKind`
+- `MsgState`
+- `IngressContext`
+- `SendContext`
+- `RouteInfo`
+- `DeliveryInfo`
+- `MsgRecord`
+- `MsgRecordWithObject`
+- `DeliveryReportResult`
+- `MsgTunnel`
+- `MsgTunnelInstanceMgr`
 
-/// 外部 IM 账号 ID。它是平台语义下的字符串，不一定对应 BuckyOS DID。
-pub type ExternalAccountId = String;
+如果实现发现这些类型不能表达必要语义，先在详细设计文档中说明升级原因，再修改共享类型、前后端和文档。
 
-/// 外部 IM 会话 ID。可能是私聊、群聊、频道、邮件线程或应用内会话。
-pub type ExternalConversationId = String;
-
-/// 外部 IM 消息 ID。只在某个平台、账号、会话范围内有唯一性。
-pub type ExternalMessageId = String;
-
-/// 外部参与者引用。用于保留原平台语义，并为可选 DID 映射提供位置。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalActorRef {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// 平台账号 ID。
-    pub account_id: ExternalAccountId,
-    /// 可选显示名。
-    pub display_name: Option<String>,
-    /// 可选平台 handle，例如 Telegram username、Lark open_id、email address。
-    pub display_id: Option<String>,
-    /// 如果 ContactMgr 已经解析出内部身份，填入对应 DID。
-    pub mapped_did: Option<DID>,
-    /// 平台特有扩展字段。未知字段必须可保留。
-    pub extra: serde_json::Value,
-}
-
-/// 外部会话引用。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalConversationRef {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// 会话 ID。
-    pub conversation_id: ExternalConversationId,
-    /// 会话类型。
-    pub kind: ExternalConversationKind,
-    /// 可选内部群 DID 或会话 owner DID。
-    pub mapped_did: Option<DID>,
-    /// 原平台扩展字段。
-    pub extra: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ExternalConversationKind {
-    /// 1v1 会话。
-    Direct,
-    /// 多人会话或群聊。
-    Group,
-    /// 群聊里的子群、话题、线程或临时会话。
-    Subgroup,
-    /// 邮件 thread、频道、工单等不能归入上述类型的会话。
-    Thread,
-    /// 平台新增未知类型。必须降级保留，不得 panic。
-    Unknown(String),
-}
-```
-
-### 3.2 Tunnel 类型
+## 4. 核心对象
 
 ```rust
-/// Tunnel 代表的账号类型。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// 外部平台类型。`Custom` 用于新平台，避免因为未知平台导致反序列化失败。
+pub enum TunnelPlatform {
+    Telegram,
+    Lark,
+    Email,
+    MessageHub,
+    Custom(String),
+}
+
+/// 账号运行形态。不同平台对 bot 和 user 的 API 限制不同。
 pub enum TunnelAccountKind {
-    /// 平台机器人账号。受平台 Bot API 限制。
     Bot,
-    /// 自然人账号或用户授权账号。权限更接近真实用户。
     User,
-    /// 系统内置通道，例如 MessageHub。
     System,
 }
 
-/// Message Tunnel 的能力声明。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TunnelCapabilities {
-    /// 是否可读取外部消息。
-    pub ingress: bool,
-    /// 是否可发送外部消息。
-    pub egress: bool,
-    /// 是否可同步会话成员、加入退出、上线下线等状态。
-    pub conversation_state: bool,
-    /// 是否支持消息已读、送达、失败等回执。
-    pub receipts: bool,
-    /// 是否支持 typing、在线状态等临时状态。
-    pub ephemeral_state: bool,
-    /// 是否支持附件上传下载。
-    pub attachments: bool,
-    /// 是否支持外部平台的特殊可操作消息，例如红包、投票、小程序。
-    pub interactive_objects: bool,
-    /// 是否允许主动加入会话。
-    pub join_conversation: bool,
-    /// 是否允许向非当前来源会话发送消息。
-    pub cross_conversation_send: bool,
-}
-```
-
-### 3.3 标准化事件
-
-Tunnel 应把外部输入统一降级为以下事件之一，再转换为 `MsgObject` 或状态更新：
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum TunnelIngressEvent {
-    /// 普通消息、富文本、引用消息、附件消息、表情等。
-    Message(ExternalMessage),
-    /// 会话成员、标题、权限、禁言、上线、已读、typing 等状态变化。
-    ConversationState(ExternalConversationEvent),
-    /// 平台特殊可操作对象，例如红包、小程序、投票。
-    InteractiveObject(ExternalInteractiveObject),
-    /// 平台升级后出现的未知事件。必须持久记录并可审计。
-    Unknown(UnknownExternalEvent),
-}
-```
-
-```rust
-/// 归一化后的入站结果。Tunnel 最终应把它转成 MsgObject 或状态更新。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NormalizedIngress {
-    /// 原平台事件类型。
-    pub event_kind: String,
-    /// 可 dispatch 的消息对象。状态事件也可降级为 MsgObject。
-    pub msg: Option<MsgObject>,
-    /// 入站上下文，必须包含可用于回信和审计的外部来源信息。
-    pub ingress_ctx: IngressContext,
-    /// 幂等 key。
-    pub idempotency_key: String,
-    /// 不能表达为 MsgObject 的状态更新或内部操作。
-    pub side_effects: Vec<NormalizedIngressSideEffect>,
+/// 单个 tunnel 实例的能力声明。MessageCenter 和 UI 只能使用这里声明为 true 的能力。
+pub struct TunnelCapability {
+    pub ingress: bool,             // 是否能接收入站消息。
+    pub egress: bool,              // 是否能发送出站消息。
+    pub edit_message: bool,        // 是否能编辑已发消息。
+    pub delete_message: bool,      // 是否能删除或撤回消息。
+    pub reaction: bool,            // 是否支持 reaction。
+    pub read_receipt: bool,        // 是否能读取或发送已读状态。
+    pub typing: bool,              // 是否能读取或发送正在输入。
+    pub group_chat: bool,          // 是否支持群聊。
+    pub sub_conversation: bool,    // 是否支持 thread、topic、群内临时议题。
+    pub attachments: bool,         // 是否支持附件入站/出站。
+    pub interactive_message: bool, // 是否支持红包、投票、小程序等可操作消息。
+    pub streaming: bool,           // 是否支持 AI 流式输出或平台流式更新。
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum NormalizedIngressSideEffect {
-    /// 更新 UI session、typing、在线等临时状态。
-    UpdateSessionState { key: String, value: serde_json::Value },
-    /// 写入阅读或处理回执。
-    WriteReceipt { receipt: MsgReceiptObj },
-    /// 记录未知事件，供人工或新版本重放分析。
-    StoreUnknown { event: UnknownExternalEvent },
+/// 外部账号引用。它保持平台原始语义，不强制映射为 DID。
+pub struct ExternalAccountRef {
+    pub platform: TunnelPlatform,
+    pub account_id: String,        // 平台账号 ID、邮箱地址或 MessageHub entity key。
+    pub display_id: Option<String>,
+    pub display_name: Option<String>,
+    pub account_kind: Option<TunnelAccountKind>,
 }
 
-/// 未知外部事件。必须可持久化、可审计、可被新版本重放。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UnknownExternalEvent {
-    pub platform: PlatformId,
-    pub tunnel_account_id: ExternalAccountId,
-    pub event_kind: String,
-    pub observed_at_ms: u64,
-    pub fallback_text: String,
-    pub raw: serde_json::Value,
+/// 外部会话引用。它是平台侧概念，不要求在 BuckyOS 中存在对应对象。
+pub struct ExternalConversationRef {
+    pub platform: TunnelPlatform,
+    pub conversation_id: String,       // chat_id、channel_id、thread id、mailbox/thread id 等。
+    pub parent_conversation_id: Option<String>,
+    pub conversation_kind: ExternalConversationKind,
+    pub title: Option<String>,
 }
 
-/// 未知外部内容片段。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UnknownExternalContent {
-    pub content_kind: String,
-    pub fallback_text: String,
-    pub raw: serde_json::Value,
+pub enum ExternalConversationKind {
+    Direct,
+    Group,
+    SubConversation,
+    Channel,
+    EmailThread,
+    System,
+    Unknown(String),
 }
-```
 
-未知事件处理原则：保留原始 payload、记录能力缺口、尽量生成可读通知或 `MsgContent.machine`，不能导致 tunnel 或 MsgCenter 崩溃。
-
-## 4. 核心接口形状
-
-现有 `MsgTunnel` trait 是最小运行接口。理论完整实现可在具体 tunnel 内部补齐以下逻辑，不要求一次性改公共 trait：
-
-```rust
-#[async_trait]
-pub trait FullMessageTunnel: MsgTunnel {
-    /// 返回账号类型和能力声明。
-    fn account_kind(&self) -> TunnelAccountKind;
-    fn capabilities(&self) -> TunnelCapabilities;
-
-    /// 将外部事件转换为 BuckyOS 标准对象或状态操作。
-    async fn normalize_ingress(
-        &self,
-        event: TunnelIngressEvent,
-    ) -> anyhow::Result<NormalizedIngress>;
-
-    /// 将 MsgCenter 出站记录转换为外部平台发送请求。
-    async fn build_egress(
-        &self,
-        record: MsgRecordWithObject,
-    ) -> anyhow::Result<ExternalSendRequest>;
-
-    /// 上报健康状态、offset、最近错误和能力缺口。
-    async fn health_report(&self) -> anyhow::Result<TunnelHealthReport>;
+/// 入站事件标准 envelope。具体 tunnel 先构造它，再转换为 MsgObject 或状态更新。
+pub struct TunnelIngressEvent {
+    pub event_id: String,              // 平台事件唯一 ID；没有时由 tunnel 派生。
+    pub tunnel_did: DID,
+    pub platform: TunnelPlatform,
+    pub account: ExternalAccountRef,   // tunnel 使用的本方平台账号。
+    pub conversation: ExternalConversationRef,
+    pub sender: ExternalAccountRef,
+    pub occurred_at_ms: u64,
+    pub payload: TunnelPayload,
+    pub raw: serde_json::Value,        // 原始平台数据，尽量保留但不进入核心业务判断。
 }
-```
 
-```rust
-/// 标准出站发送请求。具体平台 tunnel 再转成平台 SDK/API 的请求。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSendRequest {
-    /// 平台 ID。
-    pub platform: PlatformId,
-    /// 发送账号。
-    pub sender_account_id: ExternalAccountId,
-    /// 目标会话或目标 actor。
-    pub target: ExternalSendTarget,
-    /// 内容片段。
-    pub parts: Vec<ExternalMessagePart>,
-    /// 是否替换或编辑某条外部消息。
-    pub replace_message_id: Option<ExternalMessageId>,
-    /// 原 MsgCenter record，用于投递回报。
-    pub record_id: String,
-    /// 平台特有发送参数。
+pub enum TunnelPayload {
+    Message(TunnelMessage),
+    ConversationEvent(TunnelConversationEvent),
+    MessageState(TunnelMessageStateEvent),
+    CapabilityEvent(TunnelCapabilityEvent),
+    Unknown(serde_json::Value),
+}
+
+pub struct TunnelMessage {
+    pub external_message_id: String,
+    pub kind: TunnelMessageKind,
+    pub parts: Vec<TunnelMessagePart>,
+    pub reply_to: Option<String>,
+    pub mentions: Vec<TunnelMention>,
+    pub stream: Option<TunnelStreamInfo>,
     pub extra: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ExternalSendTarget {
-    Conversation(ExternalConversationRef),
-    Actor(ExternalActorRef),
+pub enum TunnelMessageKind {
+    Text,
+    RichText,
+    Media,
+    Attachment,
+    Reaction,
+    Interactive,
+    AppDependent,
+    AiStreamDelta,
+    AiStreamComplete,
+    Unknown(String),
+}
+
+pub enum TunnelMessagePart {
+    Text { text: String },
+    RichText { format: String, content: String },
+    Emoji { code: String, text: Option<String> },
+    Attachment { object_ref: Option<ObjId>, uri_hint: Option<String>, name: Option<String>, mime: Option<String>, size: Option<u64> },
+    PlatformObject { object_type: String, payload: serde_json::Value },
+    Unknown { payload: serde_json::Value },
 }
 ```
 
@@ -258,95 +178,110 @@ pub enum ExternalSendTarget {
 
 ```mermaid
 flowchart TD
-    A[External IM session] --> B[Message Tunnel receive loop]
-    B --> C{Known event type?}
-    C -- yes --> D[Normalize to MsgObject or state event]
-    C -- no --> E[Store UnknownExternalEvent]
-    E --> D
-    D --> F[Resolve optional DID via ContactMgr or GroupMgr]
-    F --> G[Build IngressContext and idempotency_key]
-    G --> H[MsgCenter.dispatch]
-    H --> I[Inbox / GroupInbox / RequestBox records]
-    I --> J[Agent or human UI consumes]
+    A[External IM event] --> B[Tunnel receive loop]
+    B --> C[Build TunnelIngressEvent]
+    C --> D{Duplicate event?}
+    D -- yes --> Z[ack or skip]
+    D -- no --> E{Payload type}
+    E -- message --> F[Normalize to MsgObject]
+    E -- conversation state --> G[Map to notify/event MsgObject or UI session state]
+    E -- unknown --> H[Quarantine or Unknown message]
+    F --> I[Build IngressContext]
+    G --> I
+    H --> I
+    I --> J[MessageCenter.dispatch]
+    J --> K[Persist ingress checkpoint and audit]
 ```
 
-入站幂等 key 建议：
+实现要点：
 
-```text
-{platform}:{tunnel_account_id}:{conversation_id}:{external_message_id}:{event_kind}
-```
-
-如果平台没有稳定 message id，应使用平台 offset、时间戳、发送方、内容摘要组合，并把可靠性标记为 `best_effort`。
+- `event_id` 用于 tunnel 自己去重；`MsgObject` 自身仍由 canonical object id 保证语义幂等。
+- `IngressContext.extra` 保存平台必要上下文，如原始 chat_id、message_id、thread_id、sender account、bot account、平台能力版本。
+- 外部发送者没有 DID 时，不要伪造 DID。可用 ContactMgr 自动推断联系人，或仅把外部账号放入 `RouteInfo`/metadata。
+- 未知消息转换为 `MsgObjKind::Event` 或 `MsgObjKind::Notify`，内容里说明不支持的类型，原始数据放 `extra`，避免丢失。
 
 ## 6. 出站流程
 
 ```mermaid
 flowchart TD
-    A[Agent / Human / Service] --> B[MsgCenter.post_send]
-    B --> C[ContactMgr plan delivery]
-    C --> D[TunnelOutbox MsgRecord]
-    D --> E[Message Tunnel send loop]
-    E --> F[Build external send request]
-    F --> G[External IM API]
-    G --> H{Send result}
-    H -- success --> I[MsgCenter.report_delivery SENT]
-    H -- retryable failure --> J[report_delivery WAIT or FAILED with retry]
-    H -- final failure --> K[report_delivery DEAD]
+    A[Agent/User/System] --> B[MessageCenter.post_send]
+    B --> C[Create owner OUTBOX]
+    C --> D[Create TUNNEL_OUTBOX]
+    D --> E[Tunnel egress worker get_next]
+    E --> F[Resolve RouteInfo]
+    F --> G[Render platform message]
+    G --> H{Platform send ok?}
+    H -- yes --> I[report_delivery ok with external_msg_id]
+    H -- retryable failure --> J[report_delivery retryable]
+    H -- final failure --> K[report_delivery failed/dead]
 ```
 
-出站投递必须通过 `record.route` 指定平台、tunnel、账号、会话地址和目标 DID。发送成功后，必须把外部 message id 写入 `DeliveryInfo.external_msg_id` 或 `RouteInfo.ext_ids`。
+实现要点：
 
-## 7. 会话语义
+- 出站必须从 `MsgRecord.route` 读取 `tunnel_did/platform/account_id/chat_id/address/ext_ids`。
+- 缺少必要路由信息时返回明确失败，不静默丢弃。
+- 平台不支持的功能要降级：富文本可降为纯文本，附件可降为链接，交互消息可降为说明文本。
+- 流式响应可以使用平台支持的编辑消息、typing/status 或多条 delta 消息；不支持流式的平台只发送最终消息。
 
-会话最小支持：
+## 7. 标准映射
 
-- `Direct`：1v1。
-- `Group`：多人会话，成员可以是自然人、Agent、机器人。
-- `Subgroup`：群内临时议题、thread、topic、子群。
-- `Thread`：Email thread、MessageHub session、工单类上下文。
+| 外部语义 | BuckyOS 表达 |
+|---|---|
+| 普通文本/富文本/表情 | `MsgObject.kind=chat`，`MsgContent.format/content`，必要时保留 `extra` |
+| 附件/图片/文件 | `MsgContent.refs` 指向对象；无法导入时保留平台 URI hint |
+| 回复/引用 | `MsgObject.thread.reply_to` 或 `thread.correlation_id` |
+| @mention | `content.machine.data.mentions` 或 `meta.mentions`，保留原始平台符号 |
+| 新成员、退群、禁言、屏蔽、授权 | `MsgObjKind::Event` 或 `Notify` |
+| 已读、正在输入、消息状态 | 优先写 `MsgReceiptObj` 或 `ui_session_states`；也可转成状态通知 |
+| 红包、投票、小程序等可操作消息 | `TunnelMessageKind::Interactive/AppDependent`，能执行才映射成 operation，否则降级展示 |
+| AI stream delta | 平台支持时编辑/流式发送；BuckyOS 内部用 session state 或增量消息表达 |
 
-会话 ID 优先保留外部 ID；只有系统内需要长期管理成员、权限、展示或跨平台路由时，才创建或绑定 BuckyOS DID。
-
-## 8. 消息内容语义
-
-Tunnel 必须尽量映射以下内容：
-
-- 文本、富文本、符号、表情、引用、回复、转发。
-- 附件，优先保存为 `MsgContent.refs` 指向 NamedObject 或外部 URI hint。
-- @、slash command、mention 等特殊字符，保留原文，同时在 `MsgContent.machine` 或 `msg.meta` 中提供结构化 mention。
-- 会话状态事件，映射为 `MsgObjKind` 状态消息或 `msg.meta.machine_event`。
-- 可操作消息和第三方应用消息，映射为 `MsgContent.machine`，原始 payload 放入 `msg.meta.platform_payload`。
-- 未知内容，映射为 `Unknown`，保留原始 payload 和降级展示文本。
-
-## 9. 平台子类
-
-每个平台应有两个方向的能力裁剪：
+## 8. 典型 Tunnel 子类
 
 ```rust
-pub struct TelegramBotMsgTunnel;
-pub struct TelegramUserMsgTunnel;
-pub struct LarkBotMsgTunnel;
-pub struct LarkUserMsgTunnel;
+pub trait MessageTunnel: Send + Sync {
+    fn tunnel_did(&self) -> DID;
+    fn platform(&self) -> TunnelPlatform;
+    fn account_kind(&self) -> TunnelAccountKind;
+    fn capability(&self) -> TunnelCapability;
+
+    async fn start(&self) -> anyhow::Result<()>;
+    async fn stop(&self) -> anyhow::Result<()>;
+
+    async fn pull_or_receive(&self) -> anyhow::Result<Vec<TunnelIngressEvent>>;
+    async fn handle_ingress(&self, event: TunnelIngressEvent) -> anyhow::Result<()>;
+    async fn send_record(&self, record: MsgRecordWithObject) -> anyhow::Result<DeliveryReportResult>;
+}
+
+pub struct BotMsgTunnel<T> { pub inner: T }
+pub struct UserMsgTunnel<T> { pub inner: T }
+
+pub struct TelegramMsgTunnel;
+pub struct LarkMsgTunnel;
 pub struct EmailMsgTunnel;
 pub struct MessageHubTunnel;
 ```
 
-如果平台限制机器人行为，限制应体现在该子类的 `TunnelCapabilities` 和发送前校验中，不应污染通用 Message Tunnel 定义。
+子类要求：
 
-## 10. 可靠性要求
+- Telegram：区分 Bot API 和 User API 能力；群聊、reply、附件、typing、编辑消息能力由实际 gateway 声明。
+- Lark：优先保留 tenant、open_id、chat_id、message_id、卡片消息；企业权限限制必须显式失败。
+- Email：按 mailbox/thread/message-id 工作；没有在线状态、typing、已读实时语义；出站要支持纯文本/HTML/附件。
+- MessageHub：BuckyOS 原生 tunnel，可直接使用 DID/MsgObject，主要用于跨 Zone 或内部会话桥接。
 
-- 入站 offset/checkpoint 必须持久化。进程重启后从最后确认点恢复。
-- 入站和出站都必须幂等。
-- 发送前必须把任务持久化到 `TunnelOutbox`，发送后必须回报投递结果。
-- 同一会话内应尽量保持平台顺序；跨会话不要求全局顺序。
-- 对未知字段、未知 enum、未知内容类型使用兼容降级，不能 panic。
-- 新版本写入的数据被旧版本读取时，旧版本应保留未知字段或降级为 `Unknown`。
+## 9. 兼容性规则
 
-## 11. 观测性要求
+- 所有 enum 必须保留 `Unknown(String)` 或 `Custom(String)`。
+- 所有平台原始 payload 必须作为可选 `extra/raw` 保存，不能成为核心逻辑必需字段。
+- 新字段只能 additive；旧实现看到未知字段应忽略、保留或降级展示。
+- 无法识别的新消息类型进入 quarantine/request box/notify，不得导致进程崩溃。
+- 发送失败要可观察：`DeliveryReportResult` 必须包含错误码或错误文本。
 
-每个 tunnel 至少记录：
+## 10. 最小验收
 
-- `tunnel_did`、platform、account kind、capabilities。
-- 入站事件 ID、幂等 key、转换结果、dispatch 结果。
-- 出站 record_id、目标 route、外部 message id、重试次数、失败原因。
-- Agent 读取和回复消息不由 Message Tunnel 执行，但 tunnel 需要能串联 record_id、msg_id、external ids 供审计。
+- 能从一个外部会话收消息并 `dispatch` 到目标 Agent。
+- Agent 通过 MessageCenter 生成回复后，tunnel 能从 `TUNNEL_OUTBOX` 投递回来源会话。
+- 重复入站事件不会产生重复用户可见消息。
+- 出站重试不会重复发送已成功消息。
+- 平台未知消息能被保留或降级，不会丢状态或宕机。
+- 日志能追踪一次消息从平台入站到 Agent，再从 Agent 出站到平台的完整链路。

--- a/doc/message_hub/Message Tunnel Minimal Spec.md
+++ b/doc/message_hub/Message Tunnel Minimal Spec.md
@@ -1,0 +1,352 @@
+# Message Tunnel Minimal Spec
+
+本文是给 agent/codegen 使用的最小实现说明。详细设计见 `Message Tunnel Design.md`。
+
+## 1. 定义
+
+Message Tunnel 是外部 IM 系统和 BuckyOS Message Center 之间的双向适配通道。它代表 IM 系统中的一个特定账号或访问通道，负责：
+
+1. 从外部 IM 会话读取消息、会话状态和可操作事件。
+2. 将外部事件标准化为 BuckyOS `MsgObject`，附带 `IngressContext`，调用 `MsgCenter.dispatch()`。
+3. 从 `MsgCenter` 的 `TunnelOutbox` 拉取待投递 `MsgRecordWithObject`。
+4. 将标准消息反向转换为外部 IM 可接受的消息或操作，发送后调用 `MsgCenter.report_delivery()`。
+
+Message Tunnel 不负责 Agent 如何思考、回复和保存响应。Agent 处理完消息后，应通过 `MsgCenter.post_send()` 创建出站投递任务。
+
+## 2. 现有基础类型
+
+以下类型已在 BuckyOS 中定义，本文只使用，不重新定义：
+
+- `DID`：BuckyOS 内部身份标识。
+- `ObjId`：NamedObject ID。
+- `MsgObject`：不可变消息对象，来自 `ndn_lib`。
+- `MsgContent`、`MsgContentFormat`：消息正文、附件引用和机器可读内容。
+- `MsgObjKind`：消息类型，例如 `Chat`、`GroupMsg` 等。
+- `BoxKind`：`Inbox`、`Outbox`、`GroupInbox`、`TunnelOutbox`、`RequestBox`。
+- `MsgState`：`Unread`、`Reading`、`Readed`、`Wait`、`Sending`、`Sent`、`Failed`、`Dead`、`Deleted`、`Archived`。
+- `IngressContext`、`SendContext`、`RouteInfo`、`DeliveryInfo`、`MsgRecord`、`MsgRecordWithObject`、`MsgReceiptObj`。
+- `MsgTunnel` trait 和 `MsgTunnelInstanceMgr`。
+
+若实现需要升级上述基础类型，应先明确原因并单独提交协议变更文档。
+
+## 3. 新增或扩展概念
+
+### 3.1 外部引用
+
+外部 IM 的账号、会话、消息 ID 默认保留为外部语义，不强制映射成 DID。只有当 BuckyOS 需要对它们做权限、路由、持久身份或群实体管理时，才通过 ContactMgr 或 GroupMgr 绑定到 DID。
+
+```rust
+/// 外部 IM 平台标识。建议使用稳定小写字符串，例如 "telegram"、"lark"、"email"、"messagehub"。
+pub type PlatformId = String;
+
+/// 外部 IM 账号 ID。它是平台语义下的字符串，不一定对应 BuckyOS DID。
+pub type ExternalAccountId = String;
+
+/// 外部 IM 会话 ID。可能是私聊、群聊、频道、邮件线程或应用内会话。
+pub type ExternalConversationId = String;
+
+/// 外部 IM 消息 ID。只在某个平台、账号、会话范围内有唯一性。
+pub type ExternalMessageId = String;
+
+/// 外部参与者引用。用于保留原平台语义，并为可选 DID 映射提供位置。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalActorRef {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// 平台账号 ID。
+    pub account_id: ExternalAccountId,
+    /// 可选显示名。
+    pub display_name: Option<String>,
+    /// 可选平台 handle，例如 Telegram username、Lark open_id、email address。
+    pub display_id: Option<String>,
+    /// 如果 ContactMgr 已经解析出内部身份，填入对应 DID。
+    pub mapped_did: Option<DID>,
+    /// 平台特有扩展字段。未知字段必须可保留。
+    pub extra: serde_json::Value,
+}
+
+/// 外部会话引用。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalConversationRef {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// 会话 ID。
+    pub conversation_id: ExternalConversationId,
+    /// 会话类型。
+    pub kind: ExternalConversationKind,
+    /// 可选内部群 DID 或会话 owner DID。
+    pub mapped_did: Option<DID>,
+    /// 原平台扩展字段。
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExternalConversationKind {
+    /// 1v1 会话。
+    Direct,
+    /// 多人会话或群聊。
+    Group,
+    /// 群聊里的子群、话题、线程或临时会话。
+    Subgroup,
+    /// 邮件 thread、频道、工单等不能归入上述类型的会话。
+    Thread,
+    /// 平台新增未知类型。必须降级保留，不得 panic。
+    Unknown(String),
+}
+```
+
+### 3.2 Tunnel 类型
+
+```rust
+/// Tunnel 代表的账号类型。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TunnelAccountKind {
+    /// 平台机器人账号。受平台 Bot API 限制。
+    Bot,
+    /// 自然人账号或用户授权账号。权限更接近真实用户。
+    User,
+    /// 系统内置通道，例如 MessageHub。
+    System,
+}
+
+/// Message Tunnel 的能力声明。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelCapabilities {
+    /// 是否可读取外部消息。
+    pub ingress: bool,
+    /// 是否可发送外部消息。
+    pub egress: bool,
+    /// 是否可同步会话成员、加入退出、上线下线等状态。
+    pub conversation_state: bool,
+    /// 是否支持消息已读、送达、失败等回执。
+    pub receipts: bool,
+    /// 是否支持 typing、在线状态等临时状态。
+    pub ephemeral_state: bool,
+    /// 是否支持附件上传下载。
+    pub attachments: bool,
+    /// 是否支持外部平台的特殊可操作消息，例如红包、投票、小程序。
+    pub interactive_objects: bool,
+    /// 是否允许主动加入会话。
+    pub join_conversation: bool,
+    /// 是否允许向非当前来源会话发送消息。
+    pub cross_conversation_send: bool,
+}
+```
+
+### 3.3 标准化事件
+
+Tunnel 应把外部输入统一降级为以下事件之一，再转换为 `MsgObject` 或状态更新：
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TunnelIngressEvent {
+    /// 普通消息、富文本、引用消息、附件消息、表情等。
+    Message(ExternalMessage),
+    /// 会话成员、标题、权限、禁言、上线、已读、typing 等状态变化。
+    ConversationState(ExternalConversationEvent),
+    /// 平台特殊可操作对象，例如红包、小程序、投票。
+    InteractiveObject(ExternalInteractiveObject),
+    /// 平台升级后出现的未知事件。必须持久记录并可审计。
+    Unknown(UnknownExternalEvent),
+}
+```
+
+```rust
+/// 归一化后的入站结果。Tunnel 最终应把它转成 MsgObject 或状态更新。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizedIngress {
+    /// 原平台事件类型。
+    pub event_kind: String,
+    /// 可 dispatch 的消息对象。状态事件也可降级为 MsgObject。
+    pub msg: Option<MsgObject>,
+    /// 入站上下文，必须包含可用于回信和审计的外部来源信息。
+    pub ingress_ctx: IngressContext,
+    /// 幂等 key。
+    pub idempotency_key: String,
+    /// 不能表达为 MsgObject 的状态更新或内部操作。
+    pub side_effects: Vec<NormalizedIngressSideEffect>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum NormalizedIngressSideEffect {
+    /// 更新 UI session、typing、在线等临时状态。
+    UpdateSessionState { key: String, value: serde_json::Value },
+    /// 写入阅读或处理回执。
+    WriteReceipt { receipt: MsgReceiptObj },
+    /// 记录未知事件，供人工或新版本重放分析。
+    StoreUnknown { event: UnknownExternalEvent },
+}
+
+/// 未知外部事件。必须可持久化、可审计、可被新版本重放。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnknownExternalEvent {
+    pub platform: PlatformId,
+    pub tunnel_account_id: ExternalAccountId,
+    pub event_kind: String,
+    pub observed_at_ms: u64,
+    pub fallback_text: String,
+    pub raw: serde_json::Value,
+}
+
+/// 未知外部内容片段。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnknownExternalContent {
+    pub content_kind: String,
+    pub fallback_text: String,
+    pub raw: serde_json::Value,
+}
+```
+
+未知事件处理原则：保留原始 payload、记录能力缺口、尽量生成可读通知或 `MsgContent.machine`，不能导致 tunnel 或 MsgCenter 崩溃。
+
+## 4. 核心接口形状
+
+现有 `MsgTunnel` trait 是最小运行接口。理论完整实现可在具体 tunnel 内部补齐以下逻辑，不要求一次性改公共 trait：
+
+```rust
+#[async_trait]
+pub trait FullMessageTunnel: MsgTunnel {
+    /// 返回账号类型和能力声明。
+    fn account_kind(&self) -> TunnelAccountKind;
+    fn capabilities(&self) -> TunnelCapabilities;
+
+    /// 将外部事件转换为 BuckyOS 标准对象或状态操作。
+    async fn normalize_ingress(
+        &self,
+        event: TunnelIngressEvent,
+    ) -> anyhow::Result<NormalizedIngress>;
+
+    /// 将 MsgCenter 出站记录转换为外部平台发送请求。
+    async fn build_egress(
+        &self,
+        record: MsgRecordWithObject,
+    ) -> anyhow::Result<ExternalSendRequest>;
+
+    /// 上报健康状态、offset、最近错误和能力缺口。
+    async fn health_report(&self) -> anyhow::Result<TunnelHealthReport>;
+}
+```
+
+```rust
+/// 标准出站发送请求。具体平台 tunnel 再转成平台 SDK/API 的请求。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalSendRequest {
+    /// 平台 ID。
+    pub platform: PlatformId,
+    /// 发送账号。
+    pub sender_account_id: ExternalAccountId,
+    /// 目标会话或目标 actor。
+    pub target: ExternalSendTarget,
+    /// 内容片段。
+    pub parts: Vec<ExternalMessagePart>,
+    /// 是否替换或编辑某条外部消息。
+    pub replace_message_id: Option<ExternalMessageId>,
+    /// 原 MsgCenter record，用于投递回报。
+    pub record_id: String,
+    /// 平台特有发送参数。
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ExternalSendTarget {
+    Conversation(ExternalConversationRef),
+    Actor(ExternalActorRef),
+}
+```
+
+## 5. 入站流程
+
+```mermaid
+flowchart TD
+    A[External IM session] --> B[Message Tunnel receive loop]
+    B --> C{Known event type?}
+    C -- yes --> D[Normalize to MsgObject or state event]
+    C -- no --> E[Store UnknownExternalEvent]
+    E --> D
+    D --> F[Resolve optional DID via ContactMgr or GroupMgr]
+    F --> G[Build IngressContext and idempotency_key]
+    G --> H[MsgCenter.dispatch]
+    H --> I[Inbox / GroupInbox / RequestBox records]
+    I --> J[Agent or human UI consumes]
+```
+
+入站幂等 key 建议：
+
+```text
+{platform}:{tunnel_account_id}:{conversation_id}:{external_message_id}:{event_kind}
+```
+
+如果平台没有稳定 message id，应使用平台 offset、时间戳、发送方、内容摘要组合，并把可靠性标记为 `best_effort`。
+
+## 6. 出站流程
+
+```mermaid
+flowchart TD
+    A[Agent / Human / Service] --> B[MsgCenter.post_send]
+    B --> C[ContactMgr plan delivery]
+    C --> D[TunnelOutbox MsgRecord]
+    D --> E[Message Tunnel send loop]
+    E --> F[Build external send request]
+    F --> G[External IM API]
+    G --> H{Send result}
+    H -- success --> I[MsgCenter.report_delivery SENT]
+    H -- retryable failure --> J[report_delivery WAIT or FAILED with retry]
+    H -- final failure --> K[report_delivery DEAD]
+```
+
+出站投递必须通过 `record.route` 指定平台、tunnel、账号、会话地址和目标 DID。发送成功后，必须把外部 message id 写入 `DeliveryInfo.external_msg_id` 或 `RouteInfo.ext_ids`。
+
+## 7. 会话语义
+
+会话最小支持：
+
+- `Direct`：1v1。
+- `Group`：多人会话，成员可以是自然人、Agent、机器人。
+- `Subgroup`：群内临时议题、thread、topic、子群。
+- `Thread`：Email thread、MessageHub session、工单类上下文。
+
+会话 ID 优先保留外部 ID；只有系统内需要长期管理成员、权限、展示或跨平台路由时，才创建或绑定 BuckyOS DID。
+
+## 8. 消息内容语义
+
+Tunnel 必须尽量映射以下内容：
+
+- 文本、富文本、符号、表情、引用、回复、转发。
+- 附件，优先保存为 `MsgContent.refs` 指向 NamedObject 或外部 URI hint。
+- @、slash command、mention 等特殊字符，保留原文，同时在 `MsgContent.machine` 或 `msg.meta` 中提供结构化 mention。
+- 会话状态事件，映射为 `MsgObjKind` 状态消息或 `msg.meta.machine_event`。
+- 可操作消息和第三方应用消息，映射为 `MsgContent.machine`，原始 payload 放入 `msg.meta.platform_payload`。
+- 未知内容，映射为 `Unknown`，保留原始 payload 和降级展示文本。
+
+## 9. 平台子类
+
+每个平台应有两个方向的能力裁剪：
+
+```rust
+pub struct TelegramBotMsgTunnel;
+pub struct TelegramUserMsgTunnel;
+pub struct LarkBotMsgTunnel;
+pub struct LarkUserMsgTunnel;
+pub struct EmailMsgTunnel;
+pub struct MessageHubTunnel;
+```
+
+如果平台限制机器人行为，限制应体现在该子类的 `TunnelCapabilities` 和发送前校验中，不应污染通用 Message Tunnel 定义。
+
+## 10. 可靠性要求
+
+- 入站 offset/checkpoint 必须持久化。进程重启后从最后确认点恢复。
+- 入站和出站都必须幂等。
+- 发送前必须把任务持久化到 `TunnelOutbox`，发送后必须回报投递结果。
+- 同一会话内应尽量保持平台顺序；跨会话不要求全局顺序。
+- 对未知字段、未知 enum、未知内容类型使用兼容降级，不能 panic。
+- 新版本写入的数据被旧版本读取时，旧版本应保留未知字段或降级为 `Unknown`。
+
+## 11. 观测性要求
+
+每个 tunnel 至少记录：
+
+- `tunnel_did`、platform、account kind、capabilities。
+- 入站事件 ID、幂等 key、转换结果、dispatch 结果。
+- 出站 record_id、目标 route、外部 message id、重试次数、失败原因。
+- Agent 读取和回复消息不由 Message Tunnel 执行，但 tunnel 需要能串联 record_id、msg_id、external ids 供审计。


### PR DESCRIPTION
AI 生成记录：本 PR 的文档内容由 AI assistant 根据用户提示生成，并在对话中根据用户反馈调整说明。

## Intent

让 Agent 机器人（或者就是自然人）在 IM（或其他消息系统）允许的能力范围内，最大限度通过 API 使用 IM 的完整功能。
## Summary

- 更新 `doc/message_hub/Message Tunnel Design.md`
- 更新 `doc/message_hub/Message Tunnel Minimal Spec.md`
- 将 Message Tunnel 定义为外部 IM 系统与 BuckyOS MessageCenter 之间的会话级双向适配层
- 明确入站链路：外部会话消息和状态经 Message Tunnel 标准化后，通过 MessageCenter `dispatch` 投递给目标 Agent / 控制组件 / 系统组件
- 明确出站链路：响应由 Agent 或其他组件进入 MessageCenter，再由 Message Tunnel 从 `TUNNEL_OUTBOX` 拉取并投递回来源 IM 会话或授权目标
- 定义文本、富文本、表情、引用、附件、mention、会话状态、可操作消息、第三方应用消息、AI 流式消息等完整消息范围
- 定义 1v1、多人成员会话、群聊、群内 thread/topic/sub-conversation、机器人群聊等会话语义
- 明确 `BotMsgTunnel` / `UserMsgTunnel` 的能力差异，并说明 Telegram、Lark、Email、MessageHub 等典型 tunnel 的裁剪方式
- 明确外部 IM 的账号 ID、会话 ID、消息 ID 默认保持平台原始语义，不强制映射成 BuckyOS DID
- 复用现有 BuckyOS 基础类型，避免重复定义 `MsgObject`、`MsgRecord`、`IngressContext`、`RouteInfo`、`DeliveryReportResult`、`MsgTunnel` 等共享类型
- 补充消息顺序、幂等、去重、遗漏恢复、重试、投递回执、checkpoint、审计和可观测性要求
- 补充未来兼容策略：未知 enum、未知字段、未知平台消息必须保留或降级，不得导致宕机或损坏数据

## Verification

- `git diff --check -- "doc/message_hub/Message Tunnel Design.md" "doc/message_hub/Message Tunnel Minimal Spec.md"`
- 文档变更，未运行构建或测试

## Original Prompt

```text
定义一个理论上完整的Message Tunnel，并生成文档：

下面是对Message Tunnel的简要定义：
	流程:
		1. 从IM会话中获取各种消息
		2. 经MsgCenter转给由消息指定的目标智能体(Agent/由人操作的控制组件/其他)
		3. 目标智能体阅读处理后把生成的响应消息按规则存储或者投递到MsgCenter(这步不需要Message Tunnel参与)
		4. 响应消息再经Message Tunnel从MsgCenter取出并投递给消息的来源IM会话

	消息(或响应消息)包括但不限于：
	1. 各种用于沟通的文本/符号/表情/富文本/引用消息/附件等消息
	2. @等特殊含义字符(@只是一个代表，不同平台的字符可能不同，也可能还有其他类似功能符号)
	3. 各种会话状态，新加入/退出一个会话，会话加入/退出其他新成员，成员上线/下线，禁言/屏蔽，授权，消息状态(新消息/已读等)，正在输入等
	4. 特殊可操作消息，例如：微信红包...
	5. 依赖第三方应用的消息，比如：微信小程序，投票，等...
	6. 如果MessageTunnel对接聊天AI，可能会接收/返回AI的流式消息
	7. 其他待补充

	会话:
	1. 1v1会话
	2. 多人会话
	3. 群聊里的子群，通常是群内部分成员就一个议题发起的临时会话
	4. 这里的人可以是自然人，也可以是机器人，群聊也可以是一群机器人的聊天

	Agent: 
	1. 一个人工智能驱动的机器人
	2. 如果IM系统对机器人没有任何限制，他应该能完成一个真实自然人在会话中完成的一切行为，这是通用Message Tunnel的最大功能集
	3. 如果特定IM系统对机器人有行为限制，在对应特定Message Tunnel子类中予以裁剪
	4. 除了聊天，它也应该能按规则使用各种授予他使用的工具：
		* 给特定人发送email
		* 向其他会话发送消息
		* 其他待补充
	5. Agent的行为应该有日志跟踪增加可观测性，否则一群机器人聊天无法被感知
	
比如，在机器人的配置会话窗口输入:
	你可以翻阅我在B站关注的主播，如果他们有内容更新就发EMAIL告诉我(email: xxx)
	你可以加入我Telegram的好友群，如果发现他们出去浪，通过Lark告诉我(ID: xxx)


	IM:
	对于IM系统来说，Message Tunnel是IM系统中一个特定用户收发消息的一个通道，按用户种类分为机器人和自然人，各平台对它们的处理可能有差异(甚至不支持)，大多数时候应该分成两个子类(BotMsgTunnel/UserMsgTunnel)来支持
	

	其他实现上的细节，比如：消息顺序性，消息去重和遗漏等

几个典型Message Tunnel：
1. Telegram
2. Lark
3. EMail
4. MessageHub

文档内容约束：
1. 用自然语言准确描述其定义和功能集
2. 以程序设计的方式定义关键对象和流程，以rust风格定义
3. 对象/enum定义属性/方法应该标注说明
4. 流程描述除了自然语言准确描述外，再配上流程图
5. 外部IM系统范围的对象应该能保持原有语义，它们可能能并且需要被封装或映射成BuckyOS系统里类似DID的语义，也可能不能或者不必封装
	* 比如，IM系统的用户账号ID，它就是一个字符串，可能对应BuckyOS系统中的一个Agent，但也可能是消息的发出者，并不能在BuckyOS系统中找到一个匹配对象，仅仅用它作为消息的来源标识和响应消息接收方标识，是IM系统里的概念，不必强行在BuckyOS里封装或者映射成一个对象，除非有必要
6. BuckyOS系统内定义的基础类型，可以添加说明，不要另行定义，避免造成冲突；如果需要对基础类型升级，需要明确说明原因，并把列出新的定义
7. 保持对未来升级的兼容性，可以选择兼容、提示等，应避免出现宕机甚至损坏数据的灾难性结果
	* IM平台升级可能带来未知的内容
	* 其他用户升级了BuckyOS系统，旧系统可能会从这个用户接收更新的数据
8. 文档分两份，一份书写最简要内容，用来给agent生成代码，另一份书写详细说明，用来给人类review其设计细节
```