### PR TITLE
修复只读 ExtTool volume 下 Jarvis session tools 创建失败

### DIFF
--- a/src/frame/opendan/src/agent.rs
+++ b/src/frame/opendan/src/agent.rs
@@ -329,6 +329,15 @@ impl AIAgent {
         paths::sanitize_path_segment(raw)
     }
 
+    fn agent_tool_mount_id(&self) -> String {
+        std::env::var("BUCKYOS_APP_ID")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .map(|value| paths::sanitize_path_segment(&value))
+            .unwrap_or_else(|| self.agent_id())
+    }
+
     /// Build a Session Exec Bin renderer for `behavior_name`. Returns
     /// `Some(renderer)` whenever we have *any* lower-layer state to manage
     /// (Agent tools to sync or a tool plan to enforce). The renderer is
@@ -1439,7 +1448,7 @@ impl AIAgent {
                     .unwrap_or(0);
             }
         }
-        let agent_id = self.agent_id();
+        let agent_id = self.agent_tool_mount_id();
         let bin_renderer = self.build_session_bin_renderer(&agent_id, &session_id, &behavior_name);
         let appclient_session_token = resolve_appclient_session_token().await?;
 

--- a/src/kernel/node_daemon/src/app_loader.rs
+++ b/src/kernel/node_daemon/src/app_loader.rs
@@ -995,6 +995,8 @@ impl AppLoader {
             .check_docker_volume_exists(DEFAULT_EXTTOOL_VOLUME_NAME)
             .await?
         {
+            self.ensure_worker_tool_mountpoints(&image_name, app_type_label)
+                .await?;
             args.push("-v".to_string());
             args.push(format!(
                 "{}:{}:ro",
@@ -1006,6 +1008,7 @@ impl AppLoader {
                 DEFAULT_EXTTOOL_VOLUME_NAME, container_name
             );
         }
+        append_worker_tool_tmpfs(&mut args, app_type_label, &self.app_id);
 
         // Bind mounts (pkg source ro, logs, storage, data, declared mounts).
         for (container_path, host_path, permission) in mounts {
@@ -1065,6 +1068,40 @@ impl AppLoader {
             "worker container {} started (image={}, app_type={})",
             container_name, image_name, app_type_label
         );
+        Ok(())
+    }
+
+    async fn ensure_worker_tool_mountpoints(
+        &self,
+        image_name: &str,
+        app_type_label: &str,
+    ) -> Result<()> {
+        let mut mkdir_paths = vec![format!("{}/bin", WORKER_CONTAINER_EXTTOOL_ROOT)];
+        if app_type_label == "agent" {
+            mkdir_paths.push(format!(
+                "{}/{}",
+                WORKER_CONTAINER_EXTTOOL_ROOT,
+                sanitize_container_path_segment(&self.app_id)
+            ));
+        }
+
+        let mut args = vec![
+            "run".to_string(),
+            "--rm".to_string(),
+            "-v".to_string(),
+            format!(
+                "{}:{}:rw",
+                DEFAULT_EXTTOOL_VOLUME_NAME, WORKER_CONTAINER_EXTTOOL_ROOT
+            ),
+            "--entrypoint".to_string(),
+            "mkdir".to_string(),
+            image_name.to_string(),
+            "-p".to_string(),
+        ];
+        args.extend(mkdir_paths);
+
+        let output = run_command("docker", &args, None, None).await?;
+        ensure_success("docker run (prepare worker tool mountpoints)", &output)?;
         Ok(())
     }
 
@@ -2230,6 +2267,7 @@ impl AppLoader {
             "{}:{}:ro",
             DEFAULT_EXTTOOL_VOLUME_NAME, WORKER_CONTAINER_EXTTOOL_ROOT
         ));
+        append_worker_tool_tmpfs(&mut docker_run_args, app_type_label, &self.app_id);
         docker_run_args.push("-v".to_string());
         docker_run_args.push(format!("<app_pkg>:{}:ro", WORKER_CONTAINER_PKG_SOURCE_ROOT));
         docker_run_args.push("-v".to_string());
@@ -2944,4 +2982,35 @@ fn command_arg_value<'a>(cmd: &'a [String], key: &str) -> Option<&'a str> {
 
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn append_worker_tool_tmpfs(args: &mut Vec<String>, app_type_label: &str, app_id: &str) {
+    args.push("--tmpfs".to_string());
+    args.push(format!(
+        "{}/bin:rw,exec,nosuid,nodev,size=64m",
+        WORKER_CONTAINER_EXTTOOL_ROOT
+    ));
+    if app_type_label == "agent" {
+        args.push("--tmpfs".to_string());
+        args.push(format!(
+            "{}/{}:rw,exec,nosuid,nodev,size=64m",
+            WORKER_CONTAINER_EXTTOOL_ROOT,
+            sanitize_container_path_segment(app_id)
+        ));
+    }
+}
+
+fn sanitize_container_path_segment(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push('_');
+    }
+    out
 }

--- a/src/kernel/node_daemon/src/test_app_loader.rs
+++ b/src/kernel/node_daemon/src/test_app_loader.rs
@@ -530,6 +530,14 @@ fn agent_control_commands_match_expected_process_flow_on_linux() {
         .any(|arg| arg == "buckyos-exttool:/opt/buckyos/tools:ro"));
     assert!(start.commands[1]
         .args
+        .iter()
+        .any(|arg| arg == "/opt/buckyos/tools/bin:rw,exec,nosuid,nodev,size=64m"));
+    assert!(start.commands[1]
+        .args
+        .iter()
+        .any(|arg| arg == "/opt/buckyos/tools/jarvis:rw,exec,nosuid,nodev,size=64m"));
+    assert!(start.commands[1]
+        .args
         .contains(&"BUCKYOS_EXTTOOL_DIR=/opt/buckyos/tools".to_string()));
     assert!(start.commands[1]
         .args
@@ -654,6 +662,14 @@ fn host_script_start_preview_uses_docker_with_script_service_image() {
         .args
         .iter()
         .any(|a| a == "buckyos-exttool:/opt/buckyos/tools:ro"));
+    assert!(preview.commands[1]
+        .args
+        .iter()
+        .any(|a| a == "/opt/buckyos/tools/bin:rw,exec,nosuid,nodev,size=64m"));
+    assert!(!preview.commands[1]
+        .args
+        .iter()
+        .any(|a| a == "/opt/buckyos/tools/desktop-tool:rw,exec,nosuid,nodev,size=64m"));
     assert!(preview.commands[1]
         .args
         .iter()


### PR DESCRIPTION
## 摘要

修复 Jarvis/OpenDAN 在统一 worker 容器中运行时，`/opt/buckyos/tools` 挂载为只读 ExtTool volume 后导致 session tools 创建失败的问题。

本 PR 保持共享 ExtTool volume 只读挂载，同时为运行期需要写入的工具目录叠加容器私有 tmpfs：

- `/opt/buckyos/tools/bin`
- Agent 容器的 `/opt/buckyos/tools/<app_id>`，例如 `/opt/buckyos/tools/jarvis`

同时，OpenDAN 在计算 session tools 的文件系统路径时优先使用 `BUCKYOS_APP_ID`，确保它写入的目录和 `node_daemon` 为容器准备的 tmpfs 路径一致。

## 问题背景

Jarvis 容器启动时会把共享 ExtTool volume 以只读方式挂载到容器内：

```text
-v buckyos-exttool:/opt/buckyos/tools:ro
```

但是 OpenDAN 在收到消息并创建 session 时，会在 `/opt/buckyos/tools/...` 下生成 per-session 的可执行工具目录和工具链接。如果没有可写 overlay，第一次处理入站消息时就会失败。

诊断过程中观察到两个相关问题。

第一，Docker 在只读父目录下面创建 tmpfs 子挂载点时会失败，除非该挂载点目录已经预先存在于 named volume 中：

```text
error mounting "tmpfs" to rootfs at "/opt/buckyos/tools/jarvis":
create mountpoint ... /opt/buckyos/tools/jarvis: read-only file system
```

第二，即使 `node_daemon` 已经给 `/opt/buckyos/tools/jarvis` 挂了 tmpfs，旧 OpenDAN 仍然使用 Agent DID 来计算 session tools 路径，实际会写到另一个只读路径，例如 `/opt/buckyos/tools/did_web_jarvis_test_buckyos_io/<session>`。

OpenDAN 日志中的关键错误：

```text
06-02 07:43:17.906 INFO  [main.rs:844] opendan.bootstrap: agent_root=/home/devtest/.local/share/jarvis package_root=/opt/buckyos/bin/jarvis agent_did=did:web:jarvis.test.buckyos.io
06-02 07:45:53.740 WARN  [agent.rs:476] opendan.agent[Jarvis]: dispatch_inbound failed: build session tools: Read-only file system (os error 30)
```

匹配的 `node_daemon` 日志显示，容器侧已经准备并挂载了基于 `app_id=jarvis` 的可写 tmpfs 路径：

```text
06-02 07:43:16.930 INFO  [app_loader.rs:2757] executing docker run: docker 'run' '--rm' '-v' 'buckyos-exttool:/opt/buckyos/tools:rw' '--entrypoint' 'mkdir' 'paios/aios_dev:latest-amd64' '-p' '/opt/buckyos/tools/bin' '/opt/buckyos/tools/jarvis'
06-02 07:43:17.351 INFO  [app_loader.rs:2757] executing docker run: docker 'run' '--rm' '-d' '--name' 'devtest-jarvis' ... '-v' 'buckyos-exttool:/opt/buckyos/tools:ro' '--tmpfs' '/opt/buckyos/tools/bin:rw,exec,nosuid,nodev,size=64m' '--tmpfs' '/opt/buckyos/tools/jarvis:rw,exec,nosuid,nodev,size=64m' ... '-e' 'BUCKYOS_APP_ID=jarvis' ...
```

因此这里需要统一运行时路径约定：`node_daemon` 按 `app_id` 准备和挂载容器内可写工具目录，OpenDAN 也应使用同一个 segment 写入 session tools。

## 修改内容

- 在 worker 容器启动参数中，为 `/opt/buckyos/tools/bin` 增加 tmpfs overlay。
- 对 Agent 容器，为 `/opt/buckyos/tools/<app_id>` 增加 tmpfs overlay，例如 Jarvis 使用 `/opt/buckyos/tools/jarvis`。
- 在启动 worker 容器前，用短生命周期 Docker `mkdir` 命令把 tmpfs 挂载点目录预创建到 `buckyos-exttool` named volume 中，避免 Docker 在只读父挂载下创建 mountpoint 失败。
- OpenDAN 计算 session tools 文件系统路径时优先使用 `BUCKYOS_APP_ID`；当该环境变量不存在时，回退到原来的 Agent DID based `agent_id()`。
- 补充 `node_daemon` app loader 测试，覆盖新增的 ExtTool tmpfs 挂载参数。

## 验证

```text
cargo test -p node_daemon test_app_loader -- --nocapture
22 passed
```

```text
cargo test -p opendan agent_bash -- --nocapture
14 passed
```

Ubuntu 手工验证：重新构建 worker image 并重启 BuckyOS 后，Jarvis 已能正常回复。