### PR TITLE
Fix node_active install path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ doc/local
 src/kernel/node_active/dist/
 src/kernel/buckyos_sdk/dist/
 src/kernel/task_manager/tasks.db
-src/rootfs/bin/node-active/
+src/rootfs/bin/node-active/*
+!src/rootfs/bin/node-active/README.md
 src/rootfs/bin/cyfs-gateway/cyfs_gateway
 src/rootfs/bin/scheduler/scheduler
 src/rootfs/bin/system-config/system_config

--- a/src/bucky_project.yaml
+++ b/src/bucky_project.yaml
@@ -35,7 +35,7 @@ modules:
     name: buckycli
   node_active:
     type: web
-    name: node_active
+    name: node-active
     src_dir: kernel/node_active/
   control_panel:
     type: rust

--- a/src/buckyos-build.py
+++ b/src/buckyos-build.py
@@ -11,6 +11,12 @@ from pathlib import Path
 
 DEVKIT_SPEC = "buckyos-devkit @ git+https://github.com/buckyos/buckyos-devkit.git"
 
+SKIPPED_WEB_ROOTFS_DIRS = (
+    Path("rootfs/bin/node-active"),
+    Path("rootfs/bin/buckyos_systest"),
+    Path("rootfs/bin/control-panel/web"),
+)
+
 
 def _command_names(command: str) -> list[str]:
     if os.name == "nt":
@@ -239,6 +245,16 @@ def _run_command(command: str, args: list[str], env: dict[str, str] | None = Non
     return result.returncode
 
 
+def _has_skip_web(args: list[str]) -> bool:
+    return "--skip-web" in args
+
+
+def _ensure_skipped_web_rootfs_dirs() -> None:
+    src_dir = Path(__file__).resolve().parent
+    for relative_dir in SKIPPED_WEB_ROOTFS_DIRS:
+        (src_dir / relative_dir).mkdir(parents=True, exist_ok=True)
+
+
 def main() -> int:
     print("!!! buckyos depend on cyfs-gateway, MAKE SURE YOU HAVE BUILD IT FIRST!", flush=True)
     env = _build_env(sys.argv[1:])
@@ -247,6 +263,9 @@ def main() -> int:
     if result != 0:
         print(f"buckyos-build failed with return code {result}")
         return result
+
+    if _has_skip_web(sys.argv[1:]):
+        _ensure_skipped_web_rootfs_dirs()
 
     result = _run_command("buckyos-update", [], env=env)
     if result != 0:

--- a/src/kernel/node_active/package.json
+++ b/src/kernel/node_active/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node_active",
+  "name": "node-active",
   "version": "1.0.0",
   "description": "",
   "main": "index.html",

--- a/src/rootfs/bin/node-active/README.md
+++ b/src/rootfs/bin/node-active/README.md
@@ -1,0 +1,1 @@
+node-active web build output is copied here during full web builds.


### PR DESCRIPTION
## 更新意图

统一 `node_active` web 模块的构建产物名、安装路径和运行时路径，让它和其他 rootfs `bin/<module-name>/` 模块保持一致的 kebab-case 风格：`bin/node-active/`。

这次问题包含两层：

1. `node_active` 的源码目录和配置键使用下划线命名，但 rootfs 安装清单、`node_daemon` 运行时路径和 `make_config.py` 配置生成路径都使用 `bin/node-active/`。因此模块构建产物名也应统一为 `node-active`。
2. `src/buckyos-build.py --skip-web` 会跳过 web 构建，但随后仍会执行 `buckyos-update`。fresh clone 场景下 `src/rootfs/bin/node-active/` 没有实际 web 构建产物目录，update 阶段复制目录时会失败。

本 PR 做了以下调整：

- 将 `node_active` web 模块的构建产物名改为 `node-active`。
- 将 `src/kernel/node_active/package.json` 的 package name 改为 `node-active`。
- 保持 `bucky_project.yaml` 的模块 key 为 `node_active`，源码目录仍为 `kernel/node_active/`，只统一对外 rootfs/package 名称。
- 在 `src/rootfs/bin/node-active/` 增加轻量 README 占位文件，让 fresh clone 后目录存在。
- 调整 `.gitignore`，继续忽略 `node-active` 的实际 web 构建产物，但允许提交占位 README。
- 在 `src/buckyos-build.py --skip-web` 构建成功后补齐缺失的 web rootfs 目录，避免 `buckyos-update` 在复制被跳过的 web 模块目录时直接失败。

## 观察到的错误

`--skip-web` 构建完成后，`buckyos-update` 仍会复制 rootfs 中声明的模块目录。由于 fresh clone 后没有 `src/rootfs/bin/node-active/`，update 阶段报错：

```text
+ Copying directory /home/zhangzhen/buckyos/src/rootfs/bin/node-active => /opt/buckyos/bin/node-active
Traceback (most recent call last):
  File "/home/zhangzhen/buckyos/.venv/bin/buckyos-update", line 10, in <module>
    sys.exit(install_main())
             ^^^^^^^^^^^^^^
  File "/home/zhangzhen/buckyos/.venv/lib/python3.12/site-packages/buckyos_devkit/install.py", line 343, in install_main
    update_app(bucky_project, app_name, skip_web_module, check_reinstall=True, target_rootfs=target_rootfs)
  File "/home/zhangzhen/buckyos/.venv/lib/python3.12/site-packages/buckyos_devkit/install.py", line 232, in update_app
    _copy_dir_with_exec_fix(src_path, target_path)
  File "/home/zhangzhen/buckyos/.venv/lib/python3.12/site-packages/buckyos_devkit/install.py", line 57, in _copy_dir_with_exec_fix
    shutil.copytree(src_path, target_path)
  File "/usr/lib/python3.12/shutil.py", line 598, in copytree
    with os.scandir(src) as itr:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/zhangzhen/buckyos/src/rootfs/bin/node-active'
buckyos-update failed with return code 1
```

## 验证

- 已搜索源码引用，确认安装清单、运行时路径和配置生成路径都使用 `bin/node-active/`。
- 已确认 `src/rootfs/bin/node-active/README.md` 会被 Git 跟踪，实际 web 构建产物仍会被忽略。
- 已用 `ast.parse` 检查修改过的 Python 文件语法。
- 已本地调用 `src/buckyos-build.py` 中的目录补齐函数，确认会创建 `rootfs/bin/node-active`、`rootfs/bin/buckyos_systest`、`rootfs/bin/control-panel/web`。
- 本地 Windows sandbox 没有安装 `uv`，因此没有在本机实际执行 `uv run src/buckyos-build.py --skip-web`。
