### PR TITLE
docs: define complete Message Tunnel design

### DIFF
--- a/doc/message_hub/Message Tunnel Design.md
+++ b/doc/message_hub/Message Tunnel Design.md
@@ -1,867 +1,600 @@
 # Message Tunnel Design
 
-## 1. 背景
+本文档基于当前 `MsgCenter`、`RouteInfo`、`MsgObject`、`MsgRecord` 和 Telegram tunnel 的实现，定义一个理论上完整的 Message Tunnel。目标是给人类 review 设计边界，确认哪些能力已经能用现有对象组合表达，哪些能力未来可能需要扩展。
 
-Message Tunnel 是 BuckyOS MessageHub/MessageCenter 面向外部 IM、Email、原生 MessageHub 和未来社交平台的通用适配层。它把“某个平台上的一个账号收发消息”抽象为 BuckyOS 中一个可运行、可审计、可裁剪能力的通道。
+配套简版文档见 `doc/message_hub/Message Tunnel Minimal Spec.md`。
 
-从完整能力上看，如果某个 IM 平台允许机器人完成自然人在会话里能完成的一切行为，那么对应 Message Tunnel 应能把这些行为完整桥接给 BuckyOS Agent：读消息、发消息、参与 1v1、参与群聊、加入/退出、管理会话状态、处理附件、处理引用、处理交互消息、发送状态、使用外部工具入口，并能把 Agent 行为记录下来。实际平台通常会限制 bot 或 user 账号能力，因此每个具体 tunnel 必须声明能力并按平台规则裁剪。
+## 1. 设计定位
 
-本文定义理论上完整的 Message Tunnel。当前实现已经有 `MsgTunnel`、`TgTunnel`、`MsgTunnelInstanceMgr`、`MessageCenter.dispatch/post_send`、`TUNNEL_OUTBOX`、`IngressContext`、`RouteInfo`、`DeliveryReportResult` 等基础能力。本文不替代这些基础类型，只定义它们之上的完整语义边界和后续扩展方向。
+Message Tunnel 是外部 IM 系统和 BuckyOS MessageCenter 之间的通道。对外部 IM 来说，它表现为一个特定用户或机器人账号的收发通道；对 BuckyOS 来说，它是 `MsgCenter.dispatch()` 的入站生产者，也是 `TUNNEL_OUTBOX` 的出站消费者。
 
-## 2. 目标
+完整流程是：
 
-Message Tunnel 的目标：
+1. Tunnel 从 IM 会话中获取文本、富文本、附件、引用、操作消息、会话状态、成员状态、已读、typing、平台私有事件等。
+2. Tunnel 把可标准化的内容转换为 `MsgObject`，把来源上下文放入 `IngressContext`，调用 `MsgCenter.dispatch()`。
+3. Agent、人操作的控制组件或其他系统服务从自己的 inbox 读取消息，处理后按规则保存或调用 `MsgCenter.post_send()` 生成响应消息。这一步不需要 Message Tunnel 参与。
+4. MsgCenter 根据联系人绑定和发送上下文创建 `TUNNEL_OUTBOX` record。
+5. Tunnel 从自己的 `TUNNEL_OUTBOX` 取出 record，转换为平台 API 调用，投递给原 IM 会话或其他被路由选中的外部会话。
+6. Tunnel 返回 `DeliveryReportResult`，由 MsgCenter 更新 record 的投递状态、重试信息和外部 message id。
 
-1. 让外部 IM 会话中的消息、会话事件和状态变化能进入 BuckyOS MessageCenter。
-2. 让 Agent、人操作的控制组件或系统组件生成的响应能回到消息来源 IM 会话。
-3. 保持外部 IM 对象的原始语义，不强制把所有平台账号、群、消息都封装成 BuckyOS DID。
-4. 为 Agent 提供标准化消息视图，使 Agent 不必理解 Telegram、Lark、Email 等平台细节。
-5. 为平台差异提供能力声明、降级策略和错误报告。
-6. 支持去重、顺序、遗漏恢复、重试和幂等。
-7. 支持日志、审计和可观测性，避免一组 Agent 或机器人互相通信时系统不可感知。
-8. 面向未来平台升级保持兼容，未知内容不能导致宕机或数据损坏。
+Message Tunnel 的最大功能集接近一个真实自然人在 IM 中能完成的行为：聊天、发附件、加入或退出会话、处理可操作消息、观察状态、按授权调用工具向其他渠道发送消息。具体平台限制，例如 Bot 无法主动私聊未授权用户、不能加入某些群、不能读取历史消息，必须在具体 Tunnel 子类中裁剪。
 
-非目标：
+## 2. 当前实现基础
 
-1. Message Tunnel 不负责 Agent 的推理、记忆、工具调用或任务调度。
-2. Message Tunnel 不负责替 MessageCenter 维护消息真相源。
-3. Message Tunnel 不负责把所有外部身份注册到 BuckyOS DID 系统。
-4. Message Tunnel 不负责绕过平台限制实现平台禁止的机器人行为。
+当前实现已经提供以下基础，不应重复设计：
 
-## 3. 基础原则
+- `ndn_lib::MsgObject`：不可变消息对象，`gen_obj_id()` 基于 canonical JSON 生成对象 id。
+- `ndn_lib::MsgContent`：承载 `format/content/machine/refs`，可表达文本、结构化机器内容和附件引用。
+- `ndn_lib::MsgObjKind`：包括 `Chat`、`GroupMsg`、`Deliver`、`Notify`、`Event`、`Operation`。
+- `buckyos_api::IngressContext`：入站来源上下文，已有 `tunnel_did/platform/chat_id/source_account_id/context_id/contact_mgr_owner/extra`。
+- `buckyos_api::SendContext`：出站偏好，已有 `context_id/contact_mgr_owner/preferred_tunnel/priority/extra`。
+- `buckyos_api::RouteInfo`：record 级路由信息，已有 `tunnel_did/platform/account_id/address/chat_id/target_did/mode/priority/ext_ids/extra`。
+- `buckyos_api::MsgRecord`：某个 owner 的 box 里对不可变 `MsgObject` 的可变视图，承载 `state/route/delivery/ui_session_id/sort_key/tags`。
+- `buckyos_api::MsgCenterHandler`：已经包含 `dispatch/post_send/get_next/report_delivery/set_read_state/resolve_did/get_preferred_binding` 等核心 API。
+- `msg_center::MsgTunnel`：已定义通用 `start/stop/send_record` 接口。
+- `TgTunnel`：当前 Telegram 适配器已经实现入站、出站、typing/status line、附件引用、投递回报和绑定管理的主要模式。
 
-### 3.1 外部对象保持外部语义
+因此本设计原则是：优先组合现有对象；只有当现有字段无法表达稳定语义，才提出新增概念。
 
-外部 IM 系统中的用户账号 ID、chat ID、message ID、thread ID、邮箱地址、Lark open_id、Telegram peer id 等，本质上都是平台侧标识。它们可以：
+## 3. 边界原则
 
-- 映射为 ContactMgr 中的联系人绑定。
-- 绑定到某个 BuckyOS User/Agent DID。
-- 仅作为消息来源、路由、回执和审计字段保存。
-- 在没有必要时不映射成任何 BuckyOS 对象。
+### 3.1 外部 IM 对象不强制 DID 化
 
-只有当某个外部对象需要成为 BuckyOS 内部权限主体、可管理实体、群实体或长期社交对象时，才考虑把它绑定或封装为 DID。
+外部 IM 的 user id、chat id、message id、thread id、tenant id、频道 id、小程序 id、红包 id 等对象保持平台原始语义。它们可以被映射到 BuckyOS DID，也可以只是字符串。
 
-### 3.2 BuckyOS 基础类型不重复定义
+必须映射为 DID 的情况：
 
-本文复用 BuckyOS 现有基础类型：
+- 需要作为 `MsgObject.from` 或 `MsgObject.to` 的系统内消息参与方。
+- 需要被 ContactMgr、GroupMgr、RBAC 或 Agent owner scope 管理。
+- 需要跨 Zone 寻址、长期验证或被其他 BuckyOS 服务引用。
 
-- `DID`：BuckyOS 内部身份主体。
-- `MsgObject`：标准消息对象，来自 `ndn_lib`。
-- `MsgRecord`：某个 owner 在某个 box 中对 `MsgObject` 的视图。
-- `BoxKind`：`INBOX`、`OUTBOX`、`GROUP_INBOX`、`TUNNEL_OUTBOX`、`REQUEST_BOX`。
-- `IngressContext`：入站来源上下文。
-- `SendContext`：出站发送上下文。
-- `RouteInfo`：投递路由信息。
-- `DeliveryInfo`/`DeliveryReportResult`：投递状态和回报。
-- `MsgReceiptObj`：阅读和处理回执。
+不必映射为 DID 的情况：
 
-如果未来这些类型无法表达 Message Tunnel 必需语义，应优先 additive 扩展，例如新增 `extra`、新增可选字段、为 enum 增加未知兜底，而不是破坏旧字段语义。
+- 仅用于回发到同一个外部会话，例如 Telegram `chat_id`、Email `Message-ID`。
+- 仅用于幂等、诊断、平台 API 参数。
+- 平台对象过于复杂，强行封装会损失原始语义或引入错误抽象。
 
-### 3.3 MessageCenter 是消息域真相源
+推荐位置：
 
-入站消息进入 BuckyOS 后，MessageCenter 负责保存 `MsgObject`、创建 box 记录、处理权限和通知。出站消息由 MessageCenter 生成 `TUNNEL_OUTBOX`，tunnel 只消费自己的出站队列并回报结果。
+- 入站来源：`IngressContext.platform/chat_id/source_account_id/extra`。
+- record 级投递：`RouteInfo.platform/account_id/address/chat_id/ext_ids/extra`。
+- 消息展示或平台语义：`MsgObject.meta`。
+- 机器可读操作：`MsgContent.machine`。
 
-Message Tunnel 可以保存平台断点、session、access token、event 去重表、平台附件缓存和审计日志，但不能成为 BuckyOS 标准消息历史的唯一来源。
+### 3.2 MsgObject 不承载可变投递状态
 
-### 3.4 能力先声明，行为按能力裁剪
+`MsgObject` 是消息语义本体，应保持不可变。已读、正在输入、投递重试、外部 message id、归档、删除、UI 会话归类等状态属于 `MsgRecord`、read receipt、UI session state 或新的状态对象。
 
-Bot 账号和自然人账号通常能力不同：
+### 3.3 Agent 不依赖具体平台
 
-- Bot 可能不能主动给未互动用户发消息。
-- Bot 可能不能读取历史消息或成员列表。
-- User tunnel 可能能做更多自然人行为，但安全和平台合规风险更高。
-- Email 没有在线、typing、群成员实时事件等 IM 语义。
+Agent 从 MessageCenter 读取标准化消息。除非业务明确需要平台细节，Agent 不应知道消息来自 Telegram、Lark、Email 还是 MessageHub。平台细节保留在 route/meta/machine 中，供诊断、工具调用或特定技能读取。
 
-因此每个 tunnel 实例都要声明能力。MessageCenter、UI、Agent runtime 和配置页只能使用它声明支持的能力。
+## 4. 消息能力集
 
-## 4. 总体流程
+Message Tunnel 理论上需要接收和发送以下消息或事件：
 
-### 4.1 入站到 Agent
+| 类型 | 推荐 MsgObject 表达 | 说明 |
+|---|---|---|
+| 普通文本、表情、符号 | `kind=Chat` 或 `GroupMsg`，`content.format=text/plain` | 表情可保持 Unicode 或平台 token |
+| 富文本、Markdown、HTML | `content.format=text/markdown` 或 `text/html` | 平台不支持时降级为纯文本 |
+| 引用/回复 | `thread.reply_to` 或 `meta.platform_reply_to` | 能解析为 `ObjId` 时使用 `reply_to` |
+| 附件、图片、音视频、文件 | `content.refs` 指向 `DataObj` | 大对象不直接塞入 `content.content` |
+| @、mention、特殊符号 | `content.content` 保留原文，结构化列表放 `machine.data.mentions` | 不同平台符号不统一 |
+| 成员加入/退出、会话创建/关闭 | `kind=Event`，`machine.intent=session.member_changed` 等 | 变更前后状态放 `machine.data` |
+| 上线/下线、禁言、屏蔽、授权 | `kind=Event` 或 `Notify` | 可影响 ContactMgr/RBAC 的事件由可信组件处理 |
+| 已读、新消息、typing | `kind=Notify` 或 UI session state | 高频 typing 不建议永久化为普通聊天历史 |
+| 红包、投票、小程序、审批卡片 | `kind=Operation` | 平台 payload 放 `machine.data.raw` 或 `meta` |
+| 第三方应用消息 | `kind=Operation` 或 `Event` | 保留原始 app id 和 action |
+| AI 流式消息 | 中间 `Notify/Event`，最终 `Chat/GroupMsg` | 保持 `MsgObject` 不可变 |
+| 未知平台升级消息 | `kind=Event` 或 `Operation` + raw payload | 必须可保留、可忽略、不可 panic |
 
-```mermaid
-flowchart TD
-    A[External IM Conversation] --> B[Message Tunnel receive/poll/webhook]
-    B --> C[Parse platform event]
-    C --> D[Build TunnelIngressEvent]
-    D --> E{Event duplicate?}
-    E -- yes --> F[Skip but keep checkpoint]
-    E -- no --> G{Event kind}
-    G -- message --> H[Normalize to MsgObject]
-    G -- conversation status --> I[Normalize to Event/Notify/Receipt/SessionState]
-    G -- unknown --> J[Unknown/Quarantine object]
-    H --> K[MessageCenter.dispatch]
-    I --> K
-    J --> K
-    K --> L[Owner/Agent INBOX or REQUEST_BOX]
-    L --> M[Agent/Control Component reads]
-```
+## 5. 会话模型
 
-自然语言说明：
+Message Tunnel 需要覆盖以下会话：
 
-1. Tunnel 从外部 IM 会话中接收各种消息和事件。
-2. Tunnel 解析平台事件，构造一个包含原始平台上下文的 `TunnelIngressEvent`。
-3. Tunnel 使用平台事件 ID、消息 ID、offset、timestamp 等做入站去重。
-4. 可标准化内容转换为 `MsgObject`；状态事件转换为 `MsgObject.kind=event/notify`、`MsgReceiptObj` 或 `ui_session_states`。
-5. Tunnel 调用 MessageCenter `dispatch`。
-6. MessageCenter 根据目标 DID、群、联系人策略、请求箱策略和权限，把消息投递给 Agent、人操作组件或其他系统组件。
+- 1v1 会话：外部 `chat_id` 通常对应一个外部用户和一个 tunnel 账号之间的上下文。
+- 多人会话：外部群、频道、聊天室，推荐映射到 group DID；如果尚未创建 DID，可先通过 ContactMgr 自动推断。
+- 群聊子群或议题线程：优先用 `MsgObject.thread.topic`、`thread.correlation_id`、`RouteInfo.chat_id` 或平台 thread id 表达，不强制创建新 group DID。
+- 人与机器人混合会话：消息参与方既可以是自然人，也可以是 Agent DID；外部平台未识别身份只保留 account id。
+- 机器人群聊：与普通群聊相同，但日志和可观察性更重要，避免机器人之间的行为不可感知。
 
-### 4.2 Agent 响应回外部会话
+当前 MessageCenter 的群消息语义是：`kind=GroupMsg`，`to.first()` 是 group DID，`from` 是发送者 DID。实现里仍保留旧数据 fallback：当 `to` 为空时可从 `from` 推断 group DID。新实现必须使用新语义。
 
-```mermaid
-flowchart TD
-    A[Agent/Control Component] --> B[Generate response MsgObject]
-    B --> C[MessageCenter.post_send]
-    C --> D[Owner OUTBOX]
-    C --> E[TUNNEL_OUTBOX by RouteInfo]
-    E --> F[Message Tunnel egress worker]
-    F --> G[Render to platform payload]
-    G --> H[External IM send API]
-    H --> I{Result}
-    I -- success --> J[report_delivery SENT + external_msg_id]
-    I -- retryable error --> K[report_delivery WAIT/FAILED with retry_after]
-    I -- final error --> L[report_delivery DEAD/FAILED]
-```
+## 6. Rust 风格关键对象
 
-自然语言说明：
+下面是设计视角的关键对象。已存在的基础类型只添加说明，不重新定义字段。
 
-1. Agent 阅读消息后生成响应。响应如何保存或进入 MessageCenter 不是 Message Tunnel 的职责。
-2. MessageCenter 根据 ContactMgr、`SendContext`、原入站 `RouteInfo` 或显式目标构造投递计划。
-3. Tunnel 从自己的 `TUNNEL_OUTBOX` 拉取待投递记录。
-4. Tunnel 把标准 `MsgObject` 渲染成平台 payload。
-5. Tunnel 调用平台发送 API。
-6. Tunnel 使用 `report_delivery` 把结果写回 MessageCenter。
-
-## 5. 理论完整功能集
-
-### 5.1 消息内容
-
-Message Tunnel 应能表达或降级处理：
-
-- 文本、符号、表情、reaction。
-- 富文本、Markdown、HTML、平台专有富文本。
-- 回复、引用、转发、thread/topic。
-- 图片、音频、视频、文件、位置、联系人卡片等附件。
-- 多段消息和组合消息。
-- @mention、特殊命令符、平台特有触发符。
-- 系统消息和通知。
-- 可操作消息，例如红包、投票、审批卡片、按钮卡片。
-- 依赖第三方应用的消息，例如小程序、Lark 卡片、外部 app payload。
-- AI 流式消息，包括 delta、status、final、cancel。
-- 未知平台消息。
-
-处理原则：
-
-- 能转换为标准 `MsgContent` 的内容直接转换。
-- 附件优先导入对象存储并通过 `RefItem` 引用；不能导入时保留 `uri_hint` 和平台 file id。
-- 平台私有对象使用 `PlatformObject` 或 `extra/raw` 保存。
-- 未知内容要保留、降级展示或隔离，不得丢失已知字段。
-
-### 5.2 会话
-
-Message Tunnel 需要覆盖：
-
-- 1v1 会话。
-- 多人会话。
-- 群聊。
-- 群聊内 thread/topic/subgroup/sub-conversation。
-- 频道、广播、邮件线程。
-- 机器人与机器人会话。
-- 自然人与机器人混合会话。
-- 仅由系统组件操作的控制会话。
-
-群聊里的子群不一定是 BuckyOS self-host group。外部平台 thread/topic 可以只是 `ExternalConversationRef.parent_conversation_id` 加 `MsgObject.thread`；只有当它需要成为 BuckyOS 可管理群实体时，才映射到 group DID。
-
-### 5.3 会话状态和成员事件
-
-Message Tunnel 应尽量表达：
-
-- 加入/退出会话。
-- 邀请、移除、成员角色变化。
-- 成员上线/下线。
-- 禁言、屏蔽、解除屏蔽。
-- 会话授权、bot 被授予/撤销权限。
-- 新消息、已投递、已读、撤回、编辑、删除。
-- typing、recording、processing、status line。
-- 平台 API 限流、会话不可达、用户已阻止 bot。
-
-这些状态不都适合进入普通聊天时间线。建议：
-
-- 与消息处理强相关的状态写 `MsgReceiptObj` 或 `MsgRecord.delivery`。
-- 与 UI 会话运行态相关的状态写 `ui_session_states`。
-- 对用户可见且需要留痕的状态写 `MsgObjKind::Notify/Event`。
-- 对权限有影响的状态同步到 ContactMgr 或 GroupMgr。
-
-### 5.4 Agent 行为
-
-理论完整 Agent 作为 IM 用户时，应能在平台允许的范围内完成自然人能完成的行为：
-
-- 阅读会话消息和上下文。
-- 回复、引用、转发、编辑、撤回。
-- 发送文本、富文本、附件、状态。
-- 被 @ 后按规则响应。
-- 参与群聊和子会话。
-- 使用被授权的外部工具，例如发 Email、向其他会话发送消息、触发 Lark 通知。
-- 识别需要人工确认的动作，向 MessageHub 或控制组件发确认请求。
-- 记录自身行为日志，使 owner 能审计它为什么发了某条消息、用了哪个工具、触发了什么外部投递。
-
-如果 IM 平台对机器人有限制，对应 tunnel 子类必须在能力声明和出站错误中体现限制。
-
-## 6. 对象模型
-
-### 6.1 TunnelPlatform
+### 6.1 Tunnel 角色
 
 ```rust
-/// 外部消息平台。未知平台用 Custom，避免升级时旧系统无法解析。
-pub enum TunnelPlatform {
-    Telegram,
-    Lark,
-    Email,
-    MessageHub,
-    Custom(String),
-}
-```
-
-属性说明：
-
-- `Telegram`：Telegram bot 或 user session。
-- `Lark`：Lark/飞书机器人、应用或用户授权通道。
-- `Email`：邮箱账号、SMTP/IMAP/API 通道。
-- `MessageHub`：BuckyOS 原生 MessageHub 跨 Zone 或内部 tunnel。
-- `Custom(String)`：未来平台。
-
-### 6.2 TunnelAccountKind
-
-```rust
-/// Tunnel 使用的平台账号类型。
-pub enum TunnelAccountKind {
-    Bot,    // 平台机器人账号，通常有 API 能力限制。
-    User,   // 自然人账号授权通道，权限更大，安全要求也更高。
-    System, // 系统级通道，例如 MessageHub native 或通知邮箱。
-}
-```
-
-### 6.3 TunnelCapability
-
-```rust
-/// 运行时能力声明。调用方必须按能力裁剪行为。
-pub struct TunnelCapability {
-    pub ingress: bool,
-    pub egress: bool,
-    pub receive_history: bool,
-    pub direct_chat: bool,
-    pub group_chat: bool,
-    pub sub_conversation: bool,
-    pub channel: bool,
-    pub attachments_in: bool,
-    pub attachments_out: bool,
-    pub rich_text_in: bool,
-    pub rich_text_out: bool,
-    pub mention: bool,
-    pub reaction: bool,
-    pub edit_message: bool,
-    pub delete_message: bool,
-    pub read_receipt_in: bool,
-    pub read_receipt_out: bool,
-    pub typing_in: bool,
-    pub typing_out: bool,
-    pub interactive_message: bool,
-    pub app_dependent_message: bool,
-    pub streaming_out: bool,
-    pub proactive_send: bool,
-}
-```
-
-方法建议：
-
-```rust
-impl TunnelCapability {
-    /// 判断某种标准动作是否允许执行。
-    pub fn allows(&self, action: TunnelAction) -> bool;
-
-    /// 返回不支持时的降级策略。
-    pub fn fallback_for(&self, action: TunnelAction) -> TunnelFallback;
-}
-```
-
-### 6.4 ExternalAccountRef
-
-```rust
-/// 外部平台账号引用。它不是 DID。
-pub struct ExternalAccountRef {
-    pub platform: TunnelPlatform,
-    pub account_id: String,
-    pub display_id: Option<String>,
-    pub display_name: Option<String>,
-    pub account_kind: Option<TunnelAccountKind>,
-    pub avatar_uri: Option<String>,
-    pub extra: serde_json::Value,
-}
-```
-
-字段说明：
-
-- `account_id`：平台稳定账号 ID、open_id、邮箱地址等。
-- `display_id`：用户可见 ID，例如 @handle、邮箱地址。
-- `extra`：平台字段，不能作为跨平台核心逻辑依赖。
-
-### 6.5 ExternalConversationRef
-
-```rust
-/// 外部平台会话引用。它不是 BuckyOS Group 的替代品。
-pub struct ExternalConversationRef {
-    pub platform: TunnelPlatform,
-    pub conversation_id: String,
-    pub parent_conversation_id: Option<String>,
-    pub conversation_kind: ExternalConversationKind,
-    pub title: Option<String>,
-    pub extra: serde_json::Value,
-}
-
-pub enum ExternalConversationKind {
-    Direct,
-    Group,
-    SubConversation,
-    Channel,
-    EmailThread,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageTunnelAccountKind {
+    /// 平台机器人账号。能力受 Bot API 限制。
+    Bot,
+    /// 自然人账号或用户授权账号。理论上接近真实用户能力。
+    User,
+    /// BuckyOS 内部入口，例如 MessageHub。
     System,
-    Unknown(String),
 }
-```
 
-字段说明：
-
-- `conversation_id`：平台原始会话 ID。
-- `parent_conversation_id`：thread/topic/subgroup 所属父会话。
-- `Unknown`：平台升级后旧系统仍可保留数据。
-
-### 6.6 TunnelIngressEvent
-
-```rust
-/// 入站平台事件。是平台事件到 BuckyOS MsgObject 之间的中间层。
-pub struct TunnelIngressEvent {
-    pub event_id: String,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageTunnelBinding {
+    /// 该绑定服务的 BuckyOS owner/user/agent。
+    pub owner_did: DID,
+    /// Tunnel 实例 DID，也是 TUNNEL_OUTBOX 的 owner。
     pub tunnel_did: DID,
-    pub platform: TunnelPlatform,
-    pub account: ExternalAccountRef,
-    pub conversation: ExternalConversationRef,
-    pub sender: ExternalAccountRef,
-    pub occurred_at_ms: u64,
-    pub received_at_ms: u64,
-    pub payload: TunnelPayload,
-    pub raw: serde_json::Value,
-}
-
-pub enum TunnelPayload {
-    Message(TunnelMessage),
-    ConversationEvent(TunnelConversationEvent),
-    MessageState(TunnelMessageStateEvent),
-    CapabilityEvent(TunnelCapabilityEvent),
-    Unknown(serde_json::Value),
-}
-```
-
-方法建议：
-
-```rust
-impl TunnelIngressEvent {
-    /// 构造平台级幂等 key。优先使用平台 event id；没有时用 platform/account/conversation/message/time 派生。
-    pub fn idempotency_key(&self) -> String;
-
-    /// 构造 MessageCenter 入站上下文。
-    pub fn to_ingress_context(&self) -> IngressContext;
-}
-```
-
-### 6.7 TunnelMessage
-
-```rust
-pub struct TunnelMessage {
-    pub external_message_id: String,
-    pub kind: TunnelMessageKind,
-    pub parts: Vec<TunnelMessagePart>,
-    pub reply_to: Option<String>,
-    pub mentions: Vec<TunnelMention>,
-    pub stream: Option<TunnelStreamInfo>,
+    /// 外部平台，例如 telegram/lark/email/messagehub。
+    pub platform: String,
+    /// 外部账号 id，保持原始字符串语义。
+    pub account_id: String,
+    /// 展示或投递地址，例如 email、open_id、chat_id。
+    pub display_id: String,
+    /// bot/user/system。
+    pub account_kind: MessageTunnelAccountKind,
+    /// 运行期和平台扩展字段。只能追加，旧版本忽略未知字段。
     pub extra: serde_json::Value,
 }
+```
 
-pub enum TunnelMessageKind {
-    Text,
-    RichText,
-    Media,
-    Attachment,
-    Reaction,
-    Interactive,
-    AppDependent,
-    AiStreamDelta,
-    AiStreamComplete,
-    Unknown(String),
-}
+当前 `Contact::bindings: Vec<AccountBinding>` 已能表达 `platform/account_id/display_id/tunnel_id/meta`。上面的 `MessageTunnelBinding` 是更完整的概念模型，不要求立即新增持久化结构。若未来需要区分 Bot/User/System，可在现有 binding `meta` 中追加 `account_kind`，或升级 `AccountBinding`。
 
-pub enum TunnelMessagePart {
-    Text { text: String },
-    RichText { format: String, content: String },
-    Emoji { code: String, text: Option<String> },
-    Attachment {
-        object_ref: Option<ObjId>,
-        uri_hint: Option<String>,
-        name: Option<String>,
-        mime: Option<String>,
-        size: Option<u64>,
-    },
-    PlatformObject {
-        object_type: String,
-        payload: serde_json::Value,
-    },
-    Unknown {
-        payload: serde_json::Value,
-    },
+### 6.2 入站信封
+
+```rust
+pub struct MessageTunnelIngress {
+    /// 解析后的标准消息。
+    pub msg: MsgObject,
+    /// 入站上下文，供 MsgCenter 写入 record.route 和权限判断。
+    pub ingress_ctx: IngressContext,
+    /// 稳定幂等 key。重复提交同一平台事件必须得到同一 key。
+    pub idempotency_key: String,
 }
 ```
 
-### 6.8 TunnelRoute
+字段要求：
 
-当前实现已有 `RouteInfo`，建议不新增并行基础类型。理论完整 tunnel 需要的路由信息应通过 `RouteInfo` 表达：
+- `ingress_ctx.tunnel_did`：当前 tunnel DID。
+- `ingress_ctx.platform`：平台名。
+- `ingress_ctx.chat_id`：平台会话 id，不强制 DID 化。
+- `ingress_ctx.source_account_id`：平台发送者账号 id。
+- `ingress_ctx.context_id`：权限和会话上下文，推荐包含 platform、owner、chat_id。
+- `ingress_ctx.contact_mgr_owner`：联系人范围 owner。
+- `ingress_ctx.extra`：平台 message id、chat type、tenant id、thread id 等扩展。
+
+### 6.3 出站信封
 
 ```rust
-pub struct RouteInfo {
-    pub tunnel_did: Option<DID>,
-    pub platform: Option<String>,
-    pub account_id: Option<String>,
-    pub address: Option<String>,
-    pub chat_id: Option<String>,
-    pub target_did: Option<DID>,
-    pub mode: Option<String>,
-    pub priority: Option<i32>,
-    pub ext_ids: HashMap<String, String>,
-    pub extra: Option<serde_json::Value>,
+pub struct MessageTunnelEgress {
+    /// MessageCenter record id。投递结果必须回报到这个 record。
+    pub record_id: String,
+    /// 标准消息对象。
+    pub msg: MsgObject,
+    /// record.route，包含 tunnel、平台账号、外部地址和扩展 id。
+    pub route: RouteInfo,
 }
 ```
 
-使用约定：
+字段要求：
 
-- `tunnel_did`：出站必须存在，否则无法选择 tunnel。
-- `platform`：平台名，用于诊断和多 tunnel 选择。
-- `account_id`：tunnel 使用的本方平台账号。
-- `address`：Email 地址、webhook URL 或平台目标地址。
-- `chat_id`：IM 会话 ID。
-- `target_did`：已映射到 BuckyOS 联系人时填写。
-- `ext_ids`：外部 message id、thread id、tenant id、open id、reply target 等。
-- `extra`：平台专有出站参数，例如 parse_mode、card template、SMTP header。
+- `route.tunnel_did`：必须是当前 tunnel DID。
+- `route.platform`：平台名。
+- `route.account_id`：发送账号或平台账号 id。
+- `route.address`：外部目标地址，可为 email address、open_id、username 等。
+- `route.chat_id`：目标会话 id。
+- `route.target_did`：BuckyOS 逻辑目标 DID。
+- `route.mode`：`direct/group/reply/broadcast/status/edit` 等投递模式。
+- `route.ext_ids`：外部 message id、thread id、reply id 等可索引字符串。
+- `route.extra`：平台复杂 payload。
 
-## 7. MsgObject 映射
-
-### 7.1 普通聊天消息
+### 6.4 平台能力声明
 
 ```rust
-fn tunnel_message_to_msg_object(event: &TunnelIngressEvent, target: Vec<DID>) -> MsgObject {
-    MsgObject {
-        from: resolve_sender_did_or_tunnel_shadow(event),
-        to: target,
-        kind: MsgObjKind::Chat,
-        thread: build_thread(event),
-        workspace: None,
-        created_at_ms: event.occurred_at_ms,
-        expires_at_ms: None,
-        nonce: None,
-        content: build_msg_content(event),
-        proof: None,
-        // meta/extra should preserve platform ids and unknown fields.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MessageTunnelCapability {
+    /// 是否能接收入站消息。
+    pub ingress: bool,
+    /// 是否能发送出站消息。
+    pub egress: bool,
+    /// 是否支持编辑已发送消息。
+    pub edit_message: bool,
+    /// 是否支持删除已发送消息。
+    pub delete_message: bool,
+    /// 是否支持 typing 或 processing 状态。
+    pub typing: bool,
+    /// 是否支持已读回执。
+    pub read_receipt: bool,
+    /// 是否支持主动发起到外部用户的会话。
+    pub proactive_direct_message: bool,
+    /// 是否支持附件上传。
+    pub attachment_upload: bool,
+    /// 是否支持平台操作消息，例如卡片、投票、审批。
+    pub operation_message: bool,
+    /// 未知或平台私有能力。
+    pub extra: serde_json::Value,
+}
+```
+
+当前 `MsgTunnel::supports_ingress()` 和 `supports_egress()` 只表达两个基础能力。未来如果管理界面或路由策略需要能力裁剪，可以把完整 capability 放入 tunnel 配置或 instance info，不需要改变 `MsgObject`。
+
+## 7. 入站流程
+
+### 7.1 自然语言流程
+
+Tunnel 从外部 IM 拉取或接收事件后，先做平台层去重和顺序整理，再转换为标准 `MsgObject`。转换时，它可以通过 `MsgCenter.resolve_did()` 或 ContactMgr 把外部 sender/group 映射为 DID；如果不能映射，只保留外部 id，并把消息投递给配置目标 Agent 或 owner。
+
+转换完成后，Tunnel 调用 `dispatch(msg, ingress_ctx, idempotency_key)`。MessageCenter 保存 `MsgObject`，根据 `kind` 和 `to` 写入 `INBOX`、`GROUP_INBOX` 或 `REQUEST_BOX`，并把 `IngressContext` 转换成 record 上的 `RouteInfo`。Agent pump 之后从 inbox 读取消息并处理。
+
+```mermaid
+sequenceDiagram
+    participant IM as External IM
+    participant T as Message Tunnel
+    participant MC as MsgCenter
+    participant C as ContactMgr/GroupMgr
+    participant A as Agent/Control
+
+    IM->>T: message/event/update
+    T->>T: dedupe, normalize, preserve raw ids
+    T->>MC: resolve_did(platform, account_id) when needed
+    MC->>C: lookup/create contact or group
+    C-->>MC: DID or policy decision
+    T->>MC: dispatch(MsgObject, IngressContext, idempotency_key)
+    MC->>MC: store MsgObject by ObjId
+    MC->>MC: create INBOX/GROUP_INBOX/REQUEST_BOX records
+    MC-->>A: box changed event
+    A->>MC: get_next(owner, box, UNREAD, lock_on_take=true)
+```
+
+### 7.2 伪代码
+
+```rust
+async fn handle_platform_update(update: PlatformUpdate) -> AnyResult<()> {
+    let idempotency_key = build_ingress_key(&update);
+
+    if local_seen_recently(&idempotency_key) {
+        return Ok(());
+    }
+
+    let sender_did = resolve_or_infer_sender(&update).await?;
+    let target = resolve_target_owner_or_group(&update).await?;
+
+    let msg = MsgObject {
+        from: sender_did,
+        to: vec![target.did],
+        kind: target.kind,
+        created_at_ms: update.timestamp_ms,
+        content: normalize_content(&update).await?,
+        meta: preserve_platform_meta(&update),
+        ..Default::default()
+    };
+
+    let ingress_ctx = IngressContext {
+        tunnel_did: Some(self.tunnel_did()),
+        platform: Some(self.platform().to_string()),
+        chat_id: Some(update.chat_id.clone()),
+        source_account_id: Some(update.sender_account_id.clone()),
+        context_id: Some(format!("{}:{}:{}", self.platform(), self.owner_did, update.chat_id)),
+        contact_mgr_owner: Some(self.owner_did.clone()),
+        extra: Some(update.raw_context_json()),
+    };
+
+    msg_center
+        .dispatch(msg, Some(ingress_ctx), Some(idempotency_key))
+        .await?;
+
+    Ok(())
+}
+```
+
+## 8. 出站流程
+
+### 8.1 自然语言流程
+
+Agent 或系统服务生成响应时调用 `post_send()`，MessageCenter 先保存 sender 的 `OUTBOX` 记录，再根据 ContactMgr binding、`SendContext.preferred_tunnel` 和目标 DID 生成一个或多个 `TUNNEL_OUTBOX` record。后台 egress worker 遍历运行中的 tunnel，调用 `get_next(tunnel_did, TUNNEL_OUTBOX, WAIT, lock_on_take=true)` 抢占一条记录，随后调用 `MsgTunnel::send_record()`。
+
+Tunnel 负责把 `MsgObject` 转为平台 API。成功或失败都返回 `DeliveryReportResult`，由 MessageCenter 的 `report_delivery()` 更新状态。可重试失败回到 `WAIT`，不可重试或超过次数进入 `DEAD`。
+
+```mermaid
+sequenceDiagram
+    participant A as Agent/Control/Service
+    participant MC as MsgCenter
+    participant W as Egress Worker
+    participant T as Message Tunnel
+    participant IM as External IM
+
+    A->>MC: post_send(MsgObject, SendContext, idempotency_key)
+    MC->>MC: store MsgObject, create OUTBOX
+    MC->>MC: plan delivery, create TUNNEL_OUTBOX
+    W->>MC: get_next(tunnel_did, TUNNEL_OUTBOX, WAIT, lock=true)
+    MC-->>W: MsgRecordWithObject, state=SENDING
+    W->>T: send_record(record)
+    T->>IM: platform send API
+    IM-->>T: external message id or error
+    T-->>W: DeliveryReportResult
+    W->>MC: report_delivery(record_id, result)
+    MC->>MC: state=SENT / WAIT / FAILED / DEAD
+```
+
+### 8.2 伪代码
+
+```rust
+async fn send_record(&self, record: MsgRecordWithObject) -> AnyResult<DeliveryReportResult> {
+    let msg = record.get_msg().await?;
+    let route = record
+        .record
+        .route
+        .clone()
+        .ok_or_else(|| anyhow!("missing route"))?;
+
+    ensure!(route.tunnel_did.as_ref() == Some(&self.tunnel_did()));
+
+    let request = convert_msg_to_platform_request(&msg, &route).await?;
+
+    match platform_client.send(request).await {
+        Ok(sent) => Ok(DeliveryReportResult {
+            ok: true,
+            external_msg_id: Some(sent.message_id),
+            delivered_at_ms: Some(now_ms()),
+            ..Default::default()
+        }),
+        Err(err) if err.retryable => Ok(DeliveryReportResult {
+            ok: false,
+            retryable: Some(true),
+            retry_after_ms: err.retry_after_ms,
+            error_code: Some(err.code),
+            error_message: Some(err.message),
+            ..Default::default()
+        }),
+        Err(err) => Ok(DeliveryReportResult {
+            ok: false,
+            retryable: Some(false),
+            error_code: Some(err.code),
+            error_message: Some(err.message),
+            ..Default::default()
+        }),
     }
 }
 ```
 
-说明：
+## 9. 身份、路由和权限
 
-- 如果外部发送者已绑定 DID，`from` 可使用该 DID。
-- 如果没有 DID，当前基础 `MsgObject.from` 仍需要 DID。实现可以使用 tunnel DID、owner 配置的 shadow DID、ContactMgr 自动创建的联系人 DID，或把消息送入 REQUEST_BOX 等待确认。不能把任意外部字符串伪装成可信 DID。
-- 原始外部账号必须保存在 `IngressContext`、`RouteInfo` 或 `MsgObject` meta 中，用于回复路由和审计。
+### 9.1 入站身份
 
-### 7.2 群消息
+入站 sender 可按三层处理：
 
-BuckyOS self-host group 的规范是 `from=group_did, source=author_did`。外部 IM 群不一定拥有 BuckyOS group DID，因此分两种：
+1. 已绑定 DID：外部账号通过 ContactMgr binding 映射到已有 DID。
+2. 自动推断 DID：系统为陌生外部账号创建临时或自动联系人 DID。
+3. 不映射 DID：消息投递给固定 Agent，外部 sender 只作为 `source_account_id` 和 meta 存在。
 
-1. 已映射为 BuckyOS group：使用 group DID 语义，MessageCenter 写 `GROUP_INBOX`。
-2. 未映射外部群：作为某个 Agent/User 的外部会话消息处理，保留 `conversation_id`，不要强行创建 group DID。
+如果一个外部账号只是消息来源和回复地址，不需要在 BuckyOS 里拥有完整身份，不应强行创建长期 DID。若需要权限、屏蔽、审计、工具授权或群成员关系，则应创建或解析 DID。
 
-### 7.3 @ 和特殊符号
+### 9.2 出站路由
 
-@ 只是平台特殊符号的一个例子。不同平台可能使用不同提及、命令或 bot trigger 规则。
+出站路由优先级：
 
-建议表达：
+1. `SendContext.preferred_tunnel`。
+2. ContactMgr 中目标 DID 的 preferred binding。
+3. 具体业务指定的 `RouteInfo` 或 `context_id` 关联历史。
+4. 默认 tunnel fallback。
 
-```rust
-pub struct TunnelMention {
-    pub raw: String,
-    pub account: Option<ExternalAccountRef>,
-    pub did: Option<DID>,
-    pub role: MentionRole,
-}
+`RouteInfo` 是 record 级字段。同一 `MsgObject` 可以有多个 `TUNNEL_OUTBOX` record，分别指向不同 tunnel 或外部地址，不改变 `MsgObjectId`。
 
-pub enum MentionRole {
-    User,
-    Bot,
-    All,
-    Here,
-    Command,
-    Unknown(String),
-}
-```
+### 9.3 权限和授权
 
-进入 `MsgObject` 时：
+Tunnel 只做平台连接认证和基础过滤；BuckyOS 层权限由 MsgCenter、ContactMgr、GroupMgr、RBAC 和 Agent runtime 处理。
 
-- 可解析 DID 的 mention 写入结构化 metadata。
-- 不可解析的 mention 保留原始文本和平台账号。
-- Agent 是否被 @ 唤醒由 tunnel 子类或 MessageCenter/Agent runtime 策略决定。
+用户在配置会话里授予 Agent 工具能力，例如“关注 B 站主播更新后发 Email”或“加入 Telegram 好友群后用 Lark 通知我”，本质是 Agent 获得了读取某些 tunnel/context 的权限和调用某些 outbound tunnel/tool 的权限。Tunnel 应把这些行为记录到 MsgCenter record、Agent worklog 或审计日志，使机器人之间的通信可观察。
 
-### 7.4 附件
-
-附件处理策略：
-
-1. 小附件或允许下载的文件，导入 BuckyOS object store，`MsgContent.refs` 指向 `ObjId`。
-2. 大附件或权限受限附件，保留 `uri_hint`、平台 file id、mime、size，按需拉取。
-3. 无法读取附件时，生成可展示的占位信息并保留错误。
-4. 附件导入失败不应阻止文本部分入站，除非平台消息只有附件且策略要求完整性。
-
-### 7.5 可操作和第三方应用消息
-
-红包、投票、小程序、审批卡片等消息有平台内操作语义。通用 Message Tunnel 不应假装自己能执行所有操作。
-
-处理方式：
-
-- 能安全转换为 BuckyOS `operation` 的，转为 `MsgObjKind::Operation` 并带权限确认。
-- 只能展示的，降级为 `MsgObjKind::Notify` 或 chat 文本说明。
-- 完全未知的，作为 `PlatformObject` 保存并进入 unknown/quarantine 流程。
-
-### 7.6 AI 流式消息
-
-如果 Message Tunnel 对接聊天 AI 或 Agent 运行状态，可能需要发送流式响应：
-
-- 支持编辑消息的平台：先发送 placeholder，再不断 edit。
-- 支持 typing/status 的平台：用 typing 或 status line 表达处理中。
-- 支持多条消息的平台：发送 delta 消息，但要用同一个 `correlation_id` 关联。
-- 不支持流式的平台：只发送 final。
-
-流式状态不应破坏最终消息幂等。最终内容应有明确完成事件或 final message。
-
-## 8. 关键接口
-
-### 8.1 理论完整 trait
-
-当前代码中的 `MsgTunnel` 是最小运行 trait。理论完整接口可按下面方向扩展，但实现时应优先兼容现有 trait：
-
-```rust
-#[async_trait::async_trait]
-pub trait MessageTunnel: Send + Sync {
-    fn tunnel_did(&self) -> DID;
-    fn name(&self) -> &str;
-    fn platform(&self) -> TunnelPlatform;
-    fn account_kind(&self) -> TunnelAccountKind;
-    fn capability(&self) -> TunnelCapability;
-
-    /// 启动连接、webhook、poller 或 watcher。
-    async fn start(&self) -> anyhow::Result<()>;
-
-    /// 停止接收和发送，保存 checkpoint。
-    async fn stop(&self) -> anyhow::Result<()>;
-
-    /// 拉取或接收外部事件。Webhook 型 tunnel 可在内部 callback 后返回空。
-    async fn pull_or_receive(&self) -> anyhow::Result<Vec<TunnelIngressEvent>>;
-
-    /// 处理单个入站事件，通常会调用 MessageCenter.dispatch。
-    async fn handle_ingress(&self, event: TunnelIngressEvent) -> anyhow::Result<()>;
-
-    /// 投递 MessageCenter TUNNEL_OUTBOX 记录。
-    async fn send_record(
-        &self,
-        record: MsgRecordWithObject,
-    ) -> anyhow::Result<DeliveryReportResult>;
-
-    /// 可选：同步平台联系人、会话或群成员。
-    async fn sync_contacts(&self) -> anyhow::Result<TunnelSyncReport>;
-
-    /// 可选：查询平台侧会话能力。
-    async fn describe_conversation(
-        &self,
-        conversation: &ExternalConversationRef,
-    ) -> anyhow::Result<TunnelConversationInfo>;
-}
-```
-
-### 8.2 BotMsgTunnel 和 UserMsgTunnel
-
-```rust
-pub struct BotMsgTunnel<T> {
-    pub inner: T,
-    pub bot_account: ExternalAccountRef,
-    pub allowed_scopes: Vec<String>,
-}
-
-pub struct UserMsgTunnel<T> {
-    pub inner: T,
-    pub user_account: ExternalAccountRef,
-    pub delegated_by: Option<DID>,
-    pub allowed_scopes: Vec<String>,
-}
-```
-
-区别：
-
-- `BotMsgTunnel` 默认权限窄，适合长期运行和公开接入。
-- `UserMsgTunnel` 可以代表自然人执行更强操作，必须有清晰授权、审计和撤销路径。
-- 同一平台通常要分别实现 bot/user 两个子类或在同一实现中声明不同能力 profile。
-
-## 9. 持久状态
-
-Message Tunnel 自身可能需要持久化以下数据：
-
-| 数据 | 所属组件 | 持久性 | 说明 |
-|---|---|---|---|
-| 平台 access token/session | Tunnel 子类 | Durable | 需要安全存储和可撤销 |
-| 入站 checkpoint/offset | Tunnel 子类 | Durable | 防止重启后遗漏或重复 |
-| 入站 event 去重表 | Tunnel 子类或 MessageCenter | Durable/TTL | 至少覆盖平台重投窗口 |
-| 平台账号绑定 | system-config/ContactMgr | Durable | 已有 `UserTunnelBinding`/`AccountBinding` |
-| 标准消息历史 | MessageCenter/named_store/RDB | Durable | 不由 tunnel 私有保存 |
-| 出站投递状态 | MessageCenter `MsgRecord.delivery` | Durable | tunnel 通过 `report_delivery` 更新 |
-| 临时附件缓存 | Tunnel 子类 | Disposable | 可重建或重新下载 |
-| 运行中 typing/status | ui_session_states/内存 | Disposable/Durable by policy | 可过期 |
-| 审计日志 | Tunnel 子类/系统日志 | Durable by policy | 用于追踪 Agent 行为 |
-
-如果未来把这些状态落入 RDB，应使用平台 RDB instance，不直接绑定 sqlite 或 Postgres。新字段采用 additive-only 策略，未知字段保存在 JSON `extra` 中。
-
-## 10. 幂等、顺序和遗漏
+## 10. 顺序、去重和遗漏恢复
 
 ### 10.1 入站幂等
 
-入站去重使用三层：
+推荐入站幂等 key：
 
-1. 平台 event id 或 update id。
-2. 平台 message id + chat id + account id。
-3. 标准 `MsgObject` canonical id。
+```text
+{platform}:{tunnel_account_id}:{chat_id}:{external_message_id}
+```
 
-重复事件不应产生重复用户可见消息。若平台允许同一消息编辑，应创建状态更新或新版本事件，而不是重复 chat 消息。
+如果平台没有稳定 message id：
+
+```text
+{platform}:{tunnel_account_id}:{chat_id}:{event_timestamp}:{payload_hash}
+```
+
+要求：
+
+- 同一平台事件重复上报必须生成同一 key。
+- 幂等 key 不应包含重试次数、拉取批次或本地处理时间。
+- 对可编辑消息，原始消息和编辑事件可以是不同 key，但应通过 `ext_ids.original_message_id` 或 `thread.reply_to` 关联。
 
 ### 10.2 出站幂等
 
-出站去重以 `MsgRecord.record_id` 和平台 `external_msg_id` 为核心：
+出站由 MessageCenter 通过 `MsgObjectId`、目标 DID、tunnel DID、account id、mode 等生成稳定 record id。Tunnel 层还应处理平台 API 超时后的未知状态：
 
-- `SENT` 且已有 `external_msg_id` 的记录不能再次发送。
-- 网络超时但平台可能已发送成功时，优先查询平台状态；无法查询时按平台风险策略处理。
-- 重试必须更新 `DeliveryInfo.attempts`、`next_retry_at_ms`、`last_error`。
+- 如果平台支持 client message id，应带上 BuckyOS record id 或 idempotency key。
+- 如果无法确认发送结果，返回 retryable failure；重试前可尝试用外部幂等 token 查询。
+- 如果重试可能造成重复，但平台不支持幂等，应在 `DeliveryInfo.last_error` 中记录风险，按策略进入 `FAILED/DEAD` 或等待人工确认。
 
 ### 10.3 顺序
 
-Message Tunnel 不承诺所有平台全局有序，只承诺在可得信息范围内尽量维持会话内顺序：
+Message Tunnel 只承诺同一外部会话内尽量按平台顺序提交。MessageCenter 的 `sort_key` 通常取 `MsgObject.created_at_ms`，但不应依赖它表达严格因果。需要严格线程关系时使用：
 
-- 使用平台 sequence/update id。
-- 使用平台 message timestamp。
-- 使用接收时间作为兜底。
-- 对乱序到达的消息，可以短暂 buffer；超时后按已知顺序入站。
+- `MsgObject.thread.reply_to`
+- `MsgObject.thread.correlation_id`
+- `RouteInfo.ext_ids`
+- 平台原始 sequence/cursor
 
-Agent 和 UI 不能假设所有消息严格连续，应能处理迟到消息、编辑消息和缺失消息。
+### 10.4 漏消息恢复
 
-### 10.4 遗漏恢复
+实时 webhook、stream、kevent 都只能作为加速信号，不能作为唯一真相。Tunnel 必须能通过以下方式恢复：
 
-每个 tunnel 子类应实现：
+- 入站：平台 offset/cursor、last message id、时间窗口补拉。
+- 出站：MessageCenter `TUNNEL_OUTBOX` 中 `WAIT/FAILED/SENDING` record 扫描。
+- Agent：MessageCenter inbox sweep，当前 OpenDAN pump 已遵守“kevent 是加速，不是真相源”的规则。
 
-- 启动时从 checkpoint 后恢复。
-- 定期 reconcile 最近窗口。
-- 检测 offset gap 后触发补拉或报警。
-- 无法补拉时写审计事件，避免静默遗漏。
+## 11. 流式 AI 消息
 
-## 11. 安全和权限
+流式 AI 输出和平台 typing/status/edit 能力存在冲突。通用规则：
 
-### 11.1 入站安全
+- `MsgObject` 不可变，不能把一个对象不断改写成流式 token。
+- 中间态用 `kind=Notify` 或 `kind=Event` 表示，`machine.intent` 可为 `ai.typing`、`ai.partial`、`ai.processing`。
+- 中间态必须带同一 `thread.topic` 或 `ui_session_id`，并带 `turn_nonce` 或 `correlation_id`。
+- 最终回复用完整 `kind=Chat` 或 `kind=GroupMsg`。
+- 支持编辑的平台可以由 Tunnel 把 partial notify 合并为消息编辑；不支持编辑的平台可以只展示 typing 或只发送最终回复。
 
-- Webhook 必须校验签名或 token。
-- User tunnel session 必须加密存储。
-- Bot token 不应写入普通日志。
-- 入站消息进入普通 inbox 前应经过 ContactMgr/GroupMgr 策略。
-- 低信任或未知来源可进入 `REQUEST_BOX`，等待人工确认。
+示例：
 
-### 11.2 出站安全
-
-- Agent 主动向其他会话发消息属于外部副作用，应受权限控制。
-- 代表用户发 Email、加入群聊、通知 Lark 等动作必须有可审计授权。
-- 对风险动作可先生成确认消息，由人操作控制组件确认后再出站。
-- 出站失败必须显式可见，不能静默吞掉。
-
-### 11.3 审计
-
-至少记录：
-
-- 入站事件 ID、平台、账号、会话、外部消息 ID。
-- 标准 `MsgObjectId` 和 MessageCenter `record_id`。
-- Agent 读取、处理、响应的关联 ID。
-- 出站 `record_id`、平台发送结果、外部消息 ID。
-- 权限拒绝、能力降级、未知消息、重试和最终失败。
-
-审计日志中的敏感内容应按系统日志策略脱敏。
-
-## 12. 未来兼容
-
-### 12.1 平台升级
-
-平台升级可能新增消息类型、字段、状态或限制。兼容规则：
-
-- enum 保留 `Unknown(String)` 或 `Custom(String)`。
-- payload 保留 `raw/extra`。
-- 未知消息进入可展示降级或 quarantine。
-- 未知字段忽略但尽量保留。
-- 新能力默认关闭，只有 tunnel 声明支持后才启用。
-
-### 12.2 BuckyOS 版本互通
-
-旧系统可能收到新系统产生的数据：
-
-- 新字段必须可忽略。
-- 旧系统不认识的新 `kind` 应按 `event/notify/unknown` 展示。
-- 新系统不能要求旧系统理解平台私有 extra 才能保持数据完整。
-- 破坏性协议升级必须新建版本字段或新对象类型。
-
-### 12.3 数据保护
-
-兼容失败时的优先级：
-
-1. 不宕机。
-2. 不损坏已有数据。
-3. 不误发外部消息。
-4. 不丢弃原始平台 payload。
-5. 给用户或管理员可观察错误。
-
-## 13. 典型 Tunnel
-
-### 13.1 Telegram
-
-Telegram tunnel 需要区分：
-
-- Bot API tunnel：适合公开机器人，能力受 Telegram bot 限制。
-- User session tunnel：接近自然人账号能力，但授权、安全和合规要求更高。
-
-关键字段：
-
-- `chat_id`
-- `message_id`
-- `peer_id`
-- `bot_account_id`
-- `reply_to_message_id`
-- `thread/topic id`
-- `file_id`
-
-典型能力：
-
-- 支持 1v1、群聊、附件、reply、typing、编辑消息。
-- bot 是否能读历史、主动私聊、获取成员，取决于平台权限和配置。
-- 当前实现中的 `TgTunnel` 已提供 Telegram 方向的最小运行路径。
-
-### 13.2 Lark
-
-Lark tunnel 需要保留企业和应用上下文：
-
-- `tenant_key`
-- `app_id`
-- `open_id/user_id`
-- `chat_id`
-- `message_id`
-- 卡片消息 payload
-
-典型能力：
-
-- 机器人入站/出站。
-- 富文本和卡片消息。
-- 群聊和企业权限控制。
-- 审批、投票、按钮等交互消息可映射为 operation 或降级展示。
-
-Lark 的权限边界强，缺少 scope 时应明确失败。
-
-### 13.3 Email
-
-Email tunnel 是异步消息通道，不是完整 IM：
-
-- 入站来自 IMAP、POP3、provider API 或 webhook。
-- 出站通过 SMTP 或 provider API。
-- 会话通常是 email thread。
-- 没有 typing、在线、实时已读等 IM 状态。
-
-关键字段：
-
-- mailbox/account
-- `Message-ID`
-- `In-Reply-To`
-- `References`
-- from/to/cc/bcc
-- subject
-- MIME parts
-
-降级规则：
-
-- Email HTML 可转为 `text/html` 或提取纯文本。
-- 附件导入对象存储或保留 provider attachment id。
-- 群聊语义按多收件人或 thread 表达，不强行创建 BuckyOS group。
-
-### 13.4 MessageHub
-
-MessageHub tunnel 是 BuckyOS 原生消息通道：
-
-- 参与方可直接使用 DID。
-- 消息对象可直接使用 `MsgObject`。
-- 可用于跨 Zone、Agent-to-Agent、Group-to-Group 或系统内部桥接。
-- 平台私有语义最少，但需要严格遵守 DID、MessageCenter、GroupMgr 权限模型。
-
-MessageHub tunnel 是最接近理论完整模型的实现，应作为其他平台 tunnel 的标准参照。
-
-## 14. 示例
-
-用户在机器人配置会话输入：
-
-```text
-你可以翻阅我在B站关注的主播，如果他们有内容更新就发EMAIL告诉我(email: xxx)
-你可以加入我Telegram的好友群，如果发现他们出去浪，通过Lark告诉我(ID: xxx)
+```rust
+MsgObject {
+    kind: MsgObjKind::Notify,
+    content: MsgContent {
+        format: Some(MsgContentFormat::TextPlain),
+        content: "正在处理...".to_string(),
+        machine: Some(MachineContent {
+            intent: Some("ai.processing".to_string()),
+            data: serde_json::json!({
+                "turn_nonce": "...",
+                "partial_seq": 3,
+            }),
+        }),
+        ..Default::default()
+    },
+    ..Default::default()
+}
 ```
 
-可能流程：
+## 12. 可操作和第三方应用消息
 
-1. Telegram tunnel 收到配置会话消息。
-2. MessageCenter 把消息投递给 Jarvis Agent。
-3. Agent 判断需要使用 B 站观察工具、Email tunnel、Telegram tunnel、Lark tunnel。
-4. Agent 请求或检查 owner 授权。
-5. 授权后 Agent 保存规则。
-6. 未来触发时，Agent 通过 MessageCenter `post_send` 生成 Email 或 Lark 出站消息。
-7. 对应 tunnel 从 `TUNNEL_OUTBOX` 投递并回报结果。
-8. 所有行为都能通过审计日志串联：配置消息、授权、工具运行、外部投递。
+红包、投票、小程序、审批卡片等消息不能被简单当成文本。推荐表达：
 
-## 15. 验收标准
+- `kind=Operation`。
+- `content.content` 放人类可读摘要。
+- `content.machine.intent` 放稳定操作名，例如 `wechat.red_packet`、`lark.approval_card`、`poll.vote`。
+- `content.machine.data` 放可安全理解的结构化字段。
+- 原始平台 payload 放 `MsgObject.meta.platform_raw` 或 `machine.data.raw`。
+- 需要用户或 Agent 执行动作时，动作必须经过授权检查，不能让 Tunnel 直接代替 Agent 执行高权限操作。
 
-一个 Message Tunnel 实现可以认为满足基础要求，当它能做到：
+如果 BuckyOS 当前不能理解某类操作消息，Tunnel 仍应保留摘要和 raw payload，以便未来升级后重放、查看或迁移。
 
-1. 启动、停止、重启后恢复 checkpoint。
-2. 从至少一种外部会话接收入站消息。
-3. 把入站消息转换为标准 `MsgObject` 并调用 `dispatch`。
-4. 从 `TUNNEL_OUTBOX` 拉取响应并投递回平台。
-5. 报告成功、可重试失败、最终失败。
-6. 对重复入站和重复出站保持幂等。
-7. 对未知消息保留原始数据并降级，不宕机。
-8. 声明能力，并按能力拒绝或降级不支持动作。
-9. 记录足够日志以追踪一次完整消息链路。
-10. 不强制把外部账号或会话映射为 DID。
+## 13. 可观察性
 
-完整实现还应覆盖：
+Message Tunnel 必须让以下行为可追踪：
 
-1. 附件导入和导出。
-2. 群聊和 thread/topic。
-3. 读取状态、typing、消息编辑/撤回。
-4. 可操作消息和第三方 app 消息的安全降级。
-5. AI 流式输出。
-6. 用户授权、撤销和审计。
-7. 多平台联系人绑定和路由选择。
+- 外部事件接收、去重、转换、dispatch 结果。
+- 出站 record 获取、平台 API 请求、成功、失败、重试、最终 dead。
+- Agent 由哪条入站消息触发，生成了哪条出站消息。
+- Agent 使用了哪些 tunnel、工具和授权上下文。
+- 机器人之间通信时，每条消息的 owner、route、session、turn nonce 和外部 message id。
 
-## 16. 与当前实现的关系
+推荐落点：
 
-当前代码已经具备的基础：
+- 服务日志：运行诊断。
+- `MsgRecord.delivery`：投递尝试、错误码、外部 message id。
+- `RouteInfo.ext_ids/extra`：平台 id。
+- `ui_session_id` 和 `MsgObject.thread`：会话聚合。
+- Agent worklog 或 task log：推理、工具调用和授权链路。
 
-- `src/frame/msg_center/src/msg_tunnel.rs` 定义了 `MsgTunnel` 和 `MsgTunnelInstanceMgr`。
-- `src/frame/msg_center/src/tg_tunnel.rs` 是 Telegram tunnel 实现。
-- `src/kernel/buckyos-api/src/msg_center_client.rs` 定义了 `IngressContext`、`SendContext`、`RouteInfo`、`DeliveryInfo`、`MsgRecord`、`DeliveryReportResult` 等共享类型。
-- MessageCenter 已有 `dispatch`、`post_send`、`get_next`、`report_delivery`、`set_read_state` 等接口。
+## 14. 典型 Tunnel
 
-本文建议的新增对象主要是设计层中间模型，用于让未来 Telegram/Lark/Email/MessageHub tunnel 的实现保持一致。实现时应优先复用现有类型，只有当中间模型确实能减少平台适配重复代码时再落地为共享 Rust 类型。
+### 14.1 Telegram
+
+当前实现已经是参考基线：
+
+- Bot/User 绑定通过 tunnel 配置和 ContactMgr binding 表达。
+- 入站消息转换为 `MsgObject`，`IngressContext.extra` 保存 `tg_message_id/chat_type`。
+- 附件存对象后放 `content.refs`。
+- 出站使用 `TUNNEL_OUTBOX` record 的 route 发送。
+- 支持 typing/status line，并能把 status message 替换为最终消息。
+
+主要平台裁剪：
+
+- Bot 主动联系用户受限。
+- 群、频道、私聊能力不同。
+- 某些消息类型只能保留 raw payload。
+
+### 14.2 Lark
+
+Lark tunnel 应类似 Telegram，但需保留企业租户语义：
+
+- `platform="lark"`。
+- `RouteInfo.ext_ids` 保存 `tenant_key/open_id/user_id/chat_id/message_id`。
+- Lark card、审批、投票等优先 `kind=Operation`。
+- Bot/User tunnel 差异明显，必须在 capability 和 binding 中表达。
+
+### 14.3 Email
+
+Email 更像异步消息 tunnel：
+
+- `account_id/display_id/address` 通常是 email address。
+- `chat_id` 可使用 thread id、`Message-ID` 或 normalized subject thread。
+- `reply_to`、`in-reply-to`、`references` 放 `RouteInfo.ext_ids` 或 `MsgObject.thread`。
+- 不支持 typing，已读回执不可靠。
+- 附件按对象引用；出站 MIME 构造由 Email tunnel 负责。
+
+### 14.4 MessageHub
+
+MessageHub 是 BuckyOS 原生通道：
+
+- 可尽量无损传递 `MsgObject`。
+- 外部 IM id 不存在或只是 UI session id。
+- 权限由 BuckyOS DID、ContactMgr、GroupMgr 和 RBAC 处理。
+- 适合承载用户控制组件和 Agent 配置会话。
+
+## 15. 兼容性和升级
+
+### 15.1 IM 平台升级
+
+平台新增未知消息类型时：
+
+- Tunnel 不得 panic 或退出主循环。
+- 能转换为文本摘要就用 `Chat/GroupMsg`。
+- 不能转换为文本但有操作语义就用 `Operation`。
+- 纯状态变更用 `Event/Notify`。
+- 原始 payload 放 `extra/raw`，并限制大小；过大内容写对象引用。
+
+### 15.2 BuckyOS 新旧版本互通
+
+规则：
+
+- 新字段必须 optional 或有 default。
+- 枚举扩展时旧系统可能无法反序列化；跨版本高风险枚举应优先用 string intent 或 `extra` 承载。
+- `meta/extra/ext_ids` 只能追加，旧实现忽略未知 key。
+- 不改变 `MsgObject` 已有字段语义，否则会改变 `ObjId` 和历史对象校验。
+- `MsgRecord` 可做 additive schema 升级，但状态机语义必须保持兼容。
+
+### 15.3 降级策略
+
+当新能力不可用：
+
+- 消息编辑降级为新消息或状态消息。
+- typing 降级为无操作。
+- read receipt 降级为本地 read state。
+- operation 降级为文本摘要 + raw payload。
+- 附件上传失败返回 retryable failure；不应静默丢弃。
+
+## 16. 需要或可能需要的扩展
+
+当前对象基本能表达 Message Tunnel 的完整主流程。建议扩展仅限以下场景：
+
+1. **Tunnel capability**：用于管理界面、路由策略和平台裁剪。当前只有 `supports_ingress/egress`，不够表达 edit、typing、attachment、operation、proactive message 等能力。
+2. **Account kind**：Bot/User/System 影响平台行为和权限边界。当前可先放 `AccountBinding.meta.account_kind`，未来需要强类型时再升级。
+3. **流式消息约定**：不需要改 `MsgObject`，但需要约定 `machine.intent`、`turn_nonce`、`ui_session_id` 的使用方式。
+4. **外部 raw payload 大对象化**：当平台 payload 很大时，需要明确存对象并以 `refs` 或 `meta.raw_obj_id` 引用，避免 record/meta 膨胀。
+
+不建议的扩展：
+
+- 为每个平台新增独立 message object。
+- 把所有外部平台对象都封装成 DID。
+- 在 `MsgObject` 中写入可变投递状态。
+- 让 Agent 直接依赖 Telegram/Lark/Email 专用结构。
+
+## 17. 验收标准
+
+- 任一 Tunnel 能把入站消息转换为 `MsgObject + IngressContext + idempotency_key` 并 dispatch。
+- Agent 能在不知道平台细节的情况下消费消息。
+- Agent 或控制组件通过 `post_send()` 生成响应后，Tunnel 能从 `TUNNEL_OUTBOX` 投递回外部会话。
+- 外部账号 id、chat id、message id 能保持平台原始语义，不被强制 DID 化。
+- 群聊、1v1、子线程、机器人会话均有可表达路径。
+- 文本、附件、状态、操作消息、未知消息、流式 AI 中间态均有降级策略。
+- 重复入站、重复出站、服务重启不会造成不可控重复投递。
+- 平台升级或 BuckyOS 新旧版本互通不会因未知字段导致宕机或数据损坏。

--- a/doc/message_hub/Message Tunnel Minimal Spec.md
+++ b/doc/message_hub/Message Tunnel Minimal Spec.md
@@ -1,287 +1,211 @@
 # Message Tunnel Minimal Spec
 
-本文是给 Agent/codegen 使用的最小实现规格。详细设计见 `Message Tunnel Design.md`。
+本文档给代码生成 Agent 使用，只保留实现 Message Tunnel 所需的最小协议约束。详细设计、边界和兼容性说明见 `doc/message_hub/Message Tunnel Design.md`。
 
 ## 1. 定义
 
-Message Tunnel 是外部 IM 系统与 BuckyOS MessageCenter 之间的会话级双向适配层。它代表某个平台上的一个特定账号或访问通道，负责：
+Message Tunnel 是外部 IM 会话和 BuckyOS MessageCenter 之间的适配器。它代表某个外部平台账号或系统入口收发消息：
 
-1. 从外部 IM 会话接收消息、会话状态和平台事件。
-2. 尽量保留外部 IM 原始语义，把可标准化内容转换为 BuckyOS `MsgObject`。
-3. 调用 MessageCenter `dispatch(msg, ingress_ctx)`，把入站消息交给目标 Agent、人操作的控制组件或其他系统组件。
-4. 从 MessageCenter 的 `TUNNEL_OUTBOX` 拉取响应消息。
-5. 按平台规则把响应投递回来源 IM 会话或指定外部目标。
-6. 调用 `report_delivery()` 回报外部消息 ID、成功、失败、重试和错误。
+1. 入站：从外部 IM 获取消息、会话事件和平台状态，转换为 `MsgObject`，携带 `IngressContext` 调用 `MsgCenter.dispatch()`。
+2. 出站：从 MessageCenter 的 `TUNNEL_OUTBOX` 拉取 `MsgRecordWithObject`，转换为外部 IM API 调用，发送完成后调用 `MsgCenter.report_delivery()`。
+3. Tunnel 不负责 Agent 推理，也不负责响应消息生成。Agent、控制组件或其他系统服务处理消息后，通过 `MsgCenter.post_send()` 生成出站投递任务。
 
-Message Tunnel 不负责 Agent 如何思考、如何保存响应、如何调用工具。Agent 生成响应后，应通过 MessageCenter `post_send(msg, send_ctx)` 或等价接口进入出站流程。
+Message Tunnel 必须尽量保留外部平台原始语义，但不能把平台私有对象强行提升为 BuckyOS DID。外部 user id、chat id、message id 可以只是 `String`，通过 `RouteInfo`、`IngressContext.extra`、`MsgObject.meta` 或 `MsgContent.machine` 保留。
 
-## 2. 边界
+## 2. 复用现有类型
 
-Message Tunnel 必须做：
+不要重新定义以下基础类型，只引用当前实现：
 
-- 平台连接、认证、收发消息。
-- 入站去重、顺序恢复、断点续拉。
-- 外部会话、用户、消息、附件、状态事件到标准 envelope 的转换。
-- 构造 `IngressContext`、`RouteInfo` 和 `DeliveryReportResult`。
-- 能力裁剪：机器人账号、自然人账号、Email、MessageHub 等平台能力不同，不能假装支持不存在的动作。
-- 审计日志：至少记录入站、出站、失败、重试、权限裁剪和未知消息降级。
+- `ndn_lib::MsgObject`：不可变消息对象，使用 canonical JSON 生成 `ObjId`。
+- `ndn_lib::MsgContent`：消息内容，含 `format/content/machine/refs`。
+- `ndn_lib::MsgObjKind`：当前包括 `chat/group_msg/deliver/notify/event/operation`。
+- `buckyos_api::IngressContext`：入站来源上下文。
+- `buckyos_api::SendContext`：出站发送偏好。
+- `buckyos_api::RouteInfo`：record 级投递路径和外部 id。
+- `buckyos_api::MsgRecord` / `MsgRecordWithObject`：某个 owner box 中对 `MsgObject` 的可变视图。
+- `buckyos_api::BoxKind`：`INBOX/OUTBOX/GROUP_INBOX/TUNNEL_OUTBOX/REQUEST_BOX`。
+- `buckyos_api::MsgState`：`UNREAD/READING/READED/WAIT/SENDING/SENT/FAILED/DEAD/DELETED/ARCHIVED`。
+- `buckyos_api::DeliveryReportResult`：Tunnel 出站投递结果。
 
-Message Tunnel 不应做：
-
-- 不应绕过 MessageCenter 直接写 Agent 会话。
-- 不应要求所有外部账号强制映射为 BuckyOS DID。
-- 不应把平台私有字段扩散成 BuckyOS 基础类型。
-- 不应在无法理解新平台消息时宕机或损坏已有状态。
-
-## 3. 已有基础类型
-
-下面类型已经由 BuckyOS 或 NDN 层定义，实现时复用，不在本文重新定义：
-
-- `DID`
-- `ObjId`
-- `MsgObject`
-- `MsgContent`
-- `MsgObjKind`
-- `RefItem`
-- `BoxKind`
-- `MsgState`
-- `IngressContext`
-- `SendContext`
-- `RouteInfo`
-- `DeliveryInfo`
-- `MsgRecord`
-- `MsgRecordWithObject`
-- `DeliveryReportResult`
-- `MsgTunnel`
-- `MsgTunnelInstanceMgr`
-
-如果实现发现这些类型不能表达必要语义，先在详细设计文档中说明升级原因，再修改共享类型、前后端和文档。
-
-## 4. 核心对象
+当前通用 tunnel trait 已存在：
 
 ```rust
-/// 外部平台类型。`Custom` 用于新平台，避免因为未知平台导致反序列化失败。
-pub enum TunnelPlatform {
-    Telegram,
-    Lark,
-    Email,
-    MessageHub,
-    Custom(String),
-}
+#[async_trait]
+pub trait MsgTunnel: Send + Sync {
+    /// Tunnel 自身 DID，用作 TUNNEL_OUTBOX owner 和 RouteInfo.tunnel_did。
+    fn tunnel_did(&self) -> DID;
 
-/// 账号运行形态。不同平台对 bot 和 user 的 API 限制不同。
-pub enum TunnelAccountKind {
+    /// 人类可读名称，用于日志、配置和管理界面。
+    fn name(&self) -> &str;
+
+    /// 平台标识，例如 "telegram"、"lark"、"email"、"messagehub"。
+    fn platform(&self) -> &str;
+
+    /// 是否接收入站消息。Email outbound-only tunnel 可返回 false。
+    fn supports_ingress(&self) -> bool { true }
+
+    /// 是否支持出站投递。Webhook ingress-only tunnel 可返回 false。
+    fn supports_egress(&self) -> bool { true }
+
+    /// 启动外部连接、轮询、webhook server 或 stream consumer。
+    async fn start(&self) -> AnyResult<()>;
+
+    /// 停止外部连接并释放后台任务。
+    async fn stop(&self) -> AnyResult<()>;
+
+    /// 发送一个 TUNNEL_OUTBOX record，并返回外部平台投递结果。
+    async fn send_record(&self, record: MsgRecordWithObject) -> AnyResult<DeliveryReportResult>;
+}
+```
+
+## 3. 推荐新增的通用概念
+
+这些是设计概念，不要求立刻改协议对象；能用现有字段表达时优先组合现有字段。
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageTunnelAccountKind {
+    /// 平台机器人账号。通常受平台 Bot API 能力限制。
     Bot,
+    /// 平台自然人账号或用户授权账号。可能能执行更多真实用户行为。
     User,
+    /// BuckyOS 内部 MessageHub 或系统入口。
     System,
 }
 
-/// 单个 tunnel 实例的能力声明。MessageCenter 和 UI 只能使用这里声明为 true 的能力。
-pub struct TunnelCapability {
-    pub ingress: bool,             // 是否能接收入站消息。
-    pub egress: bool,              // 是否能发送出站消息。
-    pub edit_message: bool,        // 是否能编辑已发消息。
-    pub delete_message: bool,      // 是否能删除或撤回消息。
-    pub reaction: bool,            // 是否支持 reaction。
-    pub read_receipt: bool,        // 是否能读取或发送已读状态。
-    pub typing: bool,              // 是否能读取或发送正在输入。
-    pub group_chat: bool,          // 是否支持群聊。
-    pub sub_conversation: bool,    // 是否支持 thread、topic、群内临时议题。
-    pub attachments: bool,         // 是否支持附件入站/出站。
-    pub interactive_message: bool, // 是否支持红包、投票、小程序等可操作消息。
-    pub streaming: bool,           // 是否支持 AI 流式输出或平台流式更新。
-}
-
-/// 外部账号引用。它保持平台原始语义，不强制映射为 DID。
-pub struct ExternalAccountRef {
-    pub platform: TunnelPlatform,
-    pub account_id: String,        // 平台账号 ID、邮箱地址或 MessageHub entity key。
-    pub display_id: Option<String>,
-    pub display_name: Option<String>,
-    pub account_kind: Option<TunnelAccountKind>,
-}
-
-/// 外部会话引用。它是平台侧概念，不要求在 BuckyOS 中存在对应对象。
-pub struct ExternalConversationRef {
-    pub platform: TunnelPlatform,
-    pub conversation_id: String,       // chat_id、channel_id、thread id、mailbox/thread id 等。
-    pub parent_conversation_id: Option<String>,
-    pub conversation_kind: ExternalConversationKind,
-    pub title: Option<String>,
-}
-
-pub enum ExternalConversationKind {
-    Direct,
-    Group,
-    SubConversation,
-    Channel,
-    EmailThread,
-    System,
-    Unknown(String),
-}
-
-/// 入站事件标准 envelope。具体 tunnel 先构造它，再转换为 MsgObject 或状态更新。
-pub struct TunnelIngressEvent {
-    pub event_id: String,              // 平台事件唯一 ID；没有时由 tunnel 派生。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageTunnelBinding {
+    /// MessageCenter / ContactMgr 中的 owner 或 agent DID。
+    pub owner_did: DID,
+    /// 使用此绑定的 tunnel DID。
     pub tunnel_did: DID,
-    pub platform: TunnelPlatform,
-    pub account: ExternalAccountRef,   // tunnel 使用的本方平台账号。
-    pub conversation: ExternalConversationRef,
-    pub sender: ExternalAccountRef,
-    pub occurred_at_ms: u64,
-    pub payload: TunnelPayload,
-    pub raw: serde_json::Value,        // 原始平台数据，尽量保留但不进入核心业务判断。
-}
-
-pub enum TunnelPayload {
-    Message(TunnelMessage),
-    ConversationEvent(TunnelConversationEvent),
-    MessageState(TunnelMessageStateEvent),
-    CapabilityEvent(TunnelCapabilityEvent),
-    Unknown(serde_json::Value),
-}
-
-pub struct TunnelMessage {
-    pub external_message_id: String,
-    pub kind: TunnelMessageKind,
-    pub parts: Vec<TunnelMessagePart>,
-    pub reply_to: Option<String>,
-    pub mentions: Vec<TunnelMention>,
-    pub stream: Option<TunnelStreamInfo>,
+    /// 外部平台名。
+    pub platform: String,
+    /// 外部账号 id。保持平台原始字符串语义。
+    pub account_id: String,
+    /// 平台展示 id 或可路由地址，例如 email address、open_id、chat_id。
+    pub display_id: String,
+    /// bot/user/system。
+    pub account_kind: MessageTunnelAccountKind,
+    /// 平台扩展信息，只能追加字段，旧实现忽略未知 key。
     pub extra: serde_json::Value,
 }
-
-pub enum TunnelMessageKind {
-    Text,
-    RichText,
-    Media,
-    Attachment,
-    Reaction,
-    Interactive,
-    AppDependent,
-    AiStreamDelta,
-    AiStreamComplete,
-    Unknown(String),
-}
-
-pub enum TunnelMessagePart {
-    Text { text: String },
-    RichText { format: String, content: String },
-    Emoji { code: String, text: Option<String> },
-    Attachment { object_ref: Option<ObjId>, uri_hint: Option<String>, name: Option<String>, mime: Option<String>, size: Option<u64> },
-    PlatformObject { object_type: String, payload: serde_json::Value },
-    Unknown { payload: serde_json::Value },
-}
 ```
 
-## 5. 入站流程
+## 4. 入站转换规则
 
-```mermaid
-flowchart TD
-    A[External IM event] --> B[Tunnel receive loop]
-    B --> C[Build TunnelIngressEvent]
-    C --> D{Duplicate event?}
-    D -- yes --> Z[ack or skip]
-    D -- no --> E{Payload type}
-    E -- message --> F[Normalize to MsgObject]
-    E -- conversation state --> G[Map to notify/event MsgObject or UI session state]
-    E -- unknown --> H[Quarantine or Unknown message]
-    F --> I[Build IngressContext]
-    G --> I
-    H --> I
-    I --> J[MessageCenter.dispatch]
-    J --> K[Persist ingress checkpoint and audit]
-```
-
-实现要点：
-
-- `event_id` 用于 tunnel 自己去重；`MsgObject` 自身仍由 canonical object id 保证语义幂等。
-- `IngressContext.extra` 保存平台必要上下文，如原始 chat_id、message_id、thread_id、sender account、bot account、平台能力版本。
-- 外部发送者没有 DID 时，不要伪造 DID。可用 ContactMgr 自动推断联系人，或仅把外部账号放入 `RouteInfo`/metadata。
-- 未知消息转换为 `MsgObjKind::Event` 或 `MsgObjKind::Notify`，内容里说明不支持的类型，原始数据放 `extra`，避免丢失。
-
-## 6. 出站流程
-
-```mermaid
-flowchart TD
-    A[Agent/User/System] --> B[MessageCenter.post_send]
-    B --> C[Create owner OUTBOX]
-    C --> D[Create TUNNEL_OUTBOX]
-    D --> E[Tunnel egress worker get_next]
-    E --> F[Resolve RouteInfo]
-    F --> G[Render platform message]
-    G --> H{Platform send ok?}
-    H -- yes --> I[report_delivery ok with external_msg_id]
-    H -- retryable failure --> J[report_delivery retryable]
-    H -- final failure --> K[report_delivery failed/dead]
-```
-
-实现要点：
-
-- 出站必须从 `MsgRecord.route` 读取 `tunnel_did/platform/account_id/chat_id/address/ext_ids`。
-- 缺少必要路由信息时返回明确失败，不静默丢弃。
-- 平台不支持的功能要降级：富文本可降为纯文本，附件可降为链接，交互消息可降为说明文本。
-- 流式响应可以使用平台支持的编辑消息、typing/status 或多条 delta 消息；不支持流式的平台只发送最终消息。
-
-## 7. 标准映射
-
-| 外部语义 | BuckyOS 表达 |
-|---|---|
-| 普通文本/富文本/表情 | `MsgObject.kind=chat`，`MsgContent.format/content`，必要时保留 `extra` |
-| 附件/图片/文件 | `MsgContent.refs` 指向对象；无法导入时保留平台 URI hint |
-| 回复/引用 | `MsgObject.thread.reply_to` 或 `thread.correlation_id` |
-| @mention | `content.machine.data.mentions` 或 `meta.mentions`，保留原始平台符号 |
-| 新成员、退群、禁言、屏蔽、授权 | `MsgObjKind::Event` 或 `Notify` |
-| 已读、正在输入、消息状态 | 优先写 `MsgReceiptObj` 或 `ui_session_states`；也可转成状态通知 |
-| 红包、投票、小程序等可操作消息 | `TunnelMessageKind::Interactive/AppDependent`，能执行才映射成 operation，否则降级展示 |
-| AI stream delta | 平台支持时编辑/流式发送；BuckyOS 内部用 session state 或增量消息表达 |
-
-## 8. 典型 Tunnel 子类
+### 4.1 外部消息到 MsgObject
 
 ```rust
-pub trait MessageTunnel: Send + Sync {
-    fn tunnel_did(&self) -> DID;
-    fn platform(&self) -> TunnelPlatform;
-    fn account_kind(&self) -> TunnelAccountKind;
-    fn capability(&self) -> TunnelCapability;
-
-    async fn start(&self) -> anyhow::Result<()>;
-    async fn stop(&self) -> anyhow::Result<()>;
-
-    async fn pull_or_receive(&self) -> anyhow::Result<Vec<TunnelIngressEvent>>;
-    async fn handle_ingress(&self, event: TunnelIngressEvent) -> anyhow::Result<()>;
-    async fn send_record(&self, record: MsgRecordWithObject) -> anyhow::Result<DeliveryReportResult>;
+pub struct IngressEnvelope {
+    /// 外部平台名。
+    pub platform: String,
+    /// 当前 tunnel DID。
+    pub tunnel_did: DID,
+    /// 外部发送者账号 id，保留原始字符串。
+    pub source_account_id: String,
+    /// 外部会话 id，保留原始字符串。
+    pub chat_id: String,
+    /// 外部消息 id 或事件 id，用于幂等。
+    pub external_event_id: String,
+    /// 标准化后的 BuckyOS 消息。
+    pub msg: MsgObject,
+    /// 入站上下文。
+    pub ingress_ctx: IngressContext,
+    /// 幂等 key，必须稳定。
+    pub idempotency_key: String,
 }
-
-pub struct BotMsgTunnel<T> { pub inner: T }
-pub struct UserMsgTunnel<T> { pub inner: T }
-
-pub struct TelegramMsgTunnel;
-pub struct LarkMsgTunnel;
-pub struct EmailMsgTunnel;
-pub struct MessageHubTunnel;
 ```
 
-子类要求：
+映射要求：
 
-- Telegram：区分 Bot API 和 User API 能力；群聊、reply、附件、typing、编辑消息能力由实际 gateway 声明。
-- Lark：优先保留 tenant、open_id、chat_id、message_id、卡片消息；企业权限限制必须显式失败。
-- Email：按 mailbox/thread/message-id 工作；没有在线状态、typing、已读实时语义；出站要支持纯文本/HTML/附件。
-- MessageHub：BuckyOS 原生 tunnel，可直接使用 DID/MsgObject，主要用于跨 Zone 或内部会话桥接。
+- 1v1 普通消息：`kind=Chat`，`from=sender_did`，`to=[target_agent_or_user_did]`。
+- 群聊消息：`kind=GroupMsg`，`from=sender_did`，`to=[group_did]`。当前 MessageCenter 以 `to.first()` 作为 group DID，旧数据 fallback 到 `from`。
+- 会话状态、成员变更、typing、已读等：优先 `kind=Event` 或 `kind=Notify`，结构化部分放 `content.machine`。
+- 可操作消息、红包、投票、小程序等：优先 `kind=Operation`，`content.machine.intent` 表达操作类型，无法理解的原始 payload 放 `meta` 或 `machine.data.raw`。
+- 附件和媒体：小文本可放 `content.content`；大对象必须写入对象存储后用 `content.refs` 引用。
+- 平台原始 id：放 `IngressContext`、`RouteInfo.ext_ids`、`MsgObject.meta`，不要污染 `from/to`。
+
+### 4.2 入站流程
+
+```mermaid
+flowchart TD
+    IM[External IM Session] --> T[Message Tunnel]
+    T --> C{Normalize}
+    C --> M[MsgObject + IngressContext + idempotency_key]
+    M --> D[MsgCenter.dispatch]
+    D --> B[INBOX / GROUP_INBOX / REQUEST_BOX]
+    B --> A[Agent / User Control Component / Other Consumer]
+```
+
+## 5. 出站转换规则
+
+MessageCenter 已经通过 `post_send()` 生成 `TUNNEL_OUTBOX` record。Tunnel 只消费自己的 outbox。
+
+```rust
+pub struct EgressEnvelope {
+    /// 待发送 record，用于状态回报。
+    pub record_id: String,
+    /// 标准消息对象。
+    pub msg: MsgObject,
+    /// 出站路由，来自 MsgRecord.route。
+    pub route: RouteInfo,
+    /// 外部目标地址，通常来自 route.address/chat_id/account_id。
+    pub external_target: String,
+}
+```
+
+出站要求：
+
+- `route.tunnel_did` 必须等于当前 tunnel DID。
+- `route.platform/account_id/address/chat_id/ext_ids` 是投递主要依据。
+- `send_record()` 成功必须返回 `DeliveryReportResult { ok: true, external_msg_id, delivered_at_ms, ... }`。
+- 可重试失败返回 `ok=false, retryable=true, retry_after_ms`。
+- 不可重试失败返回 `ok=false, retryable=false, error_code/error_message`。
+- Tunnel 不直接更新 record state，统一由 egress worker 调用 `MsgCenter.report_delivery()`。
+
+### 5.1 出站流程
+
+```mermaid
+flowchart TD
+    A[Agent / User / Service] --> P[MsgCenter.post_send]
+    P --> O[Owner OUTBOX]
+    P --> TQ[TUNNEL_OUTBOX owner=tunnel_did]
+    TQ --> W[MsgCenter egress worker]
+    W --> T[Message Tunnel.send_record]
+    T --> IM[External IM Session]
+    T --> R[DeliveryReportResult]
+    R --> D[MsgCenter.report_delivery]
+```
+
+## 6. 顺序、幂等、遗漏
+
+- 入站幂等 key：`{platform}:{tunnel_account}:{chat_id}:{external_message_id}`。没有 message id 时用平台事件时间、nonce 和 payload hash 组合。
+- 出站幂等：`MsgObjectId + tunnel_did + target + route.mode` 应映射为同一 `TUNNEL_OUTBOX` record。
+- 顺序：同一外部会话内应尽量按平台消息序号或时间递增提交；跨会话不保证全局顺序。
+- 重复：MessageCenter 以 `MsgObjectId`、record id 和显式 idempotency key 去重；Tunnel 仍要避免重复提交。
+- 漏消息：Tunnel 重启后必须从平台 offset/cursor 或 MessageCenter outbox 恢复；实时通知只能作为提示，不能作为唯一真相。
+
+## 7. 流式 AI 消息
+
+对接聊天 AI 时，流式 token 不应直接破坏 `MsgObject` 不可变语义。推荐：
+
+- 中间态：发送 `kind=Notify` 或 `kind=Event`，用相同 `thread.topic/ui_session_id` 和 `content.machine.data.turn_nonce` 标识同一轮。
+- 最终态：发送一个完整 `kind=Chat` 或 `kind=GroupMsg` 回复。
+- 支持消息编辑的平台可由具体 Tunnel 把中间态合并成编辑操作；不支持编辑的平台可降级为状态消息或只发送最终消息。
+
+## 8. 典型 Tunnel 裁剪
+
+- Telegram：Bot tunnel 已实现基础形态；支持 bot 账号入站/出站、typing/status line、附件引用。平台限制由 `TgTunnel` 内裁剪。
+- Lark：同 Telegram，需额外处理企业租户、open_id/user_id/chat_id 的原始语义。
+- Email：通常是 UserMsgTunnel 或 System tunnel；`chat_id` 可映射为 thread id/message-id；typing/已读通常不支持。
+- MessageHub：BuckyOS 原生 tunnel；应尽量无损保留 `MsgObject`，不需要把外部平台 id 映射成 DID。
 
 ## 9. 兼容性规则
 
-- 所有 enum 必须保留 `Unknown(String)` 或 `Custom(String)`。
-- 所有平台原始 payload 必须作为可选 `extra/raw` 保存，不能成为核心逻辑必需字段。
-- 新字段只能 additive；旧实现看到未知字段应忽略、保留或降级展示。
-- 无法识别的新消息类型进入 quarantine/request box/notify，不得导致进程崩溃。
-- 发送失败要可观察：`DeliveryReportResult` 必须包含错误码或错误文本。
-
-## 10. 最小验收
-
-- 能从一个外部会话收消息并 `dispatch` 到目标 Agent。
-- Agent 通过 MessageCenter 生成回复后，tunnel 能从 `TUNNEL_OUTBOX` 投递回来源会话。
-- 重复入站事件不会产生重复用户可见消息。
-- 出站重试不会重复发送已成功消息。
-- 平台未知消息能被保留或降级，不会丢状态或宕机。
-- 日志能追踪一次消息从平台入站到 Agent，再从 Agent 出站到平台的完整链路。
+- 未知 `MsgObjKind`、`content.format`、`machine.intent`、`meta` key：必须保留或忽略，不能 panic。
+- 未知外部消息类型：降级为 `kind=Event` 或 `kind=Operation`，原始 payload 放 `extra/raw`。
+- 旧系统收到新字段：依赖 serde default/skip 规则忽略未知字段。
+- 新系统读取旧 record：按当前实现保留 group DID fallback。
+- 不允许因单条消息解析失败导致 tunnel 主循环退出；应记录日志并跳过或投递到 `REQUEST_BOX`。


### PR DESCRIPTION
## 意图

本 PR 定义一个理论上完整的 Message Tunnel 设计，同时明确约束：尽量复用当前已有的 `MsgCenter` / `RouteInfo` / `MsgObject` / `MsgRecord` / `MsgTunnel` 实现模型，不为每个平台另起一套消息协议。

设计目标：

- 尽量复用已有 BuckyOS 消息对象、路由记录、联系人绑定和 tunnel outbox 机制。
- 尽量完整支持 IM 系统的全部实际能力，包括文本、富文本、附件、引用、@、会话事件、成员变更、在线/离线、禁言/屏蔽、授权、已读、typing、可操作消息、第三方应用消息、AI 流式状态、1v1 会话、群聊和群内子议题会话。
- 对未来 IM 平台或 BuckyOS 新版本产生的未知消息提供保底降级：保留平台原始语义，降级为可展示的 `Event` / `Operation` / `Notify`，避免旧系统收到新数据时宕机或损坏数据。

## 变更内容

- 填充 `doc/message_hub/Message Tunnel Minimal Spec.md`：面向代码生成 Agent 的最小规格。
- 填充 `doc/message_hub/Message Tunnel Design.md`：面向人类 review 的完整设计说明。
- 说明设计如何映射到当前实现：`MsgObject`、`IngressContext`、`RouteInfo`、`AccountBinding`、`MsgRecordWithObject`、`MsgTunnel`、Telegram tunnel 和 `TUNNEL_OUTBOX`。
- 定义 Bot/User/System 账号类型、Tunnel binding、入站/出站 envelope、Tunnel capability 等设计层概念，并明确这些概念优先作为现有对象组合语义，不要求立即引入协议破坏性变更。

## 验证

- 纯文档变更。
- 已对两份修改的 Markdown 文档运行 `git diff --check`。

## 原始提示词

```text
基于当前的实现方案，定义一个理论上完整的Message Tunnel，并生成文档：

下面是对Message Tunnel的简要定义：
	流程:
		1. 从IM会话中获取各种消息
		2. 经MsgCenter转给由消息指定的目标智能体(Agent/由人操作的控制组件/其他)
		3. 目标智能体阅读处理后把生成的响应消息按规则存储或者投递到MsgCenter(这步不需要Message Tunnel参与)
		4. 响应消息再经Message Tunnel从MsgCenter取出并投递给消息的来源IM会话

	消息(或响应消息)包括但不限于：
	1. 各种用于沟通的文本/符号/表情/富文本/引用消息/附件等消息
	2. @等特殊含义字符(@只是一个代表，不同平台的字符可能不同，也可能还有其他类似功能符号)
	3. 各种会话状态，新加入/退出一个会话，会话加入/退出其他新成员，成员上线/下线，禁言/屏蔽，授权，消息状态(新消息/已读等)，正在输入等
	4. 特殊可操作消息，例如：微信红包...
	5. 依赖第三方应用的消息，比如：微信小程序，投票，等...
	6. 如果MessageTunnel对接聊天AI，可能会接收/返回AI的流式消息
	7. 其他待补充

	会话:
	1. 1v1会话
	2. 多人会话
	3. 群聊里的子群，通常是群内部分成员就一个议题发起的临时会话
	4. 这里的人可以是自然人，也可以是机器人，群聊也可以是一群机器人的聊天

	Agent: 
	1. 一个人工智能驱动的机器人
	2. 如果IM系统对机器人没有任何限制，他应该能完成一个真实自然人在会话中完成的一切行为，这是通用Message Tunnel的最大功能集
	3. 如果特定IM系统对机器人有行为限制，在对应特定Message Tunnel子类中予以裁剪
	4. 除了聊天，它也应该能按规则使用各种授予他使用的工具：
		* 给特定人发送email
		* 向其他会话发送消息
		* 其他待补充
	5. Agent的行为应该有日志跟踪增加可观测性，否则一群机器人聊天无法被感知
	
比如，在机器人的配置会话窗口输入:
	你可以翻阅我在B站关注的主播，如果他们有内容更新就发EMAIL告诉我(email: xxx)
	你可以加入我Telegram的好友群，如果发现他们出去浪，通过Lark告诉我(ID: xxx)


	IM:
	对于IM系统来说，Message Tunnel是IM系统中一个特定用户收发消息的一个通道，按用户种类分为机器人和自然人，各平台对它们的处理可能有差异(甚至不支持)，大多数时候应该分成两个子类(BotMsgTunnel/UserMsgTunnel)来支持
	

	其他实现上的细节，比如：消息顺序性，消息去重和遗漏等
	设计原则上基于当前MsgCenter/RouteInfo/MsgObject等的实现：
	1. 如果现有对象已经能够表达，尽量用已有对象组合，不要新增设计
	2. 如果现有对象不能表达，或者需要优化，说明理由

几个典型Message Tunnel：
1. Telegram
2. Lark
3. EMail
4. MessageHub

文档内容约束：
1. 用自然语言准确描述其定义和功能集
2. 以程序设计的方式定义关键对象和流程，以rust风格定义
3. 对象/enum定义属性/方法应该标注说明
4. 流程描述除了自然语言准确描述外，再配上流程图
5. 外部IM系统范围的对象应该能保持原有语义，它们可能能并且需要被封装或映射成BuckyOS系统里类似DID的语义，也可能不能或者不必封装
	* 比如，IM系统的用户账号ID，它就是一个字符串，可能对应BuckyOS系统中的一个Agent，但也可能是消息的发出者，并不能在BuckyOS系统中找到一个匹配对象，仅仅用它作为消息的来源标识和响应消息接收方标识，是IM系统里的概念，不必强行在BuckyOS里封装或者映射成一个对象，除非有必要；
	* 当然，DID本身也是一个字符串，这里的用户ID的字符串可以很方便地用DID表达，也可以保留DID类型，这里强调的意思是“不强求”，避免遇到更复杂对象时引入多余的复杂度
6. BuckyOS系统内定义的基础类型，可以添加说明，不要另行定义，避免造成冲突；如果需要对基础类型升级，需要明确说明原因，并把列出新的定义
7. 保持对未来升级的兼容性，可以选择兼容、提示等，应避免出现宕机甚至损坏数据的灾难性结果
	* IM平台升级可能带来未知的内容
	* 其他用户升级了BuckyOS系统，旧系统可能会从这个用户接收更新的数据
8. 文档分两份，一份书写最简要内容，用来给agent生成代码，另一份书写详细说明，用来给人类review其设计细节
```