### PR TITLE
修复 build_aios 构建 agent_tool_cli_dev 产物路径

### DIFF
--- a/build_aios
+++ b/build_aios
@@ -818,7 +818,7 @@ build_runtime_binaries() {
     -p
     opendan
     -p
-    agent_tool
+    agent_tool_cli_dev
     --release
     --target
     "$rust_target"
@@ -853,7 +853,7 @@ build_runtime_binaries() {
     env_cmd+=("${normalized_env_lines[@]}")
   fi
 
-  log "Building opendan and agent_tool for $arch using target $rust_target via ${cargo_cmd[*]}"
+  log "Building opendan and agent_tool_cli_dev for $arch using target $rust_target via ${cargo_cmd[*]}"
   (
     cd "$SRC_DIR"
     "${env_cmd[@]}" "${cargo_cmd[@]}"


### PR DESCRIPTION
## 原因

`build_aios` 在 beta2.2 分支的运行时构建阶段仍然使用 `-p agent_tool`，日志和后续产物检查也沿用旧的 `agent_tool` 名称。当前构建完成后没有生成脚本期望的 `release/agent_tool` 文件，导致流程在产物检查阶段失败。

## 修复

将 `build_aios` 中运行时二进制构建的包名从 `agent_tool` 调整为 `agent_tool_cli_dev`，并同步更新日志文本，使构建目标和实际产物名称保持一致。

## 对应错误

指令:  ./build_aios --image paios/aios_dev --arch amd64 --reuse-cargo-target --push
错误日志：
```text
Compiling ndn-toolkit v0.7.0 (https://github.com/buckyos/cyfs-ndn.git?branch=beta2.2#955438ae)
Compiling buckyos-api v0.7.0 (/home/zhangzhen/buckyos/src/kernel/buckyos-api)
warning: use of deprecated type alias libc::time_t: This type is changed to 64-bit in musl 1.2.0, we'll follow that change in the future release. See #1848 for more info.
   --> kernel/buckyos-api/src/kevent_ringbuffer.rs:464:44
    |
464 |         tv_sec: timeout.as_secs() as libc::time_t,
    |                                            ^^^^^^
    |
    = note: #[warn(deprecated)] on by default

Compiling llm_context v0.7.0 (/home/zhangzhen/buckyos/src/frame/llm_context)
Compiling agent_tool v0.7.0 (/home/zhangzhen/buckyos/src/frame/agent_tool)
warning: buckyos-api (lib) generated 1 warning
Compiling opendan v0.7.0 (/home/zhangzhen/buckyos/src/frame/opendan)
Finished release profile [optimized] target(s) in 3m 16s
Expected build output not found: /tmp/build_aios-cargo-zhangzhen-buckyos_-3198554474/x86_64-unknown-linux-musl/release/agent_tool
```