### PR TITLE
Add kevent and kmsg test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,11 @@ uv.lock
 test/aicc_test/deno.lock
 test/aicc_test/reports/*
 test/workflow_test/reports/*
+test/kevent_kmsg/reports/*
 test/reports/
 test/*/Cargo.lock
 test/*/target/
+test/**/Cargo.lock
+test/**/target/
 src/rootfs/bin/workflow/workflow
 *.codex

--- a/notepads/kevent_kmsg_test_plan.md
+++ b/notepads/kevent_kmsg_test_plan.md
@@ -1,4 +1,4 @@
-﻿# kevent / kmsg 测试方案
+# kevent / kmsg 测试方案
 
 ## 目录
 
@@ -7,16 +7,16 @@
   - [kevent](#kevent)
   - [kmsg](#kmsg)
   - [kevent 与 kmsg 的协作](#kevent-与-kmsg-的协作)
-  - [最新调用方边界](#最新调用方边界)
+  - [调用方边界](#调用方边界)
 - [3. 测试代码存放目录](#3-测试代码存放目录)
   - [模块级自动化测试](#模块级自动化测试)
   - [真实环境链路测试](#真实环境链路测试)
   - [路由配置测试](#路由配置测试)
   - [测试报告和证据](#测试报告和证据)
-- [4. 已有覆盖与新增补缺](#4-已有覆盖与新增补缺)
+- [4. 已有覆盖与补缺范围](#4-已有覆盖与补缺范围)
   - [kmsg 已有覆盖](#kmsg-已有覆盖)
-  - [kmsg 新增补缺范围](#kmsg-新增补缺范围)
-  - [kevent 已有覆盖与新增重点](#kevent-已有覆盖与新增重点)
+  - [kmsg 补缺范围](#kmsg-补缺范围)
+  - [kevent 已有覆盖与补缺重点](#kevent-已有覆盖与补缺重点)
 - [5. 测试分层](#5-测试分层)
   - [L1：模块级功能约定测试](#l1模块级功能约定测试)
   - [L2：系统配置与路由测试](#l2系统配置与路由测试)
@@ -35,26 +35,13 @@
 - [8. 环境构建](#8-环境构建)
   - [本地模块测试环境](#本地模块测试环境)
   - [真实环境测试环境](#真实环境测试环境)
-- [9. 推进步骤](#9-推进步骤)
-- [10. 最终测试报告格式](#10-最终测试报告格式)
-- [10.1 测试进度追踪规则](#101-测试进度追踪规则)
-  - [文件职责](#文件职责)
-  - [每轮测试后的更新规则](#每轮测试后的更新规则)
-  - [状态字段规则](#状态字段规则)
-  - [查看当前进度](#查看当前进度)
-  - [验证报告是否完整](#验证报告是否完整)
-- [11. 风险和取舍](#11-风险和取舍)
-- [12. 测试视角：以设计和生产语义为准](#12-测试视角以设计和生产语义为准)
+- [9. 测试复现指南](#9-测试复现指南)
+- [10. 推进步骤](#10-推进步骤)
+- [11. 报告和进度规则](#11-报告和进度规则)
+- [12. 风险和取舍](#12-风险和取舍)
+- [13. 测试视角：以设计和生产语义为准](#13-测试视角以设计和生产语义为准)
   - [当前已发现的设计 / 实现偏差](#当前已发现的设计--实现偏差)
-- [13. 编写 test plan 的提示词总结](#13-编写-test-plan-的提示词总结)
-  - [13.1 基础输入和范围](#131-基础输入和范围)
-  - [13.2 测试设计原则](#132-测试设计原则)
-  - [13.3 测试视角](#133-测试视角)
-  - [13.4 kmsg 测试落点和边界](#134-kmsg-测试落点和边界)
-  - [13.5 kevent / kmsg 真实环境测试要求](#135-kevent--kmsg-真实环境测试要求)
-  - [13.6 运行环境和隔离要求](#136-运行环境和隔离要求)
-  - [13.7 调用方覆盖要求](#137-调用方覆盖要求)
-  - [13.8 报告和推进方式](#138-报告和推进方式)
+- [14. 附录：测试方案维护原则](#14-附录测试方案维护原则)
 
 ## 1. 任务确认
 
@@ -81,7 +68,7 @@
 - `src/frame/opendan/src/msg_center_pump.rs`
 - `src/frame/opendan/src/session_event_pump.rs`
 
-目标是设计一套可落地、可重复执行、不过度设计的测试体系，覆盖 kevent 和 kmsg 作为生产基础通信能力必须满足的功能、可靠性、性能和真实链路行为。本轮只输出测试方案；确认后再按方案实现测试代码、执行测试并输出报告。
+目标是提供一套可落地、可重复执行、不过度设计的测试体系，覆盖 kevent 和 kmsg 作为生产基础通信能力必须满足的功能、可靠性、性能和真实链路行为。仓库内只维护测试计划、测试入口和当前测试结论；当前结论记录在 `notepads/kevent_kmsg_test_report.md`，每轮详细执行日志和原始输出可在本地归档到 `test/kevent_kmsg/reports/`，该目录不纳入版本控制。
 
 ## 2. 当前实现边界
 
@@ -131,22 +118,22 @@
 
 因此必须测试两者的组合语义，而不是只分别测各自 API。
 
-### 最新调用方边界
+### 调用方边界
 
-合入 `beta2.2` 后，`doc/arch/kevent.md` 和 `doc/arch/kmsg.md` 本身没有变化，但相关文档和调用方代码补充了更多生产使用约束，测试计划需要覆盖这些调用方契约：
+除 kevent/kmsg 模块本身外，测试还需要覆盖当前代码中已经形成的调用方契约：
 
 - `msg_center` 在消息 box 变化时发布 `/msg_center/{owner}/box/{box}/changed` 事件，payload 包含 `operation`、`owner`、`box_kind`、`box_name`、`record_id`、`msg_id`、`state`、`updated_at_ms`。
 - `control_panel` 的 chat stream 订阅 `/msg_center/{owner}/box/in/**` 和 `/msg_center/{owner}/box/out/**`，收到事件后必须重新读取 `MsgCenterClient.get_record(...)`，事件只作为加速信号。
 - `OpenDAN msg_center_pump` 订阅 `/msg_center/{owner}/box/{in,group_in,request}/**`，同时兼容旧路径 `/msg_center/{owner}/{box}/**`；无法识别的 `/msg_center/` 事件应防御性 sweep 全部 inbox 类 box。
 - `OpenDAN session_event_pump` 聚合各 session 的 kevent 订阅 pattern，动态重建 reader，并把匹配事件路由成目标 session 的 `Inbound::Event`。
 - `TaskManagerClient::wait_for_task_end_kevent` 明确把 kevent 当作加速层：订阅后立即回读 `get_task`，event 或 timeout 后都回读真相源，订阅失败时退化为轮询。
-- `agent_tool` 文档新增 `subscribe_event` / `unsubscribe_event`，说明 Agent Session 可以订阅 KEvent pattern；这依赖 `session_event_pump` 的 pattern 聚合、路由和 reader 重建行为。
+- `agent_tool` 文档提供 `subscribe_event` / `unsubscribe_event`，说明 Agent Session 可以订阅 KEvent pattern；这依赖 `session_event_pump` 的 pattern 聚合、路由和 reader 重建行为。
 
 ## 3. 测试代码存放目录
 
 ### 模块级自动化测试
 
-新增测试不放入模块源码文件，不扩展现有 `src/*.rs` 内部 `mod tests`。测试落点如下：
+测试代码不放入模块源码文件，不扩展现有 `src/*.rs` 内部 `mod tests`。
 
 - `src/kernel/kevent/tests/`
   - `client_contract.rs`
@@ -159,37 +146,40 @@
   - `sled_contract.rs`
   - `rpc_contract.rs`
 
-`kevent` 是 library crate，可直接新增模块级集成测试。
-
-`kmsg` 当前是 binary crate，没有 `src/lib.rs` library target。为了不修改生产源码，只允许 `src/kernel/kmsg/tests/sled_contract.rs` 在测试文件里临时引入实现文件：
+`kmsg` 当前是 binary crate，没有 `src/lib.rs`。只允许 `sled_contract.rs` 用一次 `#[path]` 引入底层实现，用于验证持久化、cursor、retention、权限、错误行为、并发和性能参考数据；不得写面向私有分支覆盖率的白盒测试。
 
 ```rust
 #[path = "../src/sled_msg_queue.rs"]
 mod sled_msg_queue;
 ```
 
-这种方式只用于验证对外承诺的行为，例如重启后数据仍在、消费位置正确、保留策略、权限、并发、错误行为和性能参考数据；不得写为了覆盖私有分支而存在的白盒测试。`sled_contract.rs` 是唯一允许 `#[path]` 引入实现文件的测试，避免多处重复引入。注意：被引入文件里的 `#[cfg(test)]` 内容可能会在该测试中再次参与编译或运行；如果实际造成重复或冲突，应改为拆出 `lib.rs` 或调整测试结构，需单独确认。
-
-`src/kernel/kmsg/tests/rpc_contract.rs` 不引入 sled 实现文件，只验证公开 RPC/handler 的接口行为。该测试使用测试内最小 fake `MsgQueueHandler`，挂到 `MsgQueueServerHandler` 上，专门验证方法名、参数解析、未知方法、缺字段、错类型和错误映射；不测试 sled 存储行为。真实 HTTP `/kapi/kmsg` 行为放到真实环境链路测试。
+注意：被引入文件里的 `#[cfg(test)]` 内容可能会在该测试中再次参与编译或运行；如果造成重复或冲突，应改为拆出 `lib.rs` 或调整测试结构。`rpc_contract.rs` 不引入 sled，只用测试内 fake `MsgQueueHandler` 验证 RPC/handler 接口行为。真实 HTTP `/kapi/kmsg` 行为放到 DV 测试。
 
 ### 真实环境链路测试
 
-新增根目录测试模块：
+统一目录为 `test/kevent_kmsg/`：
 
-- `test/kevent_kmsg_test/`
-  - `package.json`
-  - `kevent_kmsg_dv.ts`
-  - `README.md`
+| 目录 | 目的 | 环境要求 |
+| --- | --- | --- |
+| `dv/` | gateway 入口下的 kevent/kmsg 最小闭环、POST/GET 行为记录、event 唤醒后回读 kmsg。 | 标准 devtest 环境；Deno、pnpm、bash。 |
+| `restart/` | BuckyOS 服务重启后 kmsg 消息可读、kevent stream 可恢复，subscription 丢失作为偏差记录。 | 独立 Linux 测试机或可重建 devtest 环境。 |
+| `peer_container/` | Docker 网络命名空间下 native framed 单向 peer 投递。 | Linux 测试机、Docker。 |
+| `peer_vm/` | QEMU/KVM VM 隔离下 native framed 单向 peer 投递。 | Linux 测试机、`/dev/kvm`、`qemu-system-x86_64`、`qemu-img`、`genisoimage`。 |
+| `reports/` | 本地每轮详细测试数据和当轮结论，git 忽略，不作为仓库交付内容。 | 无。 |
 
-该目录由现有 `test/run.py` 自动发现，通过 `uv run test/run.py -p kevent_kmsg_test` 执行。这类测试只验证真实 BuckyOS 环境中的关键链路，不替代模块级测试。
+执行入口：
 
-`test/run.py` 的发现条件必须满足：
+```bash
+uv run test/run.py -p kevent_kmsg
+uv run test/run.py -p kevent_kmsg/dv
+uv run test/run.py -p kevent_kmsg/restart
+uv run test/run.py -p kevent_kmsg/peer_container
+uv run test/run.py -p kevent_kmsg/peer_vm
+```
 
-- `test/kevent_kmsg_test/package.json` 存在。
-- `package.json` 中必须包含 `scripts.test`。
-- runner 会在该目录执行 `bash -lc "pnpm install && pnpm test"`。
+`test/run.py --list` 通过 `test/kevent_kmsg/main.py` 发现分组入口。分组入口默认只打印子项说明，不直接运行重启、Docker 或 VM 测试。`dv/` 和 `restart/` 的 `package.json` 必须包含 `scripts.test`，runner 会在对应目录执行 `bash -lc "pnpm install && pnpm test"`。
 
-建议的最小 `package.json`：
+真实环境测试使用 Deno runner，并固定 WebSDK 依赖：
 
 ```json
 {
@@ -205,36 +195,28 @@ mod sled_msg_queue;
 }
 ```
 
-真实环境测试脚本使用 Deno 风格，和现有 `test/aicc_test` / `test/workflow_test` 保持一致，便于复用 `test/test_helpers/buckyos_client.ts`。如果引入除现有测试已使用依赖之外的新依赖，需要先确认。Windows devtest 下依赖 `test/run.py` 仍通过 `bash -lc` 调用 `pnpm`，因此执行前需确认当前环境可用 `bash`、`pnpm`、`deno`；若不可用，应先修 runner 或环境，而不是在测试脚本里绕过 `test/run.py`。
-
 ### 路由配置测试
 
-复用并必要时补充：
-
-- `src/test/test_boot_gatweay/`
-
-该目录已有 `/kapi/kevent/*` 早转发和 `/kapi/kmsg/*` service 路由相关用例。后续只补足缺口，不另建重复路由测试。
+路由测试复用并必要时补充 `src/test/test_boot_gatweay/`。该目录覆盖 `/kapi/kevent/*` 早转发和 `/kapi/kmsg/*` service 路由，不另建重复路由测试。
 
 ### 测试报告和证据
 
-测试输出统一保存到：
+每轮详细证据可在执行者本地保存到 `test/kevent_kmsg/reports/<yyyyMMdd-HHmmss>/`，该目录被 git 忽略。建议至少包含：
 
-- `target/test-reports/kevent-kmsg/<yyyyMMdd-HHmmss>/`
-  - `commands.log`
-  - `cargo-kevent.log`
-  - `cargo-kmsg.log`
-  - `boot-gateway.log`
-  - `dv.log`
-  - `performance.json`
-  - `report.md`
+- `commands.log`
+- `cargo-kevent.log`
+- `cargo-kmsg.log`
+- `boot-gateway.log`
+- `dv.log`
+- `performance.json`
+- `report.md`
 
-`target/` 是构建产物目录，适合存放测试证据，不污染源码。
-
-## 4. 已有覆盖与新增补缺
+仓库内的当前结论和进度索引只写入 `notepads/kevent_kmsg_test_report.md`。
+## 4. 已有覆盖与补缺范围
 
 ### kmsg 已有覆盖
 
-当前 `src/kernel/kmsg/src/sled_msg_queue.rs` 已有较完整的内部测试，后续实现时应复用这些测试，不重复搬到新测试文件里：
+`src/kernel/kmsg/src/sled_msg_queue.rs` 已有较完整的内部测试，实施本计划时应复用这些测试，不重复搬到新测试文件里：
 
 - `test_msg_queue_end_to_end`：覆盖 create/update/post/stats/subscribe/fetch/commit_ack/read/seek/delete/unsubscribe/delete_queue 的主流程。
 - `test_multiple_subscribers_and_messages`：覆盖多订阅者、不同起始位置、独立 cursor、追加消息和裁剪后的读取。
@@ -242,9 +224,9 @@ mod sled_msg_queue;
 
 `src/kernel/buckyos-api/src/msg_queue.rs` 也已有 mock client 层测试，覆盖 `MsgQueueClient` 的 in-process 行为、`read_message` 无副作用、`commit_ack`、`seek` 和路径 QueueUrn。
 
-### kmsg 新增补缺范围
+### kmsg 补缺范围
 
-新增测试不再重复 KM-01 到 KM-10 的 happy path。默认补缺范围收敛为：
+补缺测试不重复 KM-01 到 KM-10 的 happy path。默认补缺范围收敛为：
 
 - 持久化 reopen：确认 drop/reopen 后 queue、message、subscription cursor 仍符合预期。
 - config 生效：`max_messages`、`retention_seconds`、权限字段目前疑似未实现，需要用测试确认并输出偏差。
@@ -252,11 +234,11 @@ mod sled_msg_queue;
 - 并发和性能：验证 index 唯一、stats 正确，记录性能参考数据。
 - 真实服务链路：通过 gateway 的最小验证确认生产入口可用。
 
-新增 kmsg 测试放在 `src/kernel/kmsg/tests/*` 或 DV 目录。现有内部 `#[cfg(test)]` 测试继续保留并运行，但不作为新增测试的默认落点。
+kmsg 补缺测试放在 `src/kernel/kmsg/tests/*` 或 DV 目录。现有内部 `#[cfg(test)]` 测试继续保留并运行，但不作为补缺测试的默认落点。
 
-### kevent 已有覆盖与新增重点
+### kevent 已有覆盖与补缺重点
 
-`kevent` 和 `buckyos-api` 当前已有较多内部单元测试，覆盖 local pub/sub、pattern、timer、light mode、shared ring、HTTP wrapper、native transport 等。新增 `src/kernel/kevent/tests/*` 的重点不是重复内部断言，而是把公开契约和设计偏差固化为独立 integration tests，尤其是：
+`kevent` 和 `buckyos-api` 已有较多内部单元测试，覆盖 local pub/sub、pattern、timer、light mode、shared ring、HTTP wrapper、native transport 等。`src/kernel/kevent/tests/*` 的重点不是重复内部断言，而是把公开契约和设计偏差固化为独立 integration tests，尤其是：
 
 - HTTP/native 对外协议。
 - shared ring 数据大小和 overflow 边界。
@@ -285,8 +267,8 @@ cargo test -p kmsg
 
 说明：
 
-- `cargo test -p kevent` 包含现有单元测试和计划新增的 kevent integration tests。
-- `cargo test -p kmsg` 运行现有 kmsg 内部测试，以及计划新增的 `src/kernel/kmsg/tests/*` 测试。
+- `cargo test -p kevent` 包含现有单元测试和 kevent integration tests。
+- `cargo test -p kmsg` 运行现有 kmsg 内部测试，以及 `src/kernel/kmsg/tests/*` 测试。
 
 ### L2：系统配置与路由测试
 
@@ -320,7 +302,7 @@ uv run src/check.py
 命令：
 
 ```bash
-uv run test/run.py -p kevent_kmsg_test
+uv run test/run.py -p kevent_kmsg/dv
 ```
 
 真实环境测试必须通过 gateway 暴露入口访问 `/kapi/kevent` 和 `/kapi/kmsg`，不直接绕过 gateway 调服务进程端口。若调试阶段需要直连端口，只能作为临时定位手段，不计入最终通过证据。
@@ -339,9 +321,9 @@ cargo test -p kevent --test performance -- --ignored --nocapture
 cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 ```
 
-`kmsg` 性能参考数据放在 `src/kernel/kmsg/tests/sled_contract.rs` 的 ignored case 中，用唯一一次 `#[path]` 引入方式验证底层写读性能；公开 RPC 和真实环境性能参考数据仍放在 `test/kevent_kmsg_test`。
+`kmsg` 性能参考数据放在 `src/kernel/kmsg/tests/sled_contract.rs` 的 ignored case 中，用唯一一次 `#[path]` 引入方式验证底层写读性能；公开 RPC 和真实环境性能参考数据仍放在 `test/kevent_kmsg/dv`。
 
-性能测试不直接写死产品 SLO。首轮只做正确性检查和性能参考记录：测试失败条件主要是数据错误、panic、死锁、明显卡死或资源耗尽；吞吐和延迟只写入 `performance.json` 作为基线。后续产品定义明确 SLO 后，再把基线升级为硬门槛。
+性能测试不直接写死产品 SLO。默认只做正确性检查和性能参考记录：测试失败条件主要是数据错误、panic、死锁、明显卡死或资源耗尽；吞吐和延迟写入 `performance.json` 作为基线。产品定义明确 SLO 后，再把基线升级为硬门槛。
 
 ## 6. 详细测试项
 
@@ -363,14 +345,14 @@ cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 | `D-*` | 设计/实现偏差 | 已发现或待验证的设计与当前实现不一致之处。 |
 | `B-*` | 阻塞项 | 测试推进中遇到的环境或依赖问题。 |
 
-后续沟通中不使用笼统的“好了”作为测试结论。统一按下面口径判断：
+测试结论不使用笼统的“好了”。统一按下面口径判断：
 
 - `方案可推进`：测试项已经对应到设计要求、公开 API 或真实使用方式，测试放在哪里、怎么跑、需要什么环境、怎么留证据、怎么更新报告都已经明确，且没有已知结构性阻塞。
-- `测试已完成`：`notepads/kevent_kmsg_test_report.md` 第 9 章中对应测试项状态为 `已完成`，并且有可复现命令、测试文件、关键输出或运行态探针证据支撑。
+- `测试已完成`：`notepads/kevent_kmsg_test_report.md` 中对应测试项状态为 `已完成`，并且有可复现命令、测试文件、关键输出或运行态探针证据支撑。
 - `部分完成`：已有核心正确性证据，但还缺计划要求的真实环境、规模、路径或故障注入验证。
 - `未执行` / `阻塞`：没有执行证据，或当前环境问题会导致执行结果只反映环境失败。
 
-因此，当前如果说“这部分可以继续推进”，只表示计划结构和执行路径已经收敛；不表示所有 `KM-*`、`UF-*`、`DV-*` 项都已经通过。实际进度以测试报告第 9 章为准。
+`方案可推进` 不等于 `测试已完成`。实际进度以 `notepads/kevent_kmsg_test_report.md` 中的当前状态为准。
 
 ### A. kevent 模块功能测试
 
@@ -401,7 +383,7 @@ cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 | KM-EXIST-03 | 现有路径 QueueUrn 流程 | 复用已有路径型 queue name 测试。 | 高 | 保留并运行 `test_path_queue_name_roundtrip`。 | 同上 | 绝对路径 QueueUrn 可 create/post/subscribe/fetch。 |
 | KM-GAP-01 | persistence reopen | 补足现有测试未覆盖的重启恢复场景。 | 高 | 在 `src/kernel/kmsg/tests/sled_contract.rs` 用唯一一次 `#[path]` 引入方式和临时目录调用 `SledMsgQueue::new_in_dir`，创建 queue/post/sub/fetch/ack 后关闭并重新打开。 | `cd src && cargo test -p kmsg --test sled_contract` | 重新打开后 stats、read/fetch、subscription cursor 保持一致。 |
 | KM-GAP-02 | config 生效 | 验证 `max_messages`、`retention_seconds` 是否实现。 | 高 | 在 `sled_contract.rs` 创建带限制的 queue，写入超过限制并等待过期窗口，验证 stats/read/fetch。 | 同上 | 若未生效，报告标注为“实现与设计不符”。 |
-| KM-GAP-03 | 权限配置 | 验证 `other_app_can_*`、`other_user_can_*` 和 `RPCContext` 是否生效。 | 高 | 分两层：`sled_contract.rs` 构造不同 `RPCContext` 验证 handler 是否使用权限字段；该测试目标是暴露是否忽略 `RPCContext`，不能为了适配当前实现而把权限忽略当作通过。多身份真实环境测试仅在 devtest 能稳定构造多 session 时执行。 | `cd src && cargo test -p kmsg --test sled_contract`；真实环境条件具备时再跑 `uv run test/run.py -p kevent_kmsg_test` | 模块级测试若确认全部忽略权限字段，标注偏差；多身份真实环境测试不可用时记录为未验证风险，不作为默认自动门槛。 |
+| KM-GAP-03 | 权限配置 | 验证 `other_app_can_*`、`other_user_can_*` 和 `RPCContext` 是否生效。 | 高 | 分两层：`sled_contract.rs` 构造不同 `RPCContext` 验证 handler 是否使用权限字段；该测试目标是暴露是否忽略 `RPCContext`，不能为了适配当前实现而把权限忽略当作通过。多身份真实环境测试仅在 devtest 能稳定构造多 session 时执行。 | `cd src && cargo test -p kmsg --test sled_contract`；真实环境条件具备时再跑 `uv run test/run.py -p kevent_kmsg/dv` | 模块级测试若确认全部忽略权限字段，标注偏差；多身份真实环境测试不可用时记录为未验证风险，不作为默认自动门槛。 |
 | KM-GAP-04 | RPC 接口行为 | 验证公开 RPC/handler 行为，不引入 sled 私有实现。 | 高 | `rpc_contract.rs` 使用测试内最小 fake `MsgQueueHandler`，挂到 `MsgQueueServerHandler` 上，专门验证方法名、参数解析、未知方法、缺字段、错类型和错误映射；不启动完整 HTTP 服务，也不 include `sled_msg_queue.rs`。真实 `/kapi/kmsg` HTTP POST/GET 行为放到真实环境测试。 | `cd src && cargo test -p kmsg --test rpc_contract` | 正常方法返回可解析结果；异常返回明确错误，不 panic。 |
 | KM-GAP-05 | 并发 post | 补充并发生产者下 index 唯一性。 | 高 | `sled_contract.rs` 并发 post 1000 条；真实环境测试可补公开 RPC 并发小样本。 | `cd src && cargo test -p kmsg --test sled_contract` | index 唯一、连续，stats count 正确。 |
 | KM-GAP-06 | sync_write cursor 可靠性 | 验证 `sync_write` 是否覆盖 cursor 更新。 | 中高 | `sled_contract.rs` 中 sync_write=true 队列 fetch/ack/seek 后 drop/reopen。 | `cd src && cargo test -p kmsg --test sled_contract` | cursor 不回退；若回退，标注生产风险。 |
@@ -410,13 +392,13 @@ cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 
 | 编号 | 测试项 | 测试目的 | 重要性 | 测试方法 | 命令 | 验证和证据 |
 | --- | --- | --- | --- | --- | --- | --- |
-| KK-01 | event 驱动拉取 kmsg | 验证推荐生产模式。 | 高 | 创建 queue 和 subscription；post kmsg 后发布 kevent `{ queue_urn, index }`；consumer 收到 event 后 fetch kmsg。 | `uv run test/run.py -p kevent_kmsg_test`；若新增 Rust 独立测试，则命名为 `kevent_kmsg_contract` | 收到的 kmsg payload 与 event index 对应。 |
+| KK-01 | event 驱动拉取 kmsg | 验证推荐生产模式。 | 高 | 创建 queue 和 subscription；post kmsg 后发布 kevent `{ queue_urn, index }`；consumer 收到 event 后 fetch kmsg。 | `uv run test/run.py -p kevent_kmsg/dv`；若需要 Rust 独立测试，则命名为 `kevent_kmsg_contract` | 收到的 kmsg payload 与 event index 对应。 |
 | KK-02 | kevent 丢失时 kmsg 轮询兜底 | 验证尽力通知通道丢事件时，可靠数据层仍能保证业务可恢复。 | 高 | 只 post kmsg，不发布 kevent；consumer `pull_event(timeout)` 返回 None 后按 cursor fetch kmsg。 | 同上 | 即使无 event，消息仍能被 fetch 到。 |
 | KK-03 | 重复 kevent 不导致重复处理已 ack 消息 | kevent 可重复/无序场景下业务消费应靠 kmsg cursor 收敛。 | 中高 | 对同一 kmsg index 发布两次 event；第一次 fetch+ack，第二次 event 后 fetch 为空。 | 同上 | kmsg cursor 保证不重复处理。 |
 
 ### D. 使用场景归纳后的功能测试
 
-该层不按每个业务使用场景无限新增测试项，而是从现有调用方中提炼共性能力，再针对这些能力做稳定的功能测试。当前使用方包括 `TaskManagerClient::wait_for_task_end_kevent`、`msg_center` box changed event、`control_panel` chat stream、`OpenDAN msg_center_pump`、`OpenDAN session_event_pump`、`agent_tool subscribe_event` 和 AgentRuntime / workflow task 事件处理。它们共同使用的不是某个业务流程，而是以下 kevent/kmsg 能力：
+该层不按每个业务使用场景无限增加测试项，而是从现有调用方中提炼共性能力，再针对这些能力做稳定的功能测试。当前使用方包括 `TaskManagerClient::wait_for_task_end_kevent`、`msg_center` box changed event、`control_panel` chat stream、`OpenDAN msg_center_pump`、`OpenDAN session_event_pump`、`agent_tool subscribe_event` 和 AgentRuntime / workflow task 事件处理。它们共同使用的不是某个业务流程，而是以下 kevent/kmsg 能力：
 
 - kevent 作为尽力通知信号，业务必须回读真相源。
 - event path / pattern 是事件生产方和消费方的共同约定。
@@ -438,13 +420,13 @@ cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 | --- | --- | --- | --- | --- | --- | --- |
 | DV-01 | boot gateway kevent route | 确认 `/kapi/kevent/*` 走预期早转发。 | 高 | 复用或补充 `req_kevent_direct_ok.json`。 | `uv run src/test/test_boot_gatweay/run_debug_tests.py` | debug 输出 PASS，保存 `boot-gateway.log`。 |
 | DV-02 | boot gateway kmsg route | 确认 `/kapi/kmsg/*` 可路由到 service。 | 高 | 复用或补充 `req_service_kmsg_via_routes_ok.json`。 | 同上 | debug 输出 PASS。 |
-| DV-03 | kmsg gateway 最小闭环 | 验证真实 BuckyOS 环境中 `/kapi/kmsg` 可完成最小队列闭环。 | 高 | TS 测试通过 gateway 调 create/post/subscribe/fetch/ack/delete。 | `uv run test/run.py -p kevent_kmsg_test` | 所有 RPC 返回成功；测试数据清理；保存 `dv.log`。 |
+| DV-03 | kmsg gateway 最小闭环 | 验证真实 BuckyOS 环境中 `/kapi/kmsg` 可完成最小队列闭环。 | 高 | TS 测试通过 gateway 调 create/post/subscribe/fetch/ack/delete。 | `uv run test/run.py -p kevent_kmsg/dv` | 所有 RPC 返回成功；测试数据清理；保存 `dv.log`。 |
 | DV-03B | kmsg HTTP 当前行为记录 | 记录真实 `/kapi/kmsg` 当前只接受 kRPC over HTTP POST，GET 拉模型与文档不一致。 | 中 | TS 测试对 `/kapi/kmsg` 执行一个 POST 最小验证，再执行 GET 探测并记录 status。 | 同上 | POST 可用；GET 当前若不可用，不作为失败项，报告标为文档/实现偏差。 |
 | DV-04 | kevent gateway stream 最小验证 | 验证浏览器推荐消费路径在真实环境可用。 | 高 | TS 测试建 `/kapi/kevent/stream`，另一路 publish，读取 ack/event/keepalive。 | 同上 | NDJSON frame 正确；断开后进程无异常日志。 |
 | DV-05 | kevent + kmsg gateway 协作 | 验证生产链路：kmsg 持久化 + kevent 通知。 | 高 | TS 测试 create queue、subscribe、post message、publish event、stream 收 event 后 fetch。 | 同上 | event 加速路径可用；轮询兜底路径也可用。 |
-| DV-06 | kmsg 持久化自动验证 | 验证真实服务入口下消息在测试进程重连后仍可读。 | 高 | TS 测试创建 queue/post/read，关闭 client 并重新创建 client，再 read/fetch。该项不重启服务，只验证公开入口和持久数据可重复读取。 | `uv run test/run.py -p kevent_kmsg_test` | 重新连接后消息仍可读；记录 queue_urn/index。 |
-| DV-MANUAL-01 | 服务重启后 kmsg 持久化 | 验证完整 BuckyOS 服务重启后不丢数据。 | 高 | 可选手工验证：先运行真实环境测试创建并记录 queue_urn/index；执行 `uv run src/start.py` 覆盖启动；`uv run src/check.py` 通过后运行只读验证脚本。 | 不计入自动验收；命令和输出写入报告 | 重启后消息仍可读；失败时保留 start/check/read 三段日志。 |
-| DV-MANUAL-02 | kevent daemon restart 退化行为 | 验证尽力通知通道的故障语义：不会卡死，功能靠 kmsg 恢复。 | 中高 | 可选手工验证：建 stream 后重启服务，期间 post kmsg；允许 stream 断开或漏 event，但恢复后必须可 fetch kmsg。 | 不计入自动验收；命令和输出写入报告 | kevent 断开/重连行为可解释；kmsg 消息不丢。 |
+| DV-06 | kmsg 持久化自动验证 | 验证真实服务入口下消息在测试进程重连后仍可读。 | 高 | TS 测试创建 queue/post/read，关闭 client 并重新创建 client，再 read/fetch。该项不重启服务，只验证公开入口和持久数据可重复读取。 | `uv run test/run.py -p kevent_kmsg/dv` | 重新连接后消息仍可读；记录 queue_urn/index。 |
+| DV-MANUAL-01 | 服务重启后 kmsg 持久化 | 验证完整 BuckyOS 服务重启后不丢数据。 | 高 | `kevent_kmsg/restart` 创建 queue/post/read/sub/ack，执行 `uv run src/start.py --skip-update` 重启服务，`uv run src/check.py` 恢复后通过 gateway 重新 read 重启前消息。 | `uv run test/run.py -p kevent_kmsg/restart` | 重启后消息仍可读；subscription 若丢失，记录为 D-09 相关偏差，不作为该项消息持久化失败。 |
+| DV-MANUAL-02 | kevent daemon restart 退化行为 | 验证尽力通知通道的故障语义：不会卡死，功能靠 kmsg 恢复。 | 中高 | `kevent_kmsg/restart` 在重启前建立 stream，重启期间观察旧 stream 有界关闭或超时；恢复后重建 stream，post kmsg 并 publish kevent。 | `uv run test/run.py -p kevent_kmsg/restart` | 旧 stream 行为可解释；恢复后 kmsg fetch 和 kevent stream 均可用。 |
 
 ## 7. 性能测试设计
 
@@ -468,7 +450,7 @@ cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 | MP-02 | fetch throughput | 验证批量消费路径具备生产可用的基础吞吐。 | 高 | 预置 10k 条，fetch batch=100，auto_commit=true。 | 全部读完；无重复、无缺失。 | batch latency。 |
 | MP-03 | at-least-once overhead | 验证可靠消费路径在显式 ack 下不破坏 cursor。 | 高 | fetch auto_commit=false + commit_ack。 | 全部读完；无 cursor 错乱。 | ops/s。 |
 | MP-04 | concurrent producers | 验证多生产者并发写入时 index 唯一且连续。 | 高 | 10 个 task 并发 post，总 10k 条。 | index 唯一连续，stats 正确。 | index 校验摘要。 |
-| MP-05 | sync_write 性能成本 | 记录可靠写入开关的性能成本，作为后续退化对比基线。 | 中 | sync_write=false 和 true 各 post 1k 条。 | 两者都成功；记录差异，不以差异作为失败条件。 | sync_write 对比数据。 |
+| MP-05 | sync_write 性能成本 | 记录可靠写入开关的性能成本，作为退化排查基线。 | 中 | sync_write=false 和 true 各 post 1k 条。 | 两者都成功；记录差异，不以差异作为失败条件。 | sync_write 对比数据。 |
 
 ## 8. 环境构建
 
@@ -496,7 +478,7 @@ uv run src/check.py
 通过标准后再运行：
 
 ```bash
-uv run test/run.py -p kevent_kmsg_test
+uv run test/run.py -p kevent_kmsg/dv
 ```
 
 真实环境测试中的 URL 和凭证通过环境变量配置，默认使用 devtest 本地环境：
@@ -507,12 +489,41 @@ uv run test/run.py -p kevent_kmsg_test
 
 如果需要登录态，优先复用现有 `test/aicc_test` 和 `test/test_helpers` 的登录方式。测试包只增加测试依赖，不引入模块生产依赖。
 
-## 9. 推进步骤
+## 9. 测试复现指南
+
+执行者按本节准备环境和运行命令，再用 `notepads/kevent_kmsg_test_report.md` 核对当前状态。每轮详细证据可保存到本地 `test/kevent_kmsg/reports/`，但不提交到仓库。
+
+| 分类 | 命令 | 环境 | 覆盖 | 通过判断 |
+| --- | --- | --- | --- | --- |
+| 模块级功能 | `cd src && cargo test -p kevent && cargo test -p kmsg` | Rust workspace 可解析；Linux 如需 native 依赖设置 `LIBCLANG_PATH`。 | `KE-01`~`KE-15`、`KM-EXIST-*`、`KM-GAP-*`、`D-01/D-04/D-05/D-06/D-07/D-09` | 退出码 0；config/权限等当前偏差必须记录为偏差，不伪装成设计通过。 |
+| 使用功能契约 | `cd src && cargo test -p kevent --test usage_contract` | 不需要完整 BuckyOS。 | `UF-01`~`UF-05`、`D-11` | event id 与 consumer pattern 匹配；payload 只用于定位；timeout/重复 event 不破坏真相源收敛。 |
+| 真实环境 DV | `uv run src/start.py --all && uv run src/check.py && uv run test/run.py -p kevent_kmsg/dv` | 仓库根目录；标准 devtest；Deno、pnpm、bash 可用。 | `KK-01`~`KK-03`、`DV-03`~`DV-06`、`DV-03B`、`D-08` | kmsg POST/kRPC 闭环通过；kevent stream 可 ack/receive；GET `/kapi/kmsg` 当前行为只记录。 |
+| 服务重启恢复 | `uv run test/run.py -p kevent_kmsg/restart` | 可重建 devtest；测试会执行 `uv run src/start.py --skip-update`。 | `DV-MANUAL-01`、`DV-MANUAL-02`、`D-09` | 重启前消息重启后可读；旧 stream 有界关闭或超时；恢复后新 stream/kmsg 可用；subscription 丢失记录为 D-09 偏差。 |
+| peer container | `uv run test/run.py -p kevent_kmsg/peer_container` | Linux 测试机；Docker 可运行 `ubuntu:24.04`。 | `D-02`、`D-03` | 外部 client 发布到 `node_a` 后，`node_b` 能收到同一 event。 |
+| peer VM | `uv run test/run.py -p kevent_kmsg/peer_vm` | Linux 测试机；KVM、`qemu-system-x86_64`、`qemu-img`、`genisoimage` 可用。 | `D-02`、`D-03` | 与 container 同；只证明手工配置 peer 后 native framed 单向投递可达。 |
+| 性能基线 | `cd src && cargo test -p kevent --test performance -- --ignored --nocapture --test-threads=1 && cargo test -p kmsg --test sled_contract -- --ignored --nocapture` | Rust workspace；性能测试默认 ignored。 | `KP-01`~`KP-05`、`MP-01`~`MP-05` | 退出码 0；输出 baseline JSON；数值作为基线，不作为产品 SLO。 |
+| 路由 debug | `uv run src/test/test_boot_gatweay/run_debug_tests.py` | `cyfs_gateway debug` 能加载当前 `boot_gateway.yaml`。 | `DV-01`、`DV-02` | route case 输出 PASS；若 debug binary 不支持当前 `--backup-map` 语法，记录为工具链阻塞，不代表 runtime gateway DV 失败。 |
+
+单独复现 kevent slow reader baseline：
+
+```bash
+cd src
+cargo test -p kevent --test performance slow_reader_overflow_10k_baseline -- --ignored --nocapture
+```
+
+每轮执行后：
+
+- `test/kevent_kmsg/reports/` 可在本地保存该轮实际命令、环境、退出码、关键输出、日志路径和当轮结论；该目录不提交。
+- `notepads/kevent_kmsg_test_report.md` 更新当前状态表、复现索引、关键证据、阻塞项和剩余风险。
+- 实现与设计不符时，在当前报告的偏差和修补建议中记录依据、实际行为和建议处理方式。
+
+## 10. 推进步骤
 
 1. 确认本测试方案。
-2. 新增 `src/kernel/kevent/tests/*` integration tests。
-3. 新增 `src/kernel/kmsg/tests/sled_contract.rs` 和 `src/kernel/kmsg/tests/rpc_contract.rs`。其中 `sled_contract.rs` 是唯一使用 `#[path = "../src/sled_msg_queue.rs"]` 引入实现文件的测试，验证持久化、config、权限、cursor、并发、性能等对外行为；`rpc_contract.rs` 使用 fake `MsgQueueHandler` 验证 RPC/handler 接口行为。
-4. 运行 L1：
+2. 实现 `src/kernel/kevent/tests/*` integration tests。
+3. 实现 `src/kernel/kmsg/tests/sled_contract.rs` 和 `src/kernel/kmsg/tests/rpc_contract.rs`。其中 `sled_contract.rs` 是唯一使用 `#[path = "../src/sled_msg_queue.rs"]` 引入实现文件的测试，验证持久化、config、权限、cursor、并发、性能等对外行为；`rpc_contract.rs` 使用 fake `MsgQueueHandler` 验证 RPC/handler 接口行为。
+4. 实现 `test/kevent_kmsg/dv`、`restart`、`peer_container`、`peer_vm` 测试。
+5. 运行模块级测试：
 
 ```bash
 cd src
@@ -520,8 +531,7 @@ cargo test -p kevent
 cargo test -p kmsg
 ```
 
-5. 修正测试或实现中暴露的问题。若需改协议、字段、存储结构，同时检查前后端和文档联动。
-6. 新增 `test/kevent_kmsg_test` DV 测试。
+6. 修正测试或实现中暴露的问题。若需改协议、字段、存储结构，同时检查前后端和文档联动。
 7. 运行路由测试：
 
 ```bash
@@ -533,73 +543,46 @@ uv run src/test/test_boot_gatweay/run_debug_tests.py
 ```bash
 uv run src/start.py --all
 uv run src/check.py
-uv run test/run.py -p kevent_kmsg_test
+uv run test/run.py -p kevent_kmsg/dv
 ```
 
-9. 运行 ignored 性能测试和真实环境性能参考测试：
+9. 在合适环境运行 restart、peer container、peer VM 测试：
+
+```bash
+uv run test/run.py -p kevent_kmsg/restart
+uv run test/run.py -p kevent_kmsg/peer_container
+uv run test/run.py -p kevent_kmsg/peer_vm
+```
+
+10. 运行 ignored 性能测试和真实环境性能参考测试：
 
 ```bash
 cd src
 cargo test -p kevent --test performance -- --ignored --nocapture
 cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 cd ..
-uv run test/run.py -p kevent_kmsg_test
+uv run test/run.py -p kevent_kmsg/dv
 ```
 
-10. 汇总 `target/test-reports/kevent-kmsg/<timestamp>/report.md`。
+11. 可在本地汇总 `test/kevent_kmsg/reports/<timestamp>/report.md`，并更新仓库内的 `notepads/kevent_kmsg_test_report.md`。
 
-## 10. 最终测试报告格式
+## 11. 报告和进度规则
 
-测试完成后输出报告到：
-
-```text
-target/test-reports/kevent-kmsg/<timestamp>/report.md
-```
-
-报告至少包含：
-
-- 测试时间、commit、操作系统、Rust 版本。
-- 本轮修改的测试文件列表。
-- 已有测试复用清单和新增补缺清单。
-- 执行命令和退出码。
-- kevent 功能测试结果。
-- kmsg 功能测试结果。
-- 使用功能最小验证结果。
-- 路由和真实环境测试结果。
-- 性能测试摘要。
-- 失败用例、日志路径、复现命令。
-- 未验证项和剩余风险。
-
-报告结论必须能回答：
-
-- 改了什么测试。
-- 为什么这些测试覆盖了生产关键风险。
-- 跑了什么验证。
-- 还有什么风险或未验证项。
-
-## 10.1 测试进度追踪规则
-
-测试推进状态统一记录在 `notepads/kevent_kmsg_test_report.md` 中。
-
-### 文件职责
+报告分两层维护：
 
 | 文件 | 职责 |
 | --- | --- |
-| `notepads/kevent_kmsg_test_plan.md` | 人读测试方案，描述测试范围、目的、方法和推进步骤。 |
-| `notepads/kevent_kmsg_test_report.md` | 唯一测试进度台账和测试报告，记录每轮执行结果、证据、阻塞项和测试计划推进状态。 |
+| `notepads/kevent_kmsg_test_report.md` | 当前测试报告和进度索引，记录每个计划项的状态、结论、证据索引和剩余风险。 |
+| `test/kevent_kmsg/reports/<timestamp>/` 或 `test/kevent_kmsg/reports/<date>-<name>.md` | 执行者本地每一轮测试的详细记录，包含命令、环境、原始输出、日志路径、性能数据和当轮结论；该目录 git 忽略，不提交。 |
 
-### 每轮测试后的更新规则
+每执行一轮测试后：
 
-每执行一轮测试后，必须更新 `notepads/kevent_kmsg_test_report.md`：
+1. 可将该轮命令、环境、退出码、关键输出、日志路径和当轮结论归档到本地 `test/kevent_kmsg/reports/`。
+2. 更新 `notepads/kevent_kmsg_test_report.md` 中的当前结论、统计口径、测试项状态、阻塞项和证据索引。
+3. 如增加测试项、拆分测试项或调整测试目录，同时更新本测试计划和当前报告。
+4. 不在 notepad 当前报告里长期保留多轮历史数据；历史明细由执行者本地 `test/kevent_kmsg/reports/` 保留。
 
-1. 在执行结果章节记录本轮实际运行的命令、环境、退出码、关键输出和结论。
-2. 在阻塞或诊断章节记录未执行原因、环境问题和下一步。
-3. 更新 `## 9. 测试计划推进状态`，确保每个相关测试项的状态、测试结果、证据和剩余工作同步变化。
-4. 如果新增测试项或拆分测试项，同时更新 `notepads/kevent_kmsg_test_plan.md` 和报告第 9 章。
-
-### 状态字段规则
-
-第 9 章中的每个测试项必须使用以下状态之一：
+当前报告中的每个测试项必须使用以下状态之一：
 
 | 状态 | 含义 |
 | --- | --- |
@@ -608,48 +591,24 @@ target/test-reports/kevent-kmsg/<timestamp>/report.md
 | `未执行` | 计划项尚无执行证据。 |
 | `阻塞` | 受环境或依赖问题阻塞，当前执行只会得到环境失败。 |
 
-每个测试项至少要维护：
+每个测试项至少维护：`当前状态`、`测试结果`、`通过证据 / 当前证据`、`剩余工作`。
 
-| 字段 | 填写要求 |
-| --- | --- |
-| `当前状态` | 使用固定状态枚举。 |
-| `测试结果` | 写明 `通过`、`未验证`、`失败`、`当前行为已确认`、`实现与设计不符` 等。 |
-| `通过证据 / 当前证据` | 写明命令、测试文件、关键输出、日志路径或探针结果。 |
-| `剩余工作` | 写明未完成内容、阻塞原因、下一步或修复后需要调整的预期。 |
+报告完整性检查：
 
-### 查看当前进度
-
-直接查看：
-
-```text
-notepads/kevent_kmsg_test_report.md
-```
-
-其中：
-
-- 第 1-8 章记录本轮执行过程、构建和诊断证据。
-- 第 9 章是测试计划推进状态总览。
-
-### 验证报告是否完整
-
-人工 review 报告时至少检查：
-
-- 第 9 章是否覆盖 test plan 中所有测试项。
-- 每个测试项是否有明确状态。
-- `已完成` 项是否有可复现命令或明确探针证据。
-- `阻塞` 项是否写明阻塞原因、影响范围和下一步。
-- 第 1-8 章的执行证据是否能支撑第 9 章中的状态变化。
-
-## 11. 风险和取舍
+- 当前报告覆盖 test plan 中所有测试项。
+- `已完成` 项有可复现命令或明确探针证据。
+- `阻塞` 项写明阻塞原因、影响范围和下一步。
+- 当前报告中的状态变化要有可复现命令和关键证据；本地 `test/kevent_kmsg/reports/` 可作为执行者自留的详细证据。
+## 12. 风险和取舍
 
 - 不把所有行为都放到真实环境测试里。大多数语义用模块级测试快速覆盖，真实环境测试只验证关键链路，避免测试慢且不稳定。
-- kevent 新增测试优先放在 integration test 或根目录 test 模块，避免侵入模块源码。
+- kevent 补充测试优先放在 integration test 或根目录 test 模块，避免侵入模块源码。
 - kmsg 当前是 binary crate，仅 `src/kernel/kmsg/tests/sled_contract.rs` 通过 `#[path]` 引入实现文件，不改生产源码。该方式只能验证设计要求和对外行为，不能写面向私有分支覆盖率的白盒测试。公开链路测试仍放在真实环境/RPC/HTTP 层。
 - kevent 是尽力通知通道，测试不会要求事件永不丢；只要求错误可解释、不会卡死、丢事件时 kmsg 兜底有效。
 - kmsg 是可靠层，测试会严格要求持久化、index 单调、cursor 正确、重启后数据仍可读。
 - 性能阈值先作为防明显退化的 guardrail，首轮报告记录基线；没有产品 SLO 前不做过度性能门槛。
 
-## 12. 测试视角：以设计和生产语义为准
+## 13. 测试视角：以设计和生产语义为准
 
 本测试方案不能面向源码实现细节来设计，也不能把“当前代码怎么写的”直接当成正确行为。测试的判断基准按优先级排列如下：
 
@@ -658,7 +617,7 @@ notepads/kevent_kmsg_test_report.md
 3. 模块公开 API、服务入口、调用方使用方式所体现的契约。
 4. 当前源码实现。
 
-因此后续实现测试时，需要把测试分成两类：
+实施测试时，需要把测试分成两类：
 
 - **功能约定测试**：验证当前实现是否满足设计文档和公开接口语义。例如 kmsg 的 index 单调、cursor 正确、重启后数据仍可读；kevent 的 local/global 边界、pattern 匹配、尽力通知下的丢旧保新、HTTP stream frame 语义。
 - **实现审视测试**：通过测试暴露当前实现中不合理、过度耦合、与设计不符或生产风险较高的地方。例如文档要求的能力未实现、错误码与文档不一致、HTTP facade 与 native 协议不一致、kmsg 配置字段没有生效、kevent 事件大小限制与 shared ring slot 限制冲突、异常路径返回 500 或 panic。
@@ -688,13 +647,13 @@ notepads/kevent_kmsg_test_report.md
 
 ### 当前已发现的设计 / 实现偏差
 
-以下是基于当前文档和代码静态阅读已经能确认或需要重点验证的偏差。后续测试实现时应把这些作为优先验证目标；如果测试证明偏差存在，需要在测试报告中明确标注“实现与设计不符”或“文档需要补充”。
+以下是基于当前文档和代码静态阅读已经能确认或需要重点验证的偏差。实施测试时应把这些作为优先验证目标；如果测试证明偏差存在，需要在测试报告中明确标注“实现与设计不符”或“文档需要补充”。
 
-| 编号 | 模块 | 偏差说明 | 依据 | 状态 | 初步判断 | 后续验证方式 |
+| 编号 | 模块 | 偏差说明 | 依据 | 状态 | 初步判断 | 验证方式 / 剩余验证 |
 | --- | --- | --- | --- | --- | --- | --- |
 | D-01 | kevent | 文档建议 `data` 字段大小上限可为 64KB，`KEventClient` 也按 64KB 校验；但 shared ringbuffer 单 slot 只有 2048 bytes，且写入的是序列化后的完整 `Event`，因此 2KB 左右以上的 global event 在 shared-ring 路径可能失败。 | `doc/arch/kevent.md` 提到 64KB；`kevent_client.rs` 有 `MAX_EVENT_DATA_SIZE_BYTES = 64 * 1024`；`kevent_ringbuffer.rs` 有 `SLOT_DATA_SIZE = 2048`。 | 已静态确认 | 明确的设计/实现冲突。需要决定是降低文档/API 上限，还是调整 shared ring 传输策略。 | 增加 1KB、2KB、4KB、64KB event 的 local/service/shared ring/HTTP publish 测试，记录各路径行为。 |
-| D-02 | kevent | 文档描述 Node Daemon 通过全 mesh TCP 长连接向所有 peer 广播 global event；当前代码只有 `KEventPeerPublisher` 抽象和 in-process 测试，`node_daemon/src/kevent_server.rs` 未看到 peer 连接建立、维护和配置加载。 | `doc/arch/kevent.md` 的 peer daemon 协议和 `remote_peers` 设计；当前 node_daemon kevent server 只启动 HTTP、native TCP 和 shared-ring importer。 | 疑似未实现 | 生产跨节点 kevent 能力疑似未落地。 | 增加双 daemon / 双节点 DV 测试；若当前环境无法搭建，报告中标为未实现或未验证。 |
-| D-03 | kevent | 文档说外部 Light SDK 连接任意 daemon 发布事件后应广播到所有 peer；若 D-02 未实现，则 Light SDK 的跨节点语义也无法满足。 | `doc/arch/kevent.md` 说明 Light SDK 只需连接任意 Daemon；当前只有本地 service/HTTP/native publish 路径。 | 疑似未实现 | 依赖 D-02，疑似设计未落地。 | Light client 发布到 Node A，Node B reader 订阅验证是否收到。 |
+| D-02 | kevent | 文档描述 Node Daemon 通过全 mesh TCP 长连接向所有 peer 广播 global event；当前代码有 `KEventPeerPublisher` 抽象、in-process 测试、container 级和 QEMU/KVM VM 级 native framed 单向投递测试，但 `node_daemon/src/kevent_server.rs` 未看到 peer 连接建立、维护和配置加载。 | `doc/arch/kevent.md` 的 peer daemon 协议和 `remote_peers` 设计；当前 node_daemon kevent server 只启动 HTTP、native TCP 和 shared-ring importer。`test/kevent_kmsg/peer_container` 与 `test/kevent_kmsg/peer_vm` 可验证手工配置 peer 后的单向 framed 投递。 | 部分验证，仍疑似未完整实现 | 生产跨节点自动 peer mesh 能力疑似未落地。 | 已有 container 和 QEMU/KVM VM harness 验证单向 framed peer 投递；剩余验证是完整 `ood1 + node1` BuckyOS DV，确认 node-daemon 是否自动建立和维护 peer 连接。 |
+| D-03 | kevent | 文档说外部 Light SDK 连接任意 daemon 发布事件后应广播到所有 peer；container 和 QEMU/KVM VM harness 已验证“外部 client -> node_a -> node_b”单向可达，但完整任意 daemon / 全 mesh 语义仍依赖 D-02。 | `doc/arch/kevent.md` 说明 Light SDK 只需连接任意 Daemon；当前只有本地 service/HTTP/native publish 路径。harness 显示 framed `PublishGlobal` 到接收端后 `ingress_node` 会变成接收端。 | 部分验证，仍疑似设计语义未完整落地 | 依赖 D-02；当前 framed 协议还不能清晰表达 peer 转发语义。 | 使用 `uv run test/run.py -p kevent_kmsg/peer_container` 和 `uv run test/run.py -p kevent_kmsg/peer_vm` 作为单向可达证据；剩余验证是 peer publish 协议确认和完整双节点 BuckyOS DV。 |
 | D-04 | kevent | 文档的错误码列表只有 `INVALID_EVENTID`、`INVALID_PATTERN`、`DAEMON_UNAVAILABLE`、`TIMER_INVALID_TARGET`、`TIMER_NOT_FOUND`；当前实现额外有 `NOT_SUPPORTED`、`READER_CLOSED`，且 `pull_event` 对不存在 reader 返回 `Ok(None)`，`update_reader` 对不存在 reader 返回 `READER_CLOSED`，生命周期错误语义不一致。 | `doc/arch/kevent.md` 错误码章节；`kevent_client.rs` 的 `KEventError`；`service.rs` 的 `pull_event` / `update_reader`。 | 已静态确认 | 文档与实现不一致，且 API 行为需要统一。 | 模块测试固定关闭/不存在 reader 的 pull/update/remove 行为；报告中建议统一错误语义或补文档。 |
 | D-05 | kevent | 文档强调 EventBus 是尽力通知、无匹配 reader 时静默丢弃；当前 service 在 mirror 到 shared ring 失败时可能让 HTTP publish / external publish 返回错误。这对超大事件是好事还是违反尽力通知语义，需要设计确认。 | `doc/arch/kevent.md` 的尽力通知和静默丢弃语义；`service.rs` 的 `mirror_to_shared_ring` 返回错误链路。 | 待测试验证 | 设计语义不够精确，尤其是“非法/过大事件”是否应失败。 | 构造过大事件，分别验证 publish 返回、reader 接收、日志。 |
 | D-06 | kmsg | 文档和 API 都定义了 `max_messages`、`retention_seconds`，但当前 sled 实现仅保存 config，未在 post/fetch/read 或后台维护中执行最大条数和过期清理。 | `doc/arch/kmsg.md` 的 `QueueConfig`；`msg_queue.rs` 的字段；`sled_msg_queue.rs` 只读取 `sync_write`，未使用 `max_messages` / `retention_seconds`。 | 已静态确认 | 明确的设计/实现冲突。 | 创建 `max_messages=3` / `retention_seconds=1` 的队列，写入和等待后验证 stats/read 是否裁剪。 |
@@ -704,83 +663,14 @@ notepads/kevent_kmsg_test_report.md
 | D-10 | kmsg | `doc/arch/kmsg.md` 描述的是基础 trait，没有包含当前公开 API 中的 `read_message`、权限 bool、绝对路径 QueueUrn 透传规则等扩展。 | `doc/arch/kmsg.md` 与 `msg_queue.rs` 差异。 | 文档需补充 | 文档落后于实现，不一定是代码错误，但测试计划和报告要明确当前契约来源。 | 在测试报告里列出“文档未覆盖但当前 API 暴露”的能力，建议补文档。 |
 | D-11 | kevent 调用方 | `msg_center` 当前发布 `/msg_center/{owner}/box/{box}/changed`，OpenDAN 同时订阅新旧两类 path，control_panel 只订阅 `/box/in/**` 和 `/box/out/**`。如果未来 msg_center path 或 box name 变化，两个消费方容易静默失效。 | `msg_center.rs` 的 `build_box_changed_event_id`；`message_hub.rs` 的 chat stream patterns；`msg_center_pump.rs` 的 `build_msg_center_event_patterns`。 | 已静态确认风险 | 不是当前实现 bug，但属于调用方约定脆弱点，应固化测试。 | 增加事件生产方和消费方 pattern 兼容性最小验证，验证所有消费方 pattern 能匹配 msg_center 当前发布路径。 |
 
-## 13. 编写 test plan 的提示词总结
+## 14. 附录：测试方案维护原则
 
-本节总结本轮编写和修订 `kevent_kmsg_test_plan.md` 时使用的约束、原则和 review 反馈，后续编写类似测试方案时应优先遵循。
-
-### 13.1 基础输入和范围
-
-- 只依据当前工作区实际存在的 kevent / kmsg 相关文档、模块源码和调用方源码设计测试。
-- 重点参考 `doc/arch/kevent.md`、`doc/arch/kmsg.md`、模块本身代码，以及实际使用 kevent / kmsg 的调用方代码。
-- 工作区没有的、已删除的、无法从当前仓库确认的资料不要作为测试依据。
-- 方案文档输出到 `notepads/` 下。
-
-### 13.2 测试设计原则
-
-- 测试覆盖要全面，但不要冗余。
-- 测试代码不要侵入模块源码。
-- 明确测试代码存放目录，目录选择要合理并符合工程规范。
-- 所有测试方案必须可落地、可执行、可验证。
-- 每项测试需要说明测试目的、重要性、测试方法、测试命令、环境要求、环境构建方式、验证方式和必要证据。
-- `重要性` 必须作为单独一列或单独字段，不要和 `测试目的` 混在一起。
-- 需要按步骤推进测试完成；如果需要复杂测试环境，必须说明如何搭建。
-- 测试完成后必须输出测试报告。
-- 测试报告应包含测试计划推进情况：每个测试项当前是已完成、未完成、部分完成还是阻塞；测试结果是否通过；通过证据是什么。
-
-### 13.3 测试视角
-
-- 不要只面向源码实现写测试，不能把“当前代码怎么写”直接当成正确行为。
-- 测试应以设计文档、公开 API、生产语义和调用方契约为判断基准。
-- 要主动审视当前实现中不合理、过度耦合、与设计不符或生产风险高的地方。
-- 在 test plan 中增加专门主题说明“测试视角：以设计和生产语义为准”。
-- 对已经发现的实现 / 设计冲突，需要在方案中列出偏差表，说明偏差依据、状态、初步判断和后续验证方式。
-- 偏差项要区分“已静态确认”和“待测试验证”，避免把疑似问题写成已证实问题。
-
-### 13.4 kmsg 测试落点和边界
-
-- 允许在 `src/kernel/kmsg/tests/*.rs` 下新增测试文件。
-- 新增测试不要再建议通过修改模块源码增加内部 `#[cfg(test)]`。
-- `kmsg` 是 binary crate，没有 `src/lib.rs` 时，底层 sled 行为测试可以在测试文件中用 `#[path = "../src/sled_msg_queue.rs"] mod sled_msg_queue;` 引入实现文件，不改生产源码。
-- `#[path]` 引入方式只能用于验证持久化、cursor、retention、权限、错误行为、并发和性能参考数据等设计要求，不写为了覆盖私有分支而存在的白盒测试。
-- `#[path]` include 不要分散到多个 kmsg test 文件；集中到 `src/kernel/kmsg/tests/sled_contract.rs` 一个文件中。
-- 注意 integration test crate 中 `cfg(test)` 也是开启的，被 include 文件里的内部 `#[cfg(test)]` 内容可能会再次参与编译或运行；若造成重复或冲突，应改为拆出 `lib.rs` 或调整测试结构，需单独确认。
-- `rpc_contract.rs` 不 include sled 实现；使用测试内最小 fake `MsgQueueHandler` 挂到 `MsgQueueServerHandler` 上，只验证方法名、参数解析、未知方法、缺字段、错类型和错误映射，不测试 sled 存储行为。
-- `performance.rs` 不要再单独 `#[path]` include sled；底层性能 ignored case 放入 `sled_contract.rs`。
-
-### 13.5 kevent / kmsg 真实环境测试要求
-
-- 真实环境测试目录使用 `test/kevent_kmsg_test/`。
-- `test/run.py` 只有在 `package.json` 含 `scripts.test` 时才会纳入，并会执行 `bash -lc "pnpm install && pnpm test"`，方案需要写清楚这一点。
-- 真实环境测试要与现有测试风格一致，使用 Deno runner，而不是 Node `--experimental-strip-types`。
-- `package.json` 中 `test` 脚本使用 `deno run --allow-net --allow-read --allow-write --allow-env --unsafely-ignore-certificate-errors kevent_kmsg_dv.ts`。
-- 依赖版本固定为现有测试使用的 `github:buckyos/buckyos-websdk#beta2.2`。
-- 真实 HTTP `/kapi/kmsg` 行为放到真实环境测试验证；模块级的 `rpc_contract.rs` 不启动完整 HTTP 服务。
-- 如果 devtest 当前无法稳定构造多身份 session，权限真实环境测试只记录为未验证风险，不作为默认自动测试通过条件。
-
-### 13.6 运行环境和隔离要求
-
-- shared ring 测试必须使用唯一临时 `BUCKYOS_KEVENT_RINGBUFFER_PATH`。
-- 因为 `BUCKYOS_KEVENT_RINGBUFFER_PATH` 是进程级环境变量，shared ring integration tests 需要通过全局锁或 `--test-threads=1` 串行隔离，避免偶发失败。
-- 性能测试默认标记为 ignored，避免拖慢普通开发循环。
-- 没有产品 SLO 前，性能测试先做正确性检查和性能参考记录；阈值只用于防止明显卡死、panic、死锁或资源耗尽，不作为严格产品门槛。
-- 对需要完整 BuckyOS 环境的测试，必须说明如何启动、检查和恢复环境。
-
-### 13.7 调用方覆盖要求
-
-- 测试不能只覆盖模块 API、路由和组合语义，还要把实际调用方纳入验收范围。
-- 但不要为每个新增业务使用场景都创建一条独立测试项；应先归纳这些场景共同使用了哪些 kevent/kmsg 功能，再针对共性功能建立稳定测试项。
-- 当前调用方共同能力包括：event 唤醒后回读真相源、producer path 与 consumer pattern 兼容、event payload 轻量定位、reader 动态订阅和重建、kevent 失败退化到 poll/sweep/fetch。
-- 具体调用方如 TaskManager、msg_center、control_panel、OpenDAN、agent-tool、workflow 主要作为功能测试的样本来源和证据来源。
-- 如果某个业务场景引入了新的 kevent/kmsg 使用模式，先判断是否能归入已有 `UF-*` 功能契约；只有出现新的共同能力时才新增测试项。
-
-### 13.8 报告和推进方式
-
-- 测试报告必须能回答：改了什么测试、为什么覆盖生产关键风险、跑了什么验证、还有什么风险或未验证项。
-- 报告应包含每个计划项的推进状态、测试结果、通过证据或当前证据、剩余工作或阻塞原因。
-- 如果报告已经包含推进进度，就不再维护独立 progress 文档，避免重复来源。
-- 为避免多套状态来源，当前方案以 `notepads/kevent_kmsg_test_report.md` 作为唯一进度台账；每轮测试后由执行者更新报告。
-- 进度追踪规则必须写清楚：第 9 章覆盖所有测试项，每项包含状态、测试结果、证据和剩余工作。
-- 验证进度完整性时，应检查第 9 章是否覆盖 test plan 中所有测试项，以及前文执行证据是否支撑状态变化。
-- test plan 最前面必须维护目录；每次新增、删除、重命名章节时，需要同步更新目录。
-- 对阻塞项要写明阻塞原因、影响范围、当前证据和下一步。
-- 如果发现实现与设计不符，不应为了让测试通过而改写测试目标；应在报告中明确标注偏差，并保留命令、输入、实际返回和日志证据。
+- 只依据当前工作区实际存在的 kevent/kmsg 文档、模块代码和调用方代码设计测试。
+- 测试以设计文档、公开 API、生产语义和调用方契约为判断基准，不能把当前私有实现当作正确性来源。
+- 测试覆盖要全面但不冗余；调用方测试先归纳共性功能，只有出现新的共同能力时才增加测试项。
+- 测试代码不侵入模块源码；kevent 使用 integration tests，kmsg 底层契约只允许 `sled_contract.rs` 一处 `#[path]` harness。
+- 每项测试必须写清目的、重要性、方法、命令、环境要求、验证方式和证据。
+- 真实性能阈值只用于防明显卡死、panic、死锁或资源耗尽；没有产品 SLO 前只记录 baseline。
+- 如果实现与设计不符，不改写测试目标来适配实现；在报告中标注偏差并保留命令、输入、实际返回和日志证据。
+- 当前结论统一看 `notepads/kevent_kmsg_test_report.md`；每轮具体数据和当轮结论可在本地归档到 `test/kevent_kmsg/reports/`，不提交到仓库。
+- 维护本文件时必须同步更新目录。

--- a/notepads/kevent_kmsg_test_report.md
+++ b/notepads/kevent_kmsg_test_report.md
@@ -1,774 +1,207 @@
-# kevent / kmsg 测试推进报告
+# kevent / kmsg 当前测试报告
 
-生成时间：2026-05-29
+更新时间：2026-06-04
 
-## 1. 执行范围
+## 1. 报告口径
 
-依据 `notepads/kevent_kmsg_test_plan.md` 推进，本轮完成了以下测试落地与验证：
+本文件只保留当前测试结论、计划推进状态、阻塞项和复现索引。仓库不提交每轮原始执行日志；执行者如需保留本地证据，可将每轮具体测试数据、命令输出、环境信息和当轮结论保存到本地 `test/kevent_kmsg/reports/`。
 
-- 新增 kevent 模块 contract / HTTP / service / shared ring / performance baseline 测试。
-- 新增 kmsg `sled_contract.rs` 和 `rpc_contract.rs` 测试。
-- 在 rich 上构建当前分支最新 BuckyOS 服务二进制，并覆盖安装到 `/opt/buckyos`。
-- 在 rich 上重启 systemd 管理的 BuckyOS 运行态。
-- 在 rich 上执行 Rust 自动化测试与直接运行态 HTTP 探针。
-- 2026-05-29 本地新增并执行 kevent 使用功能测试，覆盖 msg_center / control_panel / OpenDAN / task_mgr 的事件 path 与 pattern 兼容性。
+`test/kevent_kmsg/reports/` 被 git 忽略，不作为仓库交付内容。关注者可按本报告和 `notepads/kevent_kmsg_test_plan.md` 中的命令在自己的环境重新执行并生成本地 reports。
 
-当前分支提交：
+统计口径：当前总数 `62` 包含可执行测试项和设计/实现偏差验证项；`R-*` 是审视主题，已经归并到对应的功能项或 `D-*` 偏差项中，不单独计数。
 
-- `dc889219 Add kevent and kmsg contract tests`
-- `26225804 Fix buckyos-api Result import ambiguity`
+当前状态：
 
-## 2. 环境
+| 状态 | 数量 |
+| --- | ---: |
+| 已完成 | 55 |
+| 部分完成 | 7 |
+| 未执行 | 0 |
+| 阻塞 | 0 |
+| 总计 | 62 |
 
-- 本地仓库：`G:\WorkSpace\buckyos`
-- 远端机器：`root@rich`
-- 远端仓库：`/home/ss/work/buckyos`
-- 远端分支：`kevent-kmsg-tests`
-- 远端 BuckyOS root：`/opt/buckyos`
-- Rust：rich 使用 `RUSTUP_TOOLCHAIN=stable`
-- 额外安装：rich 安装了 `libclang-dev` / `clang`，用于 `librocksdb-sys` bindgen 编译。
+## 2. 当前结论
 
-## 3. 构建结果
+本轮在 Linux 测试机执行了模块级测试、真实 gateway DV、restart 恢复、Docker container peer、QEMU/KVM VM peer、route debug 和性能 baseline。除已知设计/实现偏差和 `KP-05` 尚未按 30 秒持续流方式验证外，计划内可执行测试均已完成。
 
-已在 rich 上执行：
+关键结论：
+
+- kevent 模块测试通过，包含 client/service/http/shared ring/usage contract。
+- kmsg 模块测试通过，包含现有内部测试、`rpc_contract`、`sled_contract`。
+- route debug 已通过：14 passed, 0 failed。
+- BuckyOS devtest 环境基于当前构建启动成功，最终 `src/check.py` 为 `Overall Status: Running`。
+- kevent/kmsg DV 通过，验证 kmsg POST/kRPC 闭环、kevent stream、event 唤醒后回读 kmsg、轮询兜底。
+- restart 恢复通过；本轮 `subscription_after_restart` 为 `preserved`。
+- container 和 QEMU/KVM VM peer harness 均通过，验证手工配置 peer 后 native framed 单向投递。
+- 已执行的性能 baseline 全部通过，数值作为参考基线，不作为产品 SLO；`KP-05` 当前只有 gateway stream 最小验证证据。
+
+仍需关注的风险：
+
+- `/kapi/kmsg` GET 当前返回 `500`，本计划按当前行为记录，不作为失败项；需要确认最终协议应为 GET 拉模型还是 POST/kRPC。
+- kmsg `max_messages`、`retention_seconds` 和权限字段当前测试为“当前行为确认/偏差记录”，不是设计语义已经满足。
+- peer 测试证明手工 native framed 单向投递可达，仍不证明 node-daemon 会从系统配置自动建立并维护完整 peer mesh。
+
+## 3. 分类进度
+
+| 分类 | 已完成 | 部分完成 | 未执行 | 阻塞 | 当前结论 |
+| --- | ---: | ---: | ---: | ---: | --- |
+| contract.cross_module | 3 | 0 | 0 | 0 | kevent 通知 + kmsg 回读模式通过 |
+| contract.usage_function | 5 | 0 | 0 | 0 | 归纳后的共性使用能力已覆盖 |
+| crate.kevent | 15 | 0 | 0 | 0 | 模块级 contract、HTTP、shared ring、性能 baseline 通过 |
+| crate.kmsg | 8 | 1 | 0 | 0 | 主流程、RPC contract、reopen、并发通过；权限/config 有偏差 |
+| design.kevent | 4 | 2 | 0 | 0 | peer 单向投递已验证，自动 mesh 未完整验证 |
+| design.kmsg | 2 | 3 | 0 | 0 | POST/RPC 可用；GET、权限、retention、cursor 语义需设计确认 |
+| dv.gateway | 5 | 0 | 0 | 0 | 标准 devtest gateway 链路通过 |
+| dv.manual | 2 | 0 | 0 | 0 | restart 测试通过 |
+| dv.route | 2 | 0 | 0 | 0 | route debug 14 passed, 0 failed |
+| performance.kevent | 4 | 1 | 0 | 0 | local/service/shared ring/slow reader baseline 已记录；HTTP stream sustained 部分完成 |
+| performance.kmsg | 5 | 0 | 0 | 0 | baseline 已记录 |
+
+## 4. 测试项进度
+
+| 编号 | 状态 | 测试结果 | 当前证据 |
+| --- | --- | --- | --- |
+| KE-01 | 已完成 | 通过 | `cd src && cargo test -p kevent`，`client_contract.rs` 通过。 |
+| KE-02 | 已完成 | 通过 | `cd src && cargo test -p kevent`，`client_contract.rs` 通过。 |
+| KE-03 | 已完成 | 通过 | `cd src && cargo test -p kevent`，`client_contract.rs` 通过。 |
+| KE-04 | 已完成 | 通过 | `cd src && cargo test -p kevent`，reader pattern 动态更新相关测试通过。 |
+| KE-05 | 已完成 | 通过 | `cd src && cargo test -p kevent`，timer/mode contract 通过。 |
+| KE-06 | 已完成 | 通过 | `cd src && cargo test -p kevent`，mode 边界测试通过。 |
+| KE-07 | 已完成 | 通过 | `cd src && cargo test -p kevent`，`service_contract.rs` 通过。 |
+| KE-08 | 已完成 | 通过 | `cd src && cargo test -p kevent`，queue overflow 丢旧保新通过。 |
+| KE-09 | 已完成 | 通过 | `cd src && cargo test -p kevent`，peer broadcast 防环路通过。 |
+| KE-10 | 已完成 | 通过 | `cd src && cargo test -p kevent`，`http_contract.rs` 通过。 |
+| KE-11 | 已完成 | 通过 | `cd src && cargo test -p kevent`，HTTP publish endpoint 通过。 |
+| KE-12 | 已完成 | 通过 | `cd src && cargo test -p kevent` 覆盖模块级 HTTP stream；`uv run test/run.py -p kevent_kmsg/dv` 覆盖真实 gateway stream 最小链路。 |
+| KE-13 | 已完成 | 通过 | `cd src && cargo test -p node_daemon kevent_server -- --nocapture`，node_daemon kevent native tests 3 passed。 |
+| KE-14 | 已完成 | 通过 | `cd src && cargo test -p kevent`，shared ring 多 client 测试通过。 |
+| KE-15 | 已完成 | 通过 | `cd src && cargo test -p kevent`，shared ring overrun 测试通过。 |
+| KM-EXIST-01 | 已完成 | 通过 | `cd src && cargo test -p kmsg`，现有 queue 主流程测试通过。 |
+| KM-EXIST-02 | 已完成 | 通过 | `cd src && cargo test -p kmsg`，现有多订阅者测试通过。 |
+| KM-EXIST-03 | 已完成 | 通过 | `cd src && cargo test -p kmsg`，现有路径 QueueUrn 测试通过。 |
+| KM-GAP-01 | 已完成 | 通过 | `cd src && cargo test -p kmsg`，`sled_contract.rs` reopen/persistence 通过。 |
+| KM-GAP-02 | 已完成 | 当前行为已记录，设计语义未满足 | `cd src && cargo test -p kmsg`，`max_messages` / `retention_seconds` 当前未强制执行。 |
+| KM-GAP-03 | 部分完成 | handler 层偏差已确认，多身份 DV 未验证 | `cd src && cargo test -p kmsg`，当前实现忽略权限字段和 `RPCContext`；devtest 多身份不作为默认通过条件。 |
+| KM-GAP-04 | 已完成 | 通过 | `cd src && cargo test -p kmsg --test rpc_contract`，5 passed。 |
+| KM-GAP-05 | 已完成 | 通过 | `cd src && cargo test -p kmsg` 与 ignored 性能测试确认并发 post index 唯一连续。 |
+| KM-GAP-06 | 已完成 | 通过 | `cd src && cargo test -p kmsg`，sync_write reopen 级 cursor 测试通过。 |
+| KK-01 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/dv`，收到 kevent 后按 index fetch kmsg 成功。 |
+| KK-02 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/dv`，无 event 时轮询兜底 fetch kmsg 成功。 |
+| KK-03 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/dv`，重复/降级路径靠 kmsg cursor 收敛。 |
+| UF-01 | 已完成 | 通过 | `cd src && cargo test -p kevent --test usage_contract` 和 `uv run test/run.py -p kevent_kmsg/dv`，event 只做唤醒，状态通过真相源回读。 |
+| UF-02 | 已完成 | 通过 | `cd src && cargo test -p kevent --test usage_contract`，验证 msg_center、OpenDAN、control_panel、task_mgr pattern。 |
+| UF-03 | 已完成 | 通过 | `cd src && cargo test -p kevent --test usage_contract` 和静态检查，payload 保持定位/摘要语义，消费侧回读真相源。 |
+| UF-04 | 已完成 | 通过 | `cd src && cargo test -p kevent --test usage_contract`，动态 reader、fanout、unsubscribe、rebuild 通过。 |
+| UF-05 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/restart` 和 `uv run test/run.py -p kevent_kmsg/dv`，timeout/restart/断流后通过 kmsg 兜底恢复。 |
+| DV-01 | 已完成 | 通过 | `uv run src/test/test_boot_gatweay/run_debug_tests.py`，route debug 14 passed, 0 failed，包含 kevent route。 |
+| DV-02 | 已完成 | 通过 | `uv run src/test/test_boot_gatweay/run_debug_tests.py`，route debug 14 passed, 0 failed，包含 kmsg route。 |
+| DV-03 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/dv`，真实 gateway kmsg create/post/subscribe/fetch/ack/delete 闭环通过。 |
+| DV-03B | 已完成 | 当前行为已记录 | `uv run test/run.py -p kevent_kmsg/dv`，POST 可用，GET 返回 `500`，不作为失败项。 |
+| DV-04 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/dv`，真实 gateway kevent stream 最小验证通过。 |
+| DV-05 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/dv`，kmsg 持久化 + kevent 通知组合链路通过。 |
+| DV-06 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/dv`，公开入口重连后仍可读消息。 |
+| DV-MANUAL-01 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/restart`，服务重启后重启前消息仍可读。 |
+| DV-MANUAL-02 | 已完成 | 通过 | `uv run test/run.py -p kevent_kmsg/restart`，旧 stream 有界关闭或恢复，重建后 kmsg/kevent 可用。 |
+| KP-01 | 已完成 | 通过 | `cd src && cargo test -p kevent --test performance -- --ignored --nocapture --test-threads=1`，`kevent_local_publish_10k_ms=60`。 |
+| KP-02 | 已完成 | 通过 | 同上，`kevent_service_publish_10k_ms=118`。 |
+| KP-03 | 已完成 | 通过 | 同上，`kevent_shared_ring_roundtrip_2k_ms=331`。 |
+| KP-04 | 已完成 | 通过 | 同上，slow reader retained 最新 1024 条，index 单调。 |
+| KP-05 | 部分完成 | gateway stream 最小验证通过，30 秒 sustained 未单独执行 | `uv run test/run.py -p kevent_kmsg/dv` 覆盖 stream 最小链路；缺少 30 秒持续流性能证据。 |
+| MP-01 | 已完成 | 通过 | `cd src && cargo test -p kmsg --test sled_contract -- --ignored --nocapture`，`kmsg_post_10k_ms=12226`。 |
+| MP-02 | 已完成 | 通过 | 同上，`kmsg_fetch_10k_ms=3028`。 |
+| MP-03 | 已完成 | 通过 | 同上，`kmsg_fetch_ack_10k_ms=753`。 |
+| MP-04 | 已完成 | 通过 | 同上，`kmsg_concurrent_post_10k_ms=7780`。 |
+| MP-05 | 已完成 | 通过 | 同上，sync_write false/true 1k baseline 已记录。 |
+| D-01 | 已完成 | 已确认偏差 | `cd src && cargo test -p kevent`，local 64KB 限制与 shared ring slot 限制行为已固定。 |
+| D-02 | 部分完成 | 单向 framed peer 已验证，自动 mesh 未完整验证 | `uv run test/run.py -p kevent_kmsg/peer_container` 和 `uv run test/run.py -p kevent_kmsg/peer_vm`，node_a -> node_b 可达。 |
+| D-03 | 部分完成 | 外部 client 到任一 daemon 单向可达，完整全 mesh 依赖 D-02 | `uv run test/run.py -p kevent_kmsg/peer_container` 和 `uv run test/run.py -p kevent_kmsg/peer_vm`。 |
+| D-04 | 已完成 | 当前错误语义已固定 | `cd src && cargo test -p kevent`，reader 生命周期和错误路径测试通过。 |
+| D-05 | 已完成 | 当前行为已确认 | `cd src && cargo test -p kevent`，shared ring mirror 失败时 service/HTTP publish 返回错误。 |
+| D-06 | 已完成 | 已确认偏差 | `cd src && cargo test -p kmsg`，config 字段保存但未执行裁剪/过期清理。 |
+| D-07 | 部分完成 | handler 层已确认偏差，多身份 DV 未验证 | `cd src && cargo test -p kmsg`，权限字段当前未参与鉴权。 |
+| D-08 | 已完成 | 当前行为已记录 | `uv run test/run.py -p kevent_kmsg/dv`，`/kapi/kmsg` POST 可用，GET 返回 `500`。 |
+| D-09 | 部分完成 | reopen/restart 级通过，crash 级 cursor 未验证 | `cd src && cargo test -p kmsg` 和 `uv run test/run.py -p kevent_kmsg/restart`，reopen 和服务重启恢复通过。 |
+| D-10 | 部分完成 | API/文档差异已记录，正式文档未修订 | 本报告第 9 章记录修补建议。 |
+| D-11 | 已完成 | 当前调用方 path/pattern 风险已固化测试 | `cd src && cargo test -p kevent --test usage_contract` 通过。 |
+
+## 5. 复现索引
+
+模块级测试：
 
 ```bash
-cd /home/ss/work/buckyos/src
-RUSTUP_TOOLCHAIN=stable LIBCLANG_PATH=/usr/lib/llvm-18/lib /root/.local/bin/uv run buckyos-build.py --skip-web --target=x86_64-unknown-linux-gnu
-```
-
-结果：通过。
-
-构建产物已复制并更新到 `/opt/buckyos`，包括：
-
-- `node_daemon`
-- `system_config`
-- `scheduler`
-- `task_manager`
-- `kmsg`
-- `control_panel`
-- `msg_center`
-- `opendan`
-- 其他 rootfs 内 Rust 服务
-
-同时发现默认 musl 构建缺少 `x86_64-linux-musl-g++ / ar / ranlib`，本轮使用 GNU target 完成 rich 运行态验证。
-
-## 4. 自动化测试结果
-
-### 4.1 kevent
-
-命令：
-
-```bash
-cd /home/ss/work/buckyos/src
-RUSTUP_TOOLCHAIN=stable LIBCLANG_PATH=/usr/lib/llvm-18/lib cargo test -p kevent
-```
-
-结果：通过。
-
-覆盖：
-
-- 原有 kevent 单元测试：11 passed
-- `client_contract.rs`：4 passed
-- `http_contract.rs`：4 passed
-- `service_contract.rs`：4 passed
-- `usage_contract.rs`：2 passed
-- `shared_ring_contract.rs`：2 passed
-- ignored performance 未在默认命令中执行
-
-### 4.2 kmsg
-
-命令：
-
-```bash
-cd /home/ss/work/buckyos/src
-RUSTUP_TOOLCHAIN=stable LIBCLANG_PATH=/usr/lib/llvm-18/lib cargo test -p kmsg
-```
-
-结果：通过。
-
-覆盖：
-
-- 原有 kmsg 内部测试：3 passed
-- `rpc_contract.rs`：5 passed
-- `sled_contract.rs`：9 passed，1 ignored
-
-`sled_contract.rs` 中因 `#[path]` include 触发原文件内部测试再次运行，符合测试方案中记录的风险预期。
-
-### 4.3 2026-05-29 本地补充测试
-
-本轮按 `UF-02` 和 `D-11/R-09` 继续推进，新增：
-
-- `src/kernel/kevent/tests/usage_contract.rs`
-
-新增测试覆盖：
-
-- `msg_center` 当前发布的 `/msg_center/{owner}/box/{box}/changed` 事件样本。
-- `control_panel` chat stream 当前订阅的 `/msg_center/{owner}/box/in/**` 和 `/msg_center/{owner}/box/out/**`。
-- `OpenDAN msg_center_pump` 当前订阅的新旧两类 msg_center path。
-- `TaskManagerClient::wait_for_task_end_kevent` 当前订阅的 `/task_mgr/{id}`。
-- kevent reader 注销后的生命周期行为：注销后 pull 返回空、update 返回 `READER_CLOSED`，重新注册后不继承旧队列。
-
-执行前发现 `src/kernel/buckyos-api/src/runtime.rs` 中存在重复 `use ::kRPC::Result;`，导致 `buckyos-api` 编译失败。已删除重复 import，这是继续运行 kevent/kmsg 测试所需的最小编译修复。
-
-命令：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent --test usage_contract
-```
-
-结果：通过。
-
-证据：
-
-```text
-running 2 tests
-test task_manager_wait_pattern_matches_task_events_only ... ok
-test msg_center_box_events_match_current_consumers ... ok
-
-test result: ok. 2 passed; 0 failed; 0 ignored
-```
-
-回归命令：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
+cd src
 cargo test -p kevent
-```
-
-结果：通过。
-
-关键证据：
-
-```text
-usage_contract.rs: 3 passed
-client_contract.rs: 4 passed
-http_contract.rs: 4 passed
-service_contract.rs: 4 passed
-shared_ring_contract.rs: 2 passed
-kevent lib tests: 11 passed
-```
-
-补充执行：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent --test service_contract
-```
-
-结果：通过。
-
-证据：
-
-```text
-running 4 tests
-test unregister_reader_closes_update_path_and_drops_queue ... ok
-test service_register_publish_pull_and_invalid_inputs ... ok
-test peer_publish_delivers_once_and_does_not_rebroadcast_peer_events ... ok
-test reader_queue_overflow_drops_oldest_events ... ok
-
-test result: ok. 4 passed; 0 failed; 0 ignored
-```
-
-kmsg 回归命令：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
 cargo test -p kmsg
-```
-
-结果：通过。
-
-关键证据：
-
-```text
-kmsg src/main.rs tests: 3 passed
-rpc_contract.rs: 5 passed
-sled_contract.rs: 9 passed, 1 ignored
-```
-
-### 4.4 2026-05-29 路由配置测试尝试
-
-本地执行：
-
-```powershell
-cd G:\WorkSpace\buckyos
-uv run src/test/test_boot_gatweay/run_debug_tests.py
-```
-
-结果：未进入路由断言，环境失败。
-
-证据：
-
-```text
-Error: cyfs_gateway binary not found
-```
-
-随后在 rich 上执行：
-
-```bash
-cd /home/ss/work/buckyos
-/root/.local/bin/uv run src/test/test_boot_gatweay/run_debug_tests.py
-```
-
-结果：未进入 kevent/kmsg 路由断言，cyfs-gateway debug 在加载配置阶段失败。该失败影响全部 14 个 boot gateway debug case。
-
-关键证据：
-
-```text
-Binary: /opt/buckyos/bin/cyfs-gateway/cyfs_gateway
-Config: /home/ss/work/buckyos/src/rootfs/etc/boot_gateway.yaml
-Test cases: 14
-Invalid forward command ... unexpected argument '--backup-map' found
-Usage: forward --map <upstream_map> [dest_urls]...
-debug error: create process chain executor failed
-```
-
-结论：`DV-01` / `DV-02` 当前被 cyfs-gateway debug binary 与 `boot_gateway.yaml` 的 `forward round_robin --backup-map` 配置能力不匹配阻塞；这不是 kevent/kmsg 路由规则本身的失败证据。
-
-### 4.5 2026-05-29 kevent 大事件边界补充测试
-
-本轮补充 `D-01/R-03` 和 `D-05` 的模块级验证，新增测试位于：
-
-- `src/kernel/kevent/tests/shared_ring_contract.rs`
-
-新增覆盖：
-
-- shared ring 对超过 slot 容量的事件返回 `payload too large`。
-- `KEventService` 配置 shared ring 后，若 mirror 到 shared ring 失败，当前行为是 `publish_local_global` 返回 `KEventError::Internal`，并且事件不进入 reader queue。
-- HTTP `/kapi/kevent/publish` 在同类 shared ring mirror 失败时返回 500，响应体错误码为 `INTERNAL`，并且事件不进入 reader queue。
-
-命令：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent --test shared_ring_contract -- --test-threads=1
-```
-
-结果：通过。
-
-证据：
-
-```text
-running 4 tests
-test service_returns_error_when_shared_ring_mirror_rejects_event ... ok
-test shared_ring_delivers_first_event_from_late_producer ... ok
-test shared_ring_overrun_drops_oldest_without_corrupting_events ... ok
-test shared_ring_rejects_events_larger_than_slot ... ok
-
-test result: ok. 4 passed; 0 failed; 0 ignored
-```
-
-完整 kevent 回归：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent
-```
-
-结果：通过。
-
-关键证据：
-
-```text
-shared_ring_contract.rs: 4 passed
-http_contract.rs: 5 passed
-service_contract.rs: 4 passed
-usage_contract.rs: 2 passed
-kevent lib tests: 11 passed
-```
-
-HTTP 补充命令：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent --test http_contract
-```
-
-结果：通过。
-
-证据：
-
-```text
-running 5 tests
-test publish_endpoint_reports_shared_ring_large_event_failure ... ok
-test publish_endpoint_sets_global_event_metadata_and_rejects_local_eventid ... ok
-test native_endpoint_roundtrips_protocol_and_rejects_bad_json ... ok
-test stream_endpoint_emits_ack_event_and_keepalive_frames ... ok
-test unsupported_path_returns_bad_request_response ... ok
-
-test result: ok. 5 passed; 0 failed; 0 ignored
-```
-
-结论：已确认当前 shared ring 路径与 kevent 文档 64KB data 上限存在实际冲突；service 和 HTTP publish 当前都会把 shared ring mirror 失败作为 publish 错误处理，不是静默丢弃。纯 local 路径和接近 64KB data 的行为仍需后续补充验证。
-
-### 4.6 2026-05-29 kevent local 大事件补充测试
-
-本轮补充 `D-01/R-03` 的 local SDK 路径验证，新增测试位于：
-
-- `src/kernel/kevent/tests/client_contract.rs`
-
-新增覆盖：
-
-- local pub/sub 可以投递 4KB data，不受 shared ring 2KB slot 限制影响。
-- SDK 层超过 64KB data 会被 `validate_event_data_size` 拒绝，当前错误类型为 `KEventError::InvalidEventId`。
-
-命令：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent --test client_contract
-```
-
-结果：通过。
-
-证据：
-
-```text
-running 6 tests
-test local_pub_sub_accepts_large_data_within_sdk_limit ... ok
-test event_data_larger_than_sdk_limit_is_rejected ... ok
-test eventid_and_pattern_validation_contract ... ok
-test pattern_match_and_normalize_contract ... ok
-test local_pub_sub_timeout_and_dynamic_patterns ... ok
-test timer_and_mode_boundaries_are_explicit ... ok
-
-test result: ok. 6 passed; 0 failed; 0 ignored
-```
-
-完整 kevent 回归：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent
-```
-
-结果：通过。
-
-关键证据：
-
-```text
-client_contract.rs: 6 passed
-http_contract.rs: 5 passed
-shared_ring_contract.rs: 4 passed
-service_contract.rs: 4 passed
-usage_contract.rs: 2 passed
-kevent lib tests: 11 passed
-```
-
-### 4.7 2026-05-29 使用方 reader 动态订阅 smoke
-
-本轮补充 `UF-04`，新增测试位于：
-
-- `src/kernel/kevent/tests/usage_contract.rs`
-
-新增覆盖：
-
-- 重复 pattern 不导致同一 reader 重复收到同一事件。
-- 多 reader 订阅同一事件时可以 fanout。
-- 动态取消订阅后不再收到对应事件。
-- reader 关闭后重新创建不会继承旧队列，只接收新事件。
-
-命令：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent --test usage_contract
-```
-
-结果：通过。
-
-证据：
-
-```text
-running 3 tests
-test task_manager_wait_pattern_matches_task_events_only ... ok
-test msg_center_box_events_match_current_consumers ... ok
-test dynamic_readers_fanout_unsubscribe_and_rebuild ... ok
-
-test result: ok. 3 passed; 0 failed; 0 ignored
-```
-
-完整 kevent 回归：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
-cargo test -p kevent
-```
-
-结果：通过。`usage_contract.rs` 当前 3 passed。
-
-### 4.8 2026-05-29 node_daemon native framed 测试尝试
-
-本轮尝试推进 `KE-13`：
-
-```powershell
-cd G:\WorkSpace\buckyos\src
 cargo test -p node_daemon kevent_server -- --nocapture
 ```
 
-结果：未形成有效通过证据。
-
-证据：
-
-```text
-command timed out after 184040 milliseconds
-```
-
-处理：超时后检查到残留 `cargo` 进程，并已停止。该项当前不计通过；报告中标记为阻塞，后续需要更长构建窗口、预编译 node_daemon，或把 native framed 协议测试拆到可快速运行的独立测试入口。
-
-## 5. 性能基线
-
-### 5.1 kevent performance baseline
-
-命令：
+真实环境和路由测试：
 
 ```bash
-cd G:\WorkSpace\buckyos\src
+uv run src/test/test_boot_gatweay/run_debug_tests.py
+uv run src/check.py
+uv run test/run.py -p kevent_kmsg/dv
+uv run test/run.py -p kevent_kmsg/restart
+uv run test/run.py -p kevent_kmsg/peer_container
+uv run test/run.py -p kevent_kmsg/peer_vm
+```
+
+性能 baseline：
+
+```bash
+cd src
 cargo test -p kevent --test performance -- --ignored --nocapture --test-threads=1
-```
-
-结果：通过。
-
-证据：
-
-```json
-{"kevent_local_publish_10k_ms":46,"kevent_local_consume_retained_ms":2,"kevent_local_retained":1024}
-{"kevent_service_publish_10k_ms":71,"kevent_service_consume_10k_ms":22}
-{"kevent_shared_ring_roundtrip_2k_ms":3045,"kevent_shared_ring_roundtrips":2000}
-```
-
-说明：local retained 为 1024，符合当前本地队列容量保留语义；shared ring baseline 使用 Full client publish/pull 成对执行，避免把 ring overrun 语义混入延迟基线。
-
-### 5.2 kmsg performance baseline
-
-命令：
-
-```bash
-cd G:\WorkSpace\buckyos\src
 cargo test -p kmsg --test sled_contract -- --ignored --nocapture
 ```
 
-结果：通过。
+本轮环境准备补充：
 
-证据：
+- Linux 测试机非交互 shell 需要 `PATH=/root/.deno/bin:$PATH` 才能运行 Deno。
+- `buckyos-build.py --skip-web` 默认 musl target 会因缺少 musl C++ 工具链失败；本轮使用 `--target=x86_64-unknown-linux-gnu` 完成构建。
+- 独立归档运行目录需要补齐未跟踪 rootfs 资源：`node-active`、`buckyos_systest` / `sys-test`、`control-panel/web`。
 
-```json
-{"kmsg_sync_write_false_post_1k_ms":1276,"kmsg_sync_write_true_post_1k_ms":6757}
-{"kmsg_concurrent_post_10k_ms":12248,"kmsg_concurrent_post_count":10000}
-{"kmsg_fetch_ack_10k_ms":968,"kmsg_fetch_ack_count":10000}
-{"kmsg_post_10k_ms":16760,"kmsg_fetch_10k_ms":2256}
-```
+## 6. 关键证据
 
-## 6. rich 运行态探针
-
-完整 DV 网关入口暂不可用，因此本轮补充直接访问本机服务端口的运行态探针，验证最新进程实际提供核心能力。
-
-### 6.1 kmsg 直接 HTTP/kRPC 探针
-
-目标端口：`127.0.0.1:4030`
-
-验证项：
-
-- `create_queue`
-- `post_message`
-- `read_message`
-- `get_queue_stats`
-- `delete_queue`
-
-关键证据：
-
-```json
-{"result":"buckycli::devtest::direct-probe-20260527","sys":[1]}
-{"result":1,"sys":[2]}
-{"result":[{"created_at":1779886740,"headers":{"probe":"direct"},"index":1,"payload":[123,34,99,97,115,101,34,58,34,100,105,114,101,99,116,34,44,34,118,97,108,117,101,34,58,34,104,101,108,108,111,34,125]}],"sys":[3]}
-{"result":{"first_index":1,"last_index":1,"message_count":1,"size_bytes":33},"sys":[4]}
-{"result":null,"sys":[5]}
-```
-
-结论：kmsg 最新运行进程可通过公开 HTTP/kRPC 入口完成可靠队列基本闭环。
-
-### 6.2 kevent 直接 HTTP 探针
-
-目标端口：`127.0.0.1:3181`
-
-验证项：
-
-- `/kapi/kevent/publish`
-- `/kapi/kevent` native `register_reader`
-- native `pull_event`
-- native `unregister_reader`
-
-关键证据：
-
-```json
-{"status":"ok"}
-{"status":"ok","event":{"eventid":"/direct_probe/native_20260527","source_node":"ood1","source_pid":740548,"ingress_node":"ood1","timestamp":1779889118738,"data":{"case":"native-pull","value":"hello"}}}
-{"status":"ok"}
-```
-
-结论：kevent 最新运行进程可完成订阅、发布、拉取和注销闭环，并正确补充 source / ingress 元数据。
-
-## 7. rich 构建与 DV 环境诊断
-
-本章只记录 rich 上的构建、重启、运行态探针和 DV 环境诊断细节，不作为测试计划推进状态的总览。每个计划项的状态、结果和证据以第 9 章为准。
-
-### 7.0 rich 最新二进制重建确认
-
-根据 review 反馈，已在 rich 上确认不依赖现有旧安装，而是在当前分支最新提交重新构建并更新运行产物。
-
-执行提交：
-
-```text
-11251f8ea94407e32698ef833a1acef2af485594
-```
-
-构建命令：
-
-```bash
-cd /home/ss/work/buckyos/src
-RUSTUP_TOOLCHAIN=stable LIBCLANG_PATH=/usr/lib/llvm-18/lib /root/.local/bin/uv run buckyos-build.py --skip-web --target=x86_64-unknown-linux-gnu
-```
-
-结果：通过。构建日志确认重新复制并更新了以下关键服务到 `/opt/buckyos/bin`：
-
-- `node-daemon/node_daemon`
-- `kmsg/kmsg`
-- `system-config/system_config`
-- `verify-hub/verify_hub`
-- `scheduler/scheduler`
-- `control-panel/control_panel`
-- `msg-center/msg_center`
-- `opendan/opendan`
-
-重启命令：
-
-```bash
-cd /home/ss/work/buckyos/src
-/root/.local/bin/uv run stop.py
-systemctl restart buckyos
-```
-
-运行态确认：
-
-```text
-/opt/buckyos/bin/node-daemon/node_daemon --enable_active
-/opt/buckyos/bin/system-config/system_config
-/opt/buckyos/bin/verify-hub/verify_hub
-/opt/buckyos/bin/kmsg/kmsg
-/opt/buckyos/bin/scheduler/scheduler
-/opt/buckyos/bin/control-panel/control_panel
-```
-
-监听端口确认：
-
-```text
-3181 node_daemon
-3200 system_config
-3300 verify_hub
-4020 control_panel
-4030 kmsg
-```
-
-重建后补充探针：
-
-```json
-{"status":"ok"}
-{"result":"buckycli::devtest::after-rebuild-20260527","sys":[0]}
-{"result":1,"sys":[0]}
-{"result":[{"created_at":1779891522,"headers":{"probe":"after-rebuild"},"index":1,"payload":[97,102,116,101,114,45,114,101,98,117,105,108,100]}],"sys":[0]}
-{"result":{"first_index":1,"last_index":1,"message_count":1,"size_bytes":13},"sys":[0]}
-{"result":null,"sys":[0]}
-```
-
-结论：rich 已运行当前分支最新构建产物，`kevent` 直连发布和 `kmsg` create/post/read/stats/delete 闭环在重建后继续通过。
-
-### 7.1 DV runner 阻塞详情
-
-计划中的命令：
-
-```bash
-cd /home/ss/work/buckyos
-/root/.local/bin/uv run test/run.py -p kevent_kmsg_test
-```
-
-未执行原因：
-
-- rich 当前 `cyfs_gateway` 无法保持运行。
-- `src/check.py` 状态为 `Abnormal`。
-- 80 / 3180 端口不可达。
-- `test/kevent_kmsg_test` 依赖 gateway 入口和 Deno runner；在 gateway 不可用时执行只会得到环境失败，不能验证 kevent/kmsg 业务契约。
-
-相关检查证据：
-
-```text
-[FAIL] cyfs_gateway Process: No cyfs_gateway process found
-[FAIL] Port 80: zone_gateway_http is not reachable
-[FAIL] Port 3180: node_gateway_http is not reachable
-```
-
-进一步定位：
-
-- 从 `/home/ss/work/cyfs-gateway/src` 重新构建并安装 cyfs-gateway 成功。
-- 但当前 cyfs-gateway 二进制无参数启动只打印 help 后退出。
-- 手工执行 `cyfs_gateway start` 仍因访问 `http://127.0.0.1:13451/` 失败退出。
-- 这表明当前 rich 上 cyfs-gateway 与 node_daemon/native fallback 的启动契约或运行时上下文存在不一致。
-
-### 7.2 Deno 环境状态
-
-rich 当前没有 `deno`。由于 gateway 已阻塞 DV，本轮未继续安装 Deno。待 80/3180 恢复后再安装并执行 DV 更有价值。
-
-## 8. 结论
-
-本轮已完成 kevent/kmsg 模块级测试、RPC/HTTP contract 测试、性能基线测试，并在 rich 上用当前分支最新二进制完成直接运行态探针。
-
-核心结论：
-
-- kevent 模块测试通过，运行态 `3181` 直连验证通过。
-- kmsg 模块测试通过，运行态 `4030` 直连验证通过。
-- kmsg 当前实现中 config retention / max_messages / 权限字段未被强制执行，已由 `sled_contract.rs` 作为当前行为偏差显式记录。
-- 完整 DV 仍被 rich 的 `cyfs_gateway` 运行态阻塞，需先修复 gateway 启动契约或恢复 3180 网关入口后继续。
-
-## 9. 测试计划推进状态
-
-本节是测试计划推进状态的唯一总览。每轮执行测试后，需要同步更新本节中相关测试项的状态、测试结果、证据和剩余工作。
-
-当前统计：
-
-```text
-Total: 62
-已完成: 37
-部分完成: 5
-未执行: 10
-阻塞: 10
-```
-
-状态定义：
-
-- `已完成`：已有自动化测试或明确运行态探针证据。
-- `部分完成`：已覆盖核心正确性，但未完全按计划中的环境、规模或路径执行。
-- `未执行`：计划项尚无执行证据。
-- `阻塞`：受环境或依赖问题阻塞，当前执行只会得到环境失败。
-
-### 状态统计
-
-| 状态 | 数量 |
+| 测试 | 最新证据 |
 | --- | --- |
-| 已完成 | 37 |
-| 部分完成 | 5 |
-| 未执行 | 10 |
-| 阻塞 | 10 |
+| route debug | `Result: 14 passed, 0 failed` |
+| final check | `Overall Status: Running` |
+| kevent/kmsg DV | `{"status":"passed","queue_urn":"buckycli::devtest::kevent-kmsg-dv-1780562132241-dde7a1b3","indexes":{"firstIndex":1,"signalIndex":2,"fallbackIndex":3}}` |
+| kmsg GET 当前行为 | `{"case":"DV-03B","note":"GET is recorded for current behavior only","status":500}` |
+| restart 恢复 | `{"status":"passed","queue_urn":"buckycli::devtest::kevent-kmsg-restart-1780562232327-4f21db90","indexes":{"firstIndex":1,"fallbackIndex":2},"old_stream":"closed:TypeError: error reading a body from connection","subscription_after_restart":"preserved","restart_seen":true,"check_seen":true}` |
+| container peer | `{"eventid":"/peer/container/1780562478742","ingress_node":"node_b","source_node":"external-client","status":"passed"}` |
+| VM peer | `{"backend":"qemu-kvm","node_a_port":13183,"node_b_port":23183,"status":"passed"}` |
+| kevent slow reader baseline | `{"kevent_slow_reader_publish_10k_ms":183,"kevent_slow_reader_drain_ms":3,"kevent_slow_reader_retained":1024,"kevent_slow_reader_first_seq":8976,"kevent_slow_reader_last_seq":9999}` |
+| kmsg post/fetch baseline | `{"kmsg_post_10k_ms":12226,"kmsg_fetch_10k_ms":3028}` |
 
-### 按分类统计
+## 7. 本轮测试代码修正
 
-| 分类 | 已完成 | 部分完成 | 未执行 | 阻塞 |
-| --- | --- | --- | --- | --- |
-| contract.cross_module | 0 | 0 | 3 | 0 |
-| contract.usage_function | 2 | 0 | 3 | 0 |
-| crate.kevent | 14 | 0 | 0 | 1 |
-| crate.kmsg | 8 | 1 | 0 | 0 |
-| design.kevent | 4 | 0 | 2 | 0 |
-| design.kmsg | 1 | 3 | 0 | 1 |
-| dv.gateway | 0 | 0 | 0 | 5 |
-| dv.manual | 0 | 0 | 2 | 0 |
-| dv.route | 0 | 0 | 0 | 2 |
-| performance.kevent | 3 | 1 | 0 | 1 |
-| performance.kmsg | 5 | 0 | 0 | 0 |
+本轮执行时发现统一目录迁移后的测试路径问题，并已修正：
 
-### 9.1 crate contract tests
+- `test/kevent_kmsg/restart/kevent_kmsg_restart_dv.ts`：`repoRoot()` 改为仓库根目录。
+- `test/kevent_kmsg/peer_container/main.py` 和 `test/kevent_kmsg/peer_vm/main.py`：`ROOT` 改为仓库根目录。
+- `test/kevent_kmsg/peer_container/harness/Cargo.toml`：本地依赖路径改为当前目录深度。
 
-| 编号 | 分类 | 状态 | 测试结果 | 当前证据 | 剩余工作 |
-| --- | --- | --- | --- | --- | --- |
-| KE-01 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；client_contract.rs 通过 | 无 |
-| KE-02 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；client_contract.rs 通过 | 无 |
-| KE-03 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；client_contract.rs 通过 | 无 |
-| KE-04 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；原有 kevent 单元测试通过 | 无 |
-| KE-05 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；client_contract.rs 通过 | 无 |
-| KE-06 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；client_contract.rs 通过 | 无 |
-| KE-07 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；service_contract.rs 4 passed | 无 |
-| KE-08 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；service_contract.rs 4 passed | 无 |
-| KE-09 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；service_contract.rs 4 passed | 无 |
-| KE-10 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；http_contract.rs 5 passed | 无 |
-| KE-11 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；http_contract.rs 5 passed；rich 直连 3181 publish 返回 {"status":"ok"} | 无 |
-| KE-12 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；http_contract.rs 5 passed | 后续可在 DV 中补真实 gateway stream |
-| KE-13 | crate.kevent | 阻塞 | 未形成有效通过证据 | `cargo test -p node_daemon kevent_server -- --nocapture` 在 Windows 环境 180 秒超时；已停止残留 cargo 进程 | 需要更长构建窗口、预编译 node_daemon，或拆出可快速运行的 native framed 独立测试入口；非法 frame length 仍未覆盖 |
-| KE-14 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；shared_ring_contract.rs 4 passed | 无 |
-| KE-15 | crate.kevent | 已完成 | 通过 | cargo test -p kevent；shared_ring_contract.rs 4 passed | 无 |
-| KM-EXIST-01 | crate.kmsg | 已完成 | 通过 | cargo test -p kmsg；原有内部测试通过 | 无 |
-| KM-EXIST-02 | crate.kmsg | 已完成 | 通过 | cargo test -p kmsg；原有内部测试通过 | 无 |
-| KM-EXIST-03 | crate.kmsg | 已完成 | 通过 | cargo test -p kmsg；原有内部测试通过 | 无 |
-| KM-GAP-01 | crate.kmsg | 已完成 | 通过 | cargo test -p kmsg --test sled_contract 通过 | 无 |
-| KM-GAP-02 | crate.kmsg | 已完成 | 当前行为已确认，不通过设计预期 | sled_contract.rs 确认 max_messages / retention_seconds 当前未强制执行 | 后续若修实现，需要把当前行为测试改为契约通过测试 |
-| KM-GAP-03 | crate.kmsg | 部分完成 | handler 层当前行为已确认；DV 多身份未验证 | sled_contract.rs 确认当前忽略 RPCContext / 权限字段 | DV 多身份验证未执行 |
-| KM-GAP-04 | crate.kmsg | 已完成 | 通过 | cargo test -p kmsg --test rpc_contract 通过 | 无 |
-| KM-GAP-05 | crate.kmsg | 已完成 | 通过 | sled_contract.rs 1000 条并发 post 正确性通过 | 性能规模的 10k 并发 baseline 未执行 |
-| KM-GAP-06 | crate.kmsg | 已完成 | 通过 | sled_contract.rs reopen 后 cursor 测试通过 | crash 级验证未覆盖 |
+## 8. 当前阻塞
 
-### 9.2 跨模块和使用功能契约 smoke
+无。
 
-| 编号 | 分类 | 状态 | 测试结果 | 当前证据 | 剩余工作 |
-| --- | --- | --- | --- | --- | --- |
-| KK-01 | contract.cross_module | 未执行 | 未验证 | 无 | 需要 DV 或独立跨模块 harness |
-| KK-02 | contract.cross_module | 未执行 | 未验证 | 无 | 需要 DV 或独立跨模块 harness |
-| KK-03 | contract.cross_module | 未执行 | 未验证 | 无 | 需要 DV 或独立跨模块 harness |
-| UF-01 | contract.usage_function | 未执行 | 未验证 | 已从 TaskMgr、AgentRuntime、control_panel、OpenDAN 使用方式中归纳出“event 唤醒后回读真相源”共同契约 | 增加 mock smoke：event payload 与真相源不一致、timeout、重复 event、订阅失败时仍回读真相源 |
-| UF-02 | contract.usage_function | 已完成 | 通过 | `cargo test -p kevent --test usage_contract` 3 passed；`msg_center_box_events_match_current_consumers` 和 `task_manager_wait_pattern_matches_task_events_only` 覆盖 producer event id 样本与 consumer pattern 匹配 | 无 |
-| UF-03 | contract.usage_function | 未执行 | 未验证 | 已静态确认当前事件 payload 主要承担定位和摘要职责 | 增加 payload 最小可用契约 smoke，验证消费侧通过 payload 定位后回读完整数据 |
-| UF-04 | contract.usage_function | 已完成 | 通过 | `cargo test -p kevent --test usage_contract` 3 passed；`dynamic_readers_fanout_unsubscribe_and_rebuild` 覆盖重复 pattern 去重、reader fanout、取消订阅、关闭后重建不继承旧事件 | 无 |
-| UF-05 | contract.usage_function | 未执行 | 未验证 | 已静态确认多个调用方要求 kevent 失败时 fallback 到 poll/sweep/fetch | 增加 create reader 失败、pull timeout、ReaderClosed、stream 断开、重复/丢失 event 的退化路径 smoke |
+## 9. 原始文档修补建议
 
-### 9.3 route / DV tests
+以下只记录建议，不直接修改原始文档：
 
-| 编号 | 分类 | 状态 | 测试结果 | 当前证据 | 剩余工作 |
-| --- | --- | --- | --- | --- | --- |
-| DV-01 | dv.route | 阻塞 | 未进入路由断言 | 本地执行 `uv run src/test/test_boot_gatweay/run_debug_tests.py` 失败：`cyfs_gateway binary not found`；rich 执行同命令失败：cyfs-gateway debug 不支持当前 `boot_gateway.yaml` 中的 `forward round_robin --backup-map` 参数 | 需提供本地 cyfs_gateway binary，或在 rich 上更新 cyfs-gateway 到支持当前配置语法的版本后重跑 |
-| DV-02 | dv.route | 阻塞 | 未进入路由断言 | 同 DV-01；全部 14 个 boot gateway debug case 在配置加载/链路构建阶段失败，未能验证 `/kapi/kmsg` service route | 需修复 cyfs-gateway debug binary 与 `boot_gateway.yaml` 能力不匹配后重跑 |
-| DV-03 | dv.gateway | 阻塞 | gateway 未验证；直连通过 | rich 直连 4030 CRUD 通过 | rich cyfs_gateway / 3180 不可用 |
-| DV-03B | dv.gateway | 阻塞 | gateway 未验证；GET 未记录 | rich 直连 4030 POST 通过 | 需 gateway 恢复后通过 /kapi/kmsg 记录 POST/GET |
-| DV-04 | dv.gateway | 阻塞 | gateway 未验证 | crate HTTP stream 通过；rich 直连 publish 通过 | 需 gateway 恢复后通过 /kapi/kevent/stream 验证 |
-| DV-05 | dv.gateway | 阻塞 | 未验证 | 无 | 需 gateway 恢复 |
-| DV-06 | dv.gateway | 阻塞 | gateway 未验证；crate reopen 通过 | crate reopen 通过；rich 直连 CRUD 通过 | 需 gateway 恢复并运行 DV |
-| DV-MANUAL-01 | dv.manual | 未执行 | 未验证 | 无 | 手工 checklist 尚未执行 |
-| DV-MANUAL-02 | dv.manual | 未执行 | 未验证 | 无 | 手工 checklist 尚未执行 |
+| 编号 | 结论 |
+| --- | --- |
+| D-02 / D-03 | kevent peer 单向 native framed 投递已通过模块、container、VM harness 验证；完整 node-daemon 自动 peer mesh 仍需设计或实现确认。 |
+| D-05 / D-06 | kmsg `max_messages`、`retention_seconds` 和权限字段当前未形成完整可验证约束；建议明确这些字段是生产契约还是预留字段。 |
+| D-08 | `/kapi/kmsg` 当前以 POST/kRPC 为可用入口，GET 拉模型不可用；建议修正文档或补实现。 |
+| D-09 | 本轮 restart 中 subscription 为 `preserved`，但 crash 级 cursor 可靠性仍需设计确认。 |
+| D-10 | `doc/arch/kmsg.md` 未完整覆盖当前公开 API，包括 `read_message`、权限 bool 和绝对路径 QueueUrn 透传规则，建议后续补文档。 |
 
-### 9.4 性能测试
+## 10. 维护规则
 
-| 编号 | 分类 | 状态 | 测试结果 | 当前证据 | 剩余工作 |
-| --- | --- | --- | --- | --- | --- |
-| KP-01 | performance.kevent | 已完成 | 通过 | `cargo test -p kevent --test performance -- --ignored --nocapture --test-threads=1`；kevent_local_publish_10k_ms=46；kevent_local_consume_retained_ms=2；kevent_local_retained=1024 | 无 |
-| KP-02 | performance.kevent | 已完成 | 通过 | 同上；kevent_service_publish_10k_ms=71；kevent_service_consume_10k_ms=22 | 无 |
-| KP-03 | performance.kevent | 已完成 | 通过 | 同上；kevent_shared_ring_roundtrip_2k_ms=3045；kevent_shared_ring_roundtrips=2000 | 无 |
-| KP-04 | performance.kevent | 部分完成 | 功能正确性通过；性能 baseline 未验证 | 功能层 overflow 已覆盖 | 未按 10k 性能 baseline 执行 |
-| KP-05 | performance.kevent | 阻塞 | 未验证 | 无 | 需 gateway/DV 或长连接运行态恢复 |
-| MP-01 | performance.kmsg | 已完成 | 通过 | `cargo test -p kmsg --test sled_contract -- --ignored --nocapture`；kmsg_post_10k_ms=16760 | 无 |
-| MP-02 | performance.kmsg | 已完成 | 通过 | 同上；kmsg_fetch_10k_ms=2256 | 无 |
-| MP-03 | performance.kmsg | 已完成 | 通过 | 同上；kmsg_fetch_ack_10k_ms=968；kmsg_fetch_ack_count=10000 | 无 |
-| MP-04 | performance.kmsg | 已完成 | 通过 | 同上；kmsg_concurrent_post_10k_ms=12248；kmsg_concurrent_post_count=10000；index 唯一连续 | 无 |
-| MP-05 | performance.kmsg | 已完成 | 通过 | 同上；kmsg_sync_write_false_post_1k_ms=1276；kmsg_sync_write_true_post_1k_ms=6757 | 无 |
+每执行一轮测试后：
 
-### 9.5 设计 / 实现偏差验证
-
-| 编号 | 分类 | 状态 | 测试结果 | 当前证据 | 剩余工作 |
-| --- | --- | --- | --- | --- | --- |
-| D-01/R-03 | design.kevent | 已完成 | 当前 local SDK、shared ring、service、HTTP 行为已确认 | `cargo test -p kevent --test client_contract`、`cargo test -p kevent --test shared_ring_contract -- --test-threads=1`、`cargo test -p kevent --test http_contract` 通过；local SDK 可发送 4KB data 且拒绝超过 64KB data；shared ring 拒绝超过 slot 的事件；service 返回 `KEventError::Internal`；HTTP publish 返回 500 + `INTERNAL` | 需产品/设计确认：文档 64KB data 上限与 shared ring slot 约 2KB 的实现约束如何统一 |
-| D-02 | design.kevent | 未执行 | 未验证 | 已静态确认疑似未实现 | 需要双 daemon / 双节点 DV |
-| D-03 | design.kevent | 未执行 | 未验证 | 依赖 D-02 | 需要双节点验证 |
-| D-04/R-02 | design.kevent | 已完成 | 当前行为已确认 | `cargo test -p kevent --test service_contract` 通过；`unregister_reader_closes_update_path_and_drops_queue` 固定注销后 pull 空、update 返回 `READER_CLOSED`、重新注册不继承旧队列；既有测试覆盖 unknown reader update | 若后续统一 reader 生命周期错误语义，需要同步调整测试预期和文档 |
-| D-05 | design.kevent | 已完成 | 当前 service/HTTP 行为已确认 | `cargo test -p kevent --test shared_ring_contract -- --test-threads=1` 和 `cargo test -p kevent --test http_contract` 通过；确认 shared ring mirror 失败时 service 返回 `KEventError::Internal`，HTTP publish 返回 500 + `INTERNAL`，reader 未收到事件 | 需产品/设计确认：过大事件最终应失败，还是按尽力通知静默丢弃；若确认后需同步文档或实现 |
-| D-06/R-06 | design.kmsg | 已完成 | 已确认实现与设计不符 | sled_contract.rs 确认当前不生效 | 后续实现修复后需更新测试预期 |
-| D-07/R-06 | design.kmsg | 部分完成 | 已确认 handler 层实现与设计不符；DV 未验证 | sled_contract.rs 确认 handler 层当前忽略权限字段 | DV 多身份未验证 |
-| D-08 | design.kmsg | 阻塞 | gateway 未验证 | 直连 POST 通过；GET 未记录 | gateway 恢复后执行 DV-03B |
-| D-09/R-07 | design.kmsg | 部分完成 | reopen 级通过；crash 级未验证 | sled_contract.rs reopen 级 cursor 测试通过 | crash 级可靠性未验证 |
-| D-10/R-05 | design.kmsg | 部分完成 | 已记录，未形成正式文档修订 | 报告已记录当前 API 扩展和偏差 | 后续需补正式文档或形成确认结论 |
-| D-11/R-09 | design.kevent | 已完成 | 通过 | `cargo test -p kevent --test usage_contract` 通过；确认 msg_center 当前发布路径可被 control_panel in/out pattern 和 OpenDAN 新旧路径 pattern 匹配，task_mgr wait pattern 只匹配目标 task id | 后续若 msg_center path、box name 或调用方 pattern 变化，需要同步更新该测试 |
-
-### 9.6 当前主要阻塞
-
-| 编号 | 阻塞项 | 影响范围 | 当前证据 | 下一步 |
-| --- | --- | --- | --- | --- |
-| B-01 | rich cyfs_gateway / 3180 不可用 | 所有 gateway / DV 测试 | src/check.py 报 80 / 3180 不可达；直连 3181 / 4030 可用 | 修复 gateway 与 node_daemon/native fallback 启动契约 |
-| B-02 | rich 未安装 Deno | test/kevent_kmsg_test runner | 报告记录 Deno 未安装 | gateway 恢复后再安装并运行 DV |
-| B-03 | musl toolchain 不完整 | 默认 musl 构建 | 缺 x86_64-linux-musl-g++ / ar / ranlib | 若需要 release/musl 验证，补齐工具链 |
-| B-04 | cyfs-gateway debug binary 与 boot_gateway.yaml 配置能力不匹配 | DV-01 / DV-02 路由配置测试 | 本地缺 cyfs_gateway binary；rich 上 `/opt/buckyos/bin/cyfs-gateway/cyfs_gateway debug` 解析 `forward round_robin --backup-map` 失败 | 更新或重建 cyfs-gateway，使 debug 命令支持当前配置语法；或按当前 cyfs-gateway 能力调整 boot_gateway.yaml 后重跑 |
-| B-05 | node_daemon native framed 定向测试超时 | KE-13 | `cargo test -p node_daemon kevent_server -- --nocapture` 在 Windows 环境 180 秒超时，未进入有效断言证据 | 预编译 node_daemon、延长构建窗口，或拆出 native framed 协议可快速运行的独立测试入口 |
+1. 可将本轮详细命令、日志、环境和当轮结论保存到本地 `test/kevent_kmsg/reports/`，该目录不提交。
+2. 更新本文件中的当前状态、统计、阻塞项和证据索引。
+3. 如测试计划、目录或测试项编号发生变化，同步更新 `notepads/kevent_kmsg_test_plan.md`。

--- a/src/kernel/kevent/tests/performance.rs
+++ b/src/kernel/kevent/tests/performance.rs
@@ -93,6 +93,53 @@ async fn service_publish_pull_baseline() {
 
 #[tokio::test]
 #[ignore]
+async fn slow_reader_overflow_10k_baseline() {
+    let capacity = 1024usize;
+    let service = KEventService::new_with_capacity("node_a", capacity);
+    service
+        .register_reader("slow", vec!["/perf/overflow/**".to_string()])
+        .await
+        .unwrap();
+
+    let start = Instant::now();
+    for seq in 0..10_000 {
+        service
+            .publish_local_global("/perf/overflow/event", json!({ "seq": seq }))
+            .await
+            .unwrap();
+    }
+    let publish_elapsed = start.elapsed();
+
+    let start = Instant::now();
+    let mut consumed = 0usize;
+    let mut first_seq = None;
+    let mut last_seq = None;
+    while let Some(event) = service.pull_event("slow", Some(0)).await.unwrap() {
+        let seq = event.data["seq"].as_u64().unwrap();
+        if first_seq.is_none() {
+            first_seq = Some(seq);
+        }
+        last_seq = Some(seq);
+        consumed += 1;
+    }
+    let drain_elapsed = start.elapsed();
+
+    assert_eq!(consumed, capacity);
+    assert_eq!(first_seq, Some((10_000 - capacity) as u64));
+    assert_eq!(last_seq, Some(9_999));
+
+    eprintln!(
+        "{{\"kevent_slow_reader_publish_10k_ms\":{},\"kevent_slow_reader_drain_ms\":{},\"kevent_slow_reader_retained\":{},\"kevent_slow_reader_first_seq\":{},\"kevent_slow_reader_last_seq\":{}}}",
+        publish_elapsed.as_millis(),
+        drain_elapsed.as_millis(),
+        consumed,
+        first_seq.unwrap(),
+        last_seq.unwrap()
+    );
+}
+
+#[tokio::test]
+#[ignore]
 async fn shared_ring_full_client_latency_baseline() {
     let _guard = RING_ENV_LOCK.lock().unwrap();
     let path = set_unique_ring_path("shared_ring_latency");

--- a/src/kernel/kevent/tests/usage_contract.rs
+++ b/src/kernel/kevent/tests/usage_contract.rs
@@ -1,5 +1,105 @@
 use buckyos_api::{match_event_patterns, validate_eventid, validate_pattern, KEventClient};
-use serde_json::json;
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TruthRecord {
+    id: String,
+    state: &'static str,
+}
+
+#[derive(Default)]
+struct TruthSource {
+    records: BTreeMap<String, TruthRecord>,
+    reads: usize,
+}
+
+impl TruthSource {
+    fn insert(&mut self, id: &str, state: &'static str) {
+        self.records.insert(
+            id.to_string(),
+            TruthRecord {
+                id: id.to_string(),
+                state,
+            },
+        );
+    }
+
+    fn read(&mut self, id: &str) -> Option<TruthRecord> {
+        self.reads += 1;
+        self.records.get(id).cloned()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum TruthLocator {
+    Task(String),
+    MsgRecord(String),
+    MsgBox { owner: String, box_name: String },
+    Kmsg { queue_urn: String, index: u64 },
+}
+
+fn locator_from_payload(payload: &Value) -> Option<TruthLocator> {
+    if let Some(task_id) = payload.get("task_id").and_then(Value::as_str) {
+        return Some(TruthLocator::Task(task_id.to_string()));
+    }
+
+    if let Some(record_id) = payload.get("record_id").and_then(Value::as_str) {
+        return Some(TruthLocator::MsgRecord(record_id.to_string()));
+    }
+
+    if let (Some(owner), Some(box_name)) = (
+        payload.get("owner").and_then(Value::as_str),
+        payload.get("box").and_then(Value::as_str),
+    ) {
+        return Some(TruthLocator::MsgBox {
+            owner: owner.to_string(),
+            box_name: box_name.to_string(),
+        });
+    }
+
+    if let (Some(queue_urn), Some(index)) = (
+        payload.get("queue_urn").and_then(Value::as_str),
+        payload.get("index").and_then(Value::as_u64),
+    ) {
+        return Some(TruthLocator::Kmsg {
+            queue_urn: queue_urn.to_string(),
+            index,
+        });
+    }
+
+    None
+}
+
+struct TruthDrivenConsumer {
+    pending_ids: BTreeSet<String>,
+    processed_ids: BTreeSet<String>,
+}
+
+impl TruthDrivenConsumer {
+    fn new(pending_ids: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            pending_ids: pending_ids.into_iter().map(Into::into).collect(),
+            processed_ids: BTreeSet::new(),
+        }
+    }
+
+    fn tick(&mut self, event_payload: Option<&Value>, truth: &mut TruthSource) {
+        if let Some(TruthLocator::Task(task_id)) = event_payload.and_then(locator_from_payload) {
+            self.pending_ids.insert(task_id);
+        }
+
+        let pending_ids = self.pending_ids.iter().cloned().collect::<Vec<_>>();
+        for id in pending_ids {
+            if let Some(record) = truth.read(&id) {
+                if record.state == "Completed" {
+                    self.processed_ids.insert(record.id.clone());
+                    self.pending_ids.remove(&record.id);
+                }
+            }
+        }
+    }
+}
 
 fn assert_patterns_match(patterns: &[String], eventid: &str) {
     validate_eventid(eventid).unwrap();
@@ -87,6 +187,97 @@ fn task_manager_wait_pattern_matches_task_events_only() {
     assert_patterns_match(&wait_patterns, "/task_mgr/42");
     assert_patterns_do_not_match(&wait_patterns, "/task_mgr/43");
     assert_patterns_do_not_match(&wait_patterns, "/task_mgr/42/done");
+}
+
+#[test]
+fn event_payload_carries_locator_not_truth() {
+    assert_eq!(
+        locator_from_payload(&json!({
+            "task_id": "task-42",
+            "state": "Failed"
+        })),
+        Some(TruthLocator::Task("task-42".to_string()))
+    );
+    assert_eq!(
+        locator_from_payload(&json!({
+            "record_id": "msg-001",
+            "state": "Deleted"
+        })),
+        Some(TruthLocator::MsgRecord("msg-001".to_string()))
+    );
+    assert_eq!(
+        locator_from_payload(&json!({
+            "owner": "alice",
+            "box": "in",
+            "changed": true
+        })),
+        Some(TruthLocator::MsgBox {
+            owner: "alice".to_string(),
+            box_name: "in".to_string()
+        })
+    );
+    assert_eq!(
+        locator_from_payload(&json!({
+            "queue_urn": "buckycli::devtest::queue",
+            "index": 7,
+            "payload_preview": "not authoritative"
+        })),
+        Some(TruthLocator::Kmsg {
+            queue_urn: "buckycli::devtest::queue".to_string(),
+            index: 7
+        })
+    );
+    assert!(locator_from_payload(&json!({ "state": "Completed" })).is_none());
+}
+
+#[test]
+fn event_wakeup_reloads_truth_source_instead_of_trusting_payload() {
+    let mut truth = TruthSource::default();
+    truth.insert("task-42", "Completed");
+    let mut consumer = TruthDrivenConsumer::new(Vec::<String>::new());
+
+    consumer.tick(
+        Some(&json!({
+            "task_id": "task-42",
+            "state": "Running",
+            "result": "stale event payload"
+        })),
+        &mut truth,
+    );
+
+    assert_eq!(truth.reads, 1);
+    assert!(consumer.processed_ids.contains("task-42"));
+    assert!(consumer.pending_ids.is_empty());
+}
+
+#[test]
+fn timeout_duplicate_and_bad_events_still_converge_by_truth_source() {
+    let mut truth = TruthSource::default();
+    truth.insert("task-timeout", "Completed");
+    truth.insert("task-duplicate", "Completed");
+    truth.insert("task-bad-payload", "Completed");
+    let mut consumer = TruthDrivenConsumer::new([
+        "task-timeout",
+        "task-duplicate",
+        "task-bad-payload",
+    ]);
+
+    consumer.tick(None, &mut truth);
+    assert!(consumer.processed_ids.contains("task-timeout"));
+
+    consumer.tick(
+        Some(&json!({ "task_id": "task-duplicate", "state": "Running" })),
+        &mut truth,
+    );
+    consumer.tick(
+        Some(&json!({ "task_id": "task-duplicate", "state": "Running" })),
+        &mut truth,
+    );
+    assert!(consumer.processed_ids.contains("task-duplicate"));
+
+    consumer.tick(Some(&json!({ "state": "Completed" })), &mut truth);
+    assert!(consumer.processed_ids.contains("task-bad-payload"));
+    assert!(consumer.pending_ids.is_empty());
 }
 
 #[tokio::test]

--- a/src/kernel/node_daemon/src/kevent_server.rs
+++ b/src/kernel/node_daemon/src/kevent_server.rs
@@ -166,9 +166,48 @@ fn error_response(err: KEventError) -> KEventDaemonResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use buckyos_api::{KEventDaemonRequest, KEventDaemonResponse};
+    use async_trait::async_trait;
+    use buckyos_api::{KEventDaemonRequest, KEventDaemonResponse, KEventResult};
+    use kevent::{map_response_error, KEventPeerPublisher};
     use serde_json::json;
     use tokio::io::duplex;
+
+    struct FramedPeerPublisher {
+        target: Arc<KEventService>,
+    }
+
+    impl FramedPeerPublisher {
+        fn new(target: Arc<KEventService>) -> Self {
+            Self { target }
+        }
+    }
+
+    #[async_trait]
+    impl KEventPeerPublisher for FramedPeerPublisher {
+        async fn broadcast(&self, event: &Event) -> KEventResult<()> {
+            let (mut client, server) = duplex(4096);
+            let server_task =
+                tokio::spawn(handle_native_tcp_connection(self.target.clone(), server));
+
+            write_client_frame(
+                &mut client,
+                KEventDaemonRequest::PublishGlobal {
+                    event: event.clone(),
+                },
+            )
+            .await;
+            let response = read_client_frame(&mut client).await;
+            drop(client);
+            server_task.await.unwrap().unwrap();
+
+            match response {
+                KEventDaemonResponse::Ok { .. } => Ok(()),
+                KEventDaemonResponse::Err { code, message } => {
+                    Err(map_response_error(&code, &message))
+                }
+            }
+        }
+    }
 
     #[tokio::test]
     async fn native_tcp_connection_roundtrip() {
@@ -208,6 +247,53 @@ mod tests {
 
         drop(client);
         server_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn native_tcp_rejects_invalid_frame_length() {
+        let service = Arc::new(KEventService::new("node_a"));
+
+        for invalid_len in [0_u32, (MAX_NATIVE_FRAME_SIZE as u32) + 1] {
+            let (mut client, server) = duplex(64);
+            let server_task = tokio::spawn(handle_native_tcp_connection(service.clone(), server));
+
+            client.write_u32(invalid_len).await.unwrap();
+            drop(client);
+
+            let err = server_task.await.unwrap().unwrap_err();
+            assert_eq!(err.kind(), ErrorKind::InvalidData);
+            assert!(err
+                .to_string()
+                .contains("invalid kevent native frame length"));
+        }
+    }
+
+    #[tokio::test]
+    async fn native_framed_peer_publish_delivers_one_way_current_behavior() {
+        let service_a = Arc::new(KEventService::new("node_a"));
+        let service_b = Arc::new(KEventService::new("node_b"));
+
+        service_a
+            .add_peer_publisher(Arc::new(FramedPeerPublisher::new(service_b.clone())))
+            .await;
+        service_b
+            .register_reader("b_reader", vec!["/peer/**".to_string()])
+            .await
+            .unwrap();
+
+        service_a
+            .publish_local_global("/peer/native-framed", json!({"ok": true}))
+            .await
+            .unwrap();
+
+        let event = service_b
+            .pull_event("b_reader", Some(100))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.eventid, "/peer/native-framed");
+        assert_eq!(event.source_node, "node_a");
+        assert_eq!(event.ingress_node.as_deref(), Some("node_b"));
     }
 
     async fn write_client_frame(

--- a/test/kevent_kmsg/README.md
+++ b/test/kevent_kmsg/README.md
@@ -1,0 +1,26 @@
+# kevent / kmsg tests
+
+This directory keeps the gateway, restart, and peer test entries for the
+kevent/kmsg test plan.
+
+Subdirectories:
+
+- `dv`: standard devtest gateway smoke for kmsg and kevent.
+- `restart`: standard devtest restart recovery smoke.
+- `peer_container`: two-node peer delivery harness in Docker containers.
+- `peer_vm`: two-node peer delivery harness in QEMU/KVM VMs.
+- `reports`: local per-run reports and evidence snapshots. This directory is
+  ignored by git; the repository keeps only the test plan and current summary
+  conclusion.
+
+Run from the repository root:
+
+```bash
+uv run test/run.py -p kevent_kmsg/dv
+uv run test/run.py -p kevent_kmsg/restart
+uv run test/run.py -p kevent_kmsg/peer_container
+uv run test/run.py -p kevent_kmsg/peer_vm
+```
+
+`uv run test/run.py -p kevent_kmsg` prints this grouped entry and does not run
+the heavier subcases unless `BUCKYOS_KEVENT_KMSG_CASES` is set.

--- a/test/kevent_kmsg/dv/README.md
+++ b/test/kevent_kmsg/dv/README.md
@@ -7,7 +7,7 @@ Run from the repository root:
 
 ```bash
 uv run src/check.py
-uv run test/run.py -p kevent_kmsg_test
+uv run test/run.py -p kevent_kmsg/dv
 ```
 
 Optional environment variables:

--- a/test/kevent_kmsg/dv/deno.json
+++ b/test/kevent_kmsg/dv/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "buckyos": "./node_modules/buckyos/dist/node.mjs"
+  }
+}

--- a/test/kevent_kmsg/dv/kevent_kmsg_dv.ts
+++ b/test/kevent_kmsg/dv/kevent_kmsg_dv.ts
@@ -1,4 +1,4 @@
-import { initTestRuntime } from "../test_helpers/buckyos_client.ts";
+import { initTestRuntime } from "../../test_helpers/buckyos_client.ts";
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
@@ -46,6 +46,46 @@ function getEnv(name: string, fallback?: string): string | undefined {
     return value.trim();
   }
   return fallback;
+}
+
+async function prepareAppClientConfig(): Promise<void> {
+  const sourceDir = getEnv(
+    "BUCKYOS_TEST_APP_CLIENT_DIR",
+    "/opt/buckyos/etc/.buckycli",
+  )!;
+  const tempDir = await Deno.makeTempDir({ prefix: "buckyos-appclient-" });
+
+  await Deno.copyFile(
+    `${sourceDir}/user_private_key.pem`,
+    `${tempDir}/user_private_key.pem`,
+  );
+
+  const userConfigPath = `${sourceDir}/user_config.json`;
+  const userConfig = JSON.parse(
+    await Deno.readTextFile(userConfigPath),
+  ) as JsonObject;
+  if (Array.isArray(userConfig["@context"])) {
+    const contexts = userConfig["@context"].filter((item) =>
+      typeof item === "string"
+    );
+    userConfig["@context"] = contexts.at(-1) ??
+      "https://buckyos.org/ns/owner/v1";
+  }
+  await Deno.writeTextFile(
+    `${tempDir}/user_config.json`,
+    `${JSON.stringify(userConfig, null, 2)}\n`,
+  );
+
+  try {
+    await Deno.copyFile(
+      `${sourceDir}/zone_config.json`,
+      `${tempDir}/zone_config.json`,
+    );
+  } catch {
+    // zone_config.json is not required by the WebSDK private key loader.
+  }
+
+  Deno.env.set("BUCKYOS_TEST_APP_CLIENT_DIR", tempDir);
 }
 
 function nowTag(): string {
@@ -109,7 +149,10 @@ async function createQueue(
   });
 }
 
-async function cleanupQueue(rpc: RpcClient, queueUrn: string | null): Promise<void> {
+async function cleanupQueue(
+  rpc: RpcClient,
+  queueUrn: string | null,
+): Promise<void> {
   if (!queueUrn) return;
   try {
     await rpc.call("delete_queue", { queue_urn: queueUrn });
@@ -159,7 +202,10 @@ async function openKeventStream(
       const readPromise = reader.read();
       const timeoutPromise = new Promise<ReadableStreamReadResult<Uint8Array>>(
         (_resolve, reject) =>
-          setTimeout(() => reject(new Error("kevent stream read timeout")), remaining),
+          setTimeout(
+            () => reject(new Error("kevent stream read timeout")),
+            remaining,
+          ),
       );
       const chunk = await Promise.race([readPromise, timeoutPromise]);
       if (chunk.done) throw new Error("kevent stream closed");
@@ -189,14 +235,18 @@ async function publishKevent(
   });
   const body = await response.text();
   if (!response.ok) {
-    throw new Error(`kevent publish failed: status=${response.status}, body=${body}`);
+    throw new Error(
+      `kevent publish failed: status=${response.status}, body=${body}`,
+    );
   }
   const parsed = JSON.parse(body);
   assert.equal(parsed.status, "ok", "kevent publish response should be ok");
 }
 
 async function probeKmsgGet(gatewayBaseUrl: string): Promise<void> {
-  const response = await fetch(`${gatewayBaseUrl}/kapi/kmsg`, { method: "GET" });
+  const response = await fetch(`${gatewayBaseUrl}/kapi/kmsg`, {
+    method: "GET",
+  });
   console.log(
     JSON.stringify({
       case: "DV-03B",
@@ -207,16 +257,25 @@ async function probeKmsgGet(gatewayBaseUrl: string): Promise<void> {
 }
 
 async function run(): Promise<void> {
+  await prepareAppClientConfig();
   const { buckyos, userId, ownerUserId, zoneHost } = await initTestRuntime();
   const appId = getEnv("BUCKYOS_TEST_APP_ID", "buckycli")!;
-  const gatewayBaseUrl = getEnv("BUCKYOS_GATEWAY_BASE_URL", `https://${zoneHost}`)!;
+  const gatewayBaseUrl = getEnv(
+    "BUCKYOS_GATEWAY_BASE_URL",
+    `https://${zoneHost}`,
+  )!;
   const tag = nowTag();
   const kmsg = buckyos.getServiceRpcClient("kmsg") as RpcClient;
 
   let queueUrn: string | null = null;
   let stream: StreamReader | null = null;
   try {
-    queueUrn = await createQueue(kmsg, `kevent-kmsg-dv-${tag}`, appId, ownerUserId);
+    queueUrn = await createQueue(
+      kmsg,
+      `kevent-kmsg-dv-${tag}`,
+      appId,
+      ownerUserId,
+    );
     const firstPayload = { case: "DV-03", tag, value: "durable-message" };
     const firstIndex = await rpcCall<number>(kmsg, "post_message", {
       queue_urn: queueUrn,
@@ -236,12 +295,18 @@ async function run(): Promise<void> {
       sub_id: `kevent-kmsg-dv-sub-${tag}`,
       position: "Earliest",
     });
-    const fetched = asMessages(await kmsg.call("fetch_messages", {
-      sub_id: subId,
-      length: 10,
-      auto_commit: false,
-    }));
-    assert.equal(fetched.length, 1, "kmsg fetch should return the first message");
+    const fetched = asMessages(
+      await kmsg.call("fetch_messages", {
+        sub_id: subId,
+        length: 10,
+        auto_commit: false,
+      }),
+    );
+    assert.equal(
+      fetched.length,
+      1,
+      "kmsg fetch should return the first message",
+    );
     assert.equal(fetched[0].index, firstIndex);
     assert.equal(
       (decodePayload(fetched[0]) as JsonObject).value,
@@ -252,16 +317,26 @@ async function run(): Promise<void> {
     const stats = await rpcCall<QueueStats>(kmsg, "get_queue_stats", {
       queue_urn: queueUrn,
     });
-    assert.equal(stats.message_count, 1, "queue stats should count first message");
+    assert.equal(
+      stats.message_count,
+      1,
+      "queue stats should count first message",
+    );
 
-    const reread = asMessages(await kmsg.call("read_message", {
-      queue_urn: queueUrn,
-      cursor: firstIndex,
-      length: 1,
-    }));
-    assert.equal(reread.length, 1, "reconnect/read smoke should see durable data");
+    const reread = asMessages(
+      await kmsg.call("read_message", {
+        queue_urn: queueUrn,
+        cursor: firstIndex,
+        length: 1,
+      }),
+    );
+    assert.equal(
+      reread.length,
+      1,
+      "reconnect/read smoke should see durable data",
+    );
 
-    const eventid = `/kevent_kmsg_test/${tag}`;
+    const eventid = `/kevent_kmsg/dv/${tag}`;
     stream = await openKeventStream(gatewayBaseUrl, eventid);
     const ack = await stream.readFrame(5000);
     assert.equal(ack.type, "ack", "kevent stream should ack");
@@ -297,15 +372,64 @@ async function run(): Promise<void> {
     assert.equal(eventData.queue_urn, queueUrn);
     assert.equal(eventData.index, signalIndex);
 
-    const readSignal = asMessages(await kmsg.call("read_message", {
-      queue_urn: queueUrn,
-      cursor: signalIndex,
-      length: 1,
-    }));
-    assert.equal(readSignal.length, 1, "kmsg durable payload should be readable after event");
+    const readSignal = asMessages(
+      await kmsg.call("read_message", {
+        queue_urn: queueUrn,
+        cursor: signalIndex,
+        length: 1,
+      }),
+    );
+    assert.equal(
+      readSignal.length,
+      1,
+      "kmsg durable payload should be readable after event",
+    );
     assert.equal(
       (decodePayload(readSignal[0]) as JsonObject).value,
       "event-driven-message",
+    );
+
+    const signalFetched = asMessages(
+      await kmsg.call("fetch_messages", {
+        sub_id: subId,
+        length: 10,
+        auto_commit: false,
+      }),
+    );
+    assert.equal(
+      signalFetched.length,
+      1,
+      "signal message should be fetched once",
+    );
+    assert.equal(signalFetched[0].index, signalIndex);
+    await kmsg.call("commit_ack", { sub_id: subId, index: signalIndex });
+
+    await publishKevent(gatewayBaseUrl, eventid, {
+      queue_urn: queueUrn,
+      index: signalIndex,
+      tag,
+      duplicate: true,
+    });
+    let duplicateFrame: JsonObject | null = null;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const frame = await stream.readFrame(5000);
+      if (frame.type === "event") {
+        duplicateFrame = frame;
+        break;
+      }
+    }
+    assert.ok(duplicateFrame, "duplicate kevent should still be delivered");
+    const afterDuplicate = asMessages(
+      await kmsg.call("fetch_messages", {
+        sub_id: subId,
+        length: 10,
+        auto_commit: false,
+      }),
+    );
+    assert.equal(
+      afterDuplicate.length,
+      0,
+      "duplicate kevent must not reprocess an acked kmsg message",
     );
 
     const fallbackPayload = { case: "DV-05", tag, value: "polling-fallback" };
@@ -318,12 +442,18 @@ async function run(): Promise<void> {
         headers: { test_case: "DV-05-fallback" },
       },
     });
-    const fallbackRead = asMessages(await kmsg.call("read_message", {
-      queue_urn: queueUrn,
-      cursor: fallbackIndex,
-      length: 1,
-    }));
-    assert.equal(fallbackRead.length, 1, "polling fallback should read without event");
+    const fallbackRead = asMessages(
+      await kmsg.call("read_message", {
+        queue_urn: queueUrn,
+        cursor: fallbackIndex,
+        length: 1,
+      }),
+    );
+    assert.equal(
+      fallbackRead.length,
+      1,
+      "polling fallback should read without event",
+    );
     assert.equal(
       (decodePayload(fallbackRead[0]) as JsonObject).value,
       "polling-fallback",

--- a/test/kevent_kmsg/dv/package.json
+++ b/test/kevent_kmsg/dv/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dv": "deno run --allow-net --allow-read --allow-write --allow-env --unsafely-ignore-certificate-errors kevent_kmsg_dv.ts",
+    "dv": "deno run --config deno.json --allow-net --allow-read --allow-write --allow-env --unsafely-ignore-certificate-errors kevent_kmsg_dv.ts",
     "test": "pnpm run dv"
   },
   "dependencies": {

--- a/test/kevent_kmsg/main.py
+++ b/test/kevent_kmsg/main.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CASES = {
+    "dv": "kevent_kmsg/dv",
+    "restart": "kevent_kmsg/restart",
+    "peer_container": "kevent_kmsg/peer_container",
+    "peer_vm": "kevent_kmsg/peer_vm",
+}
+
+
+def print_help() -> None:
+    print("kevent/kmsg grouped test entry")
+    print("")
+    print("Run an individual subcase from the repository root:")
+    for name, path in CASES.items():
+        print(f"  uv run test/run.py -p {path}  # {name}")
+    print("")
+    print("To run multiple subcases through this grouped entry:")
+    print("  BUCKYOS_KEVENT_KMSG_CASES=dv,restart uv run test/run.py -p kevent_kmsg")
+    print("")
+    print("Per-run detailed reports are kept in test/kevent_kmsg/reports/.")
+
+
+def main() -> int:
+    selected = os.environ.get("BUCKYOS_KEVENT_KMSG_CASES", "").strip()
+    if not selected:
+        print_help()
+        return 0
+
+    names = [item.strip() for item in selected.split(",") if item.strip()]
+    unknown = [name for name in names if name not in CASES]
+    if unknown:
+        print(f"unknown kevent/kmsg test case(s): {', '.join(unknown)}", file=sys.stderr)
+        return 2
+
+    for name in names:
+        result = subprocess.run(
+            [sys.executable, "test/run.py", "-p", CASES[name]],
+            cwd=ROOT,
+            text=True,
+        )
+        if result.returncode != 0:
+            return result.returncode
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/kevent_kmsg/peer_container/harness/Cargo.toml
+++ b/test/kevent_kmsg/peer_container/harness/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kevent_peer_container_harness"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "kevent_peer_harness"
+path = "src/main.rs"
+
+[dependencies]
+async-trait = "0.1.89"
+buckyos-api = { path = "../../../../src/kernel/buckyos-api" }
+kevent = { path = "../../../../src/kernel/kevent" }
+serde_json = "1.0.149"
+tokio = { version = "1.49.0", features = ["full"] }

--- a/test/kevent_kmsg/peer_container/harness/src/main.rs
+++ b/test/kevent_kmsg/peer_container/harness/src/main.rs
@@ -1,0 +1,276 @@
+use async_trait::async_trait;
+use buckyos_api::{Event, KEventDaemonRequest, KEventDaemonResponse, KEventError, KEventResult};
+use kevent::{
+    decode_daemon_request, encode_daemon_response, map_response_error, KEventPeerPublisher,
+    KEventService,
+};
+use serde_json::json;
+use std::env;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::sleep;
+
+const MAX_FRAME_SIZE: usize = 1024 * 1024;
+
+#[derive(Clone)]
+struct TcpPeerPublisher {
+    target: String,
+}
+
+#[async_trait]
+impl KEventPeerPublisher for TcpPeerPublisher {
+    async fn broadcast(&self, event: &Event) -> KEventResult<()> {
+        let response = call(
+            &self.target,
+            KEventDaemonRequest::PublishGlobal {
+                event: event.clone(),
+            },
+        )
+        .await?;
+        match response {
+            KEventDaemonResponse::Ok { .. } => Ok(()),
+            KEventDaemonResponse::Err { code, message } => Err(map_response_error(&code, &message)),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = run().await {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> KEventResult<()> {
+    let args = env::args().collect::<Vec<_>>();
+    match args.get(1).map(String::as_str) {
+        Some("server") => run_server(&args).await,
+        Some("client") => run_client(&args).await,
+        _ => Err(KEventError::InvalidEventId(
+            "usage: kevent_peer_harness server|client ...".to_string(),
+        )),
+    }
+}
+
+async fn run_server(args: &[String]) -> KEventResult<()> {
+    let node = arg_value(args, "--node")?;
+    let listen = arg_value(args, "--listen")?;
+    let peer = optional_arg_value(args, "--peer");
+    let service = Arc::new(KEventService::new(node.to_string()));
+    if let Some(peer) = peer {
+        service
+            .add_peer_publisher(Arc::new(TcpPeerPublisher {
+                target: peer.to_string(),
+            }))
+            .await;
+    }
+
+    let listener = TcpListener::bind(listen)
+        .await
+        .map_err(|err| KEventError::Internal(format!("bind {listen} failed: {err}")))?;
+    loop {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .map_err(|err| KEventError::Internal(format!("accept failed: {err}")))?;
+        let service = service.clone();
+        tokio::spawn(async move {
+            if let Err(err) = handle_connection(service, stream).await {
+                eprintln!("{err}");
+            }
+        });
+    }
+}
+
+async fn run_client(args: &[String]) -> KEventResult<()> {
+    let node_a = arg_value(args, "--node-a")?;
+    let node_b = arg_value(args, "--node-b")?;
+    let tag = format!("{}", now_millis());
+    let eventid = format!("/peer/container/{tag}");
+    let reader_id = format!("reader-{tag}");
+
+    retry_call(
+        node_b,
+        KEventDaemonRequest::RegisterReader {
+            reader_id: reader_id.clone(),
+            patterns: vec!["/peer/**".to_string()],
+        },
+    )
+    .await?;
+
+    retry_call(
+        node_a,
+        KEventDaemonRequest::PublishGlobal {
+            event: Event {
+                eventid: eventid.clone(),
+                source_node: "external-client".to_string(),
+                source_pid: std::process::id(),
+                ingress_node: None,
+                timestamp: now_millis(),
+                data: json!({ "tag": tag }),
+            },
+        },
+    )
+    .await?;
+
+    let mut delivered = None;
+    for _ in 0..20 {
+        match call(
+            node_b,
+            KEventDaemonRequest::PullEvent {
+                reader_id: reader_id.clone(),
+                timeout_ms: Some(200),
+            },
+        )
+        .await?
+        {
+            KEventDaemonResponse::Ok { event: Some(event) } => {
+                delivered = Some(event);
+                break;
+            }
+            KEventDaemonResponse::Ok { event: None } => sleep(Duration::from_millis(100)).await,
+            KEventDaemonResponse::Err { code, message } => {
+                return Err(map_response_error(&code, &message));
+            }
+        }
+    }
+
+    let event =
+        delivered.ok_or_else(|| KEventError::Internal("node_b did not receive event".to_string()))?;
+    if event.eventid != eventid {
+        return Err(KEventError::Internal(format!(
+            "unexpected eventid: {}",
+            event.eventid
+        )));
+    }
+    if event.source_node != "external-client" {
+        return Err(KEventError::Internal(format!(
+            "unexpected source_node: {}",
+            event.source_node
+        )));
+    }
+
+    println!(
+        "{}",
+        json!({
+            "status": "passed",
+            "eventid": event.eventid,
+            "source_node": event.source_node,
+            "ingress_node": event.ingress_node,
+        })
+    );
+    Ok(())
+}
+
+async fn retry_call(target: &str, request: KEventDaemonRequest) -> KEventResult<KEventDaemonResponse> {
+    let mut last_error = None;
+    for _ in 0..30 {
+        match call(target, request.clone()).await {
+            Ok(response) => return Ok(response),
+            Err(err) => {
+                last_error = Some(err);
+                sleep(Duration::from_millis(200)).await;
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| KEventError::Internal("retry failed".to_string())))
+}
+
+async fn call(target: &str, request: KEventDaemonRequest) -> KEventResult<KEventDaemonResponse> {
+    let mut stream = TcpStream::connect(target)
+        .await
+        .map_err(|err| KEventError::DaemonUnavailable(format!("connect {target} failed: {err}")))?;
+    let payload = kevent::encode_daemon_request(&request)?;
+    stream
+        .write_u32(payload.len() as u32)
+        .await
+        .map_err(|err| KEventError::Internal(format!("write frame length failed: {err}")))?;
+    stream
+        .write_all(&payload)
+        .await
+        .map_err(|err| KEventError::Internal(format!("write frame payload failed: {err}")))?;
+    stream
+        .flush()
+        .await
+        .map_err(|err| KEventError::Internal(format!("flush frame failed: {err}")))?;
+
+    let frame_len = stream
+        .read_u32()
+        .await
+        .map_err(|err| KEventError::Internal(format!("read response length failed: {err}")))?
+        as usize;
+    if frame_len == 0 || frame_len > MAX_FRAME_SIZE {
+        return Err(KEventError::Internal(format!(
+            "invalid response frame length: {frame_len}"
+        )));
+    }
+    let mut frame = vec![0_u8; frame_len];
+    stream
+        .read_exact(&mut frame)
+        .await
+        .map_err(|err| KEventError::Internal(format!("read response payload failed: {err}")))?;
+    kevent::decode_daemon_response(&frame)
+}
+
+async fn handle_connection(service: Arc<KEventService>, mut stream: TcpStream) -> KEventResult<()> {
+    loop {
+        let frame_len = match stream.read_u32().await {
+            Ok(len) => len as usize,
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(err) => {
+                return Err(KEventError::Internal(format!("read request length failed: {err}")));
+            }
+        };
+        if frame_len == 0 || frame_len > MAX_FRAME_SIZE {
+            return Err(KEventError::Internal(format!(
+                "invalid request frame length: {frame_len}"
+            )));
+        }
+        let mut frame = vec![0_u8; frame_len];
+        stream
+            .read_exact(&mut frame)
+            .await
+            .map_err(|err| KEventError::Internal(format!("read request payload failed: {err}")))?;
+        let response = match decode_daemon_request(&frame) {
+            Ok(request) => service.handle_protocol_request(request).await,
+            Err(err) => KEventDaemonResponse::Err {
+                code: err.code().to_string(),
+                message: err.to_string(),
+            },
+        };
+        let payload = encode_daemon_response(&response)?;
+        stream
+            .write_u32(payload.len() as u32)
+            .await
+            .map_err(|err| KEventError::Internal(format!("write response length failed: {err}")))?;
+        stream
+            .write_all(&payload)
+            .await
+            .map_err(|err| KEventError::Internal(format!("write response payload failed: {err}")))?;
+        stream
+            .flush()
+            .await
+            .map_err(|err| KEventError::Internal(format!("flush response failed: {err}")))?;
+    }
+}
+
+fn arg_value<'a>(args: &'a [String], name: &str) -> KEventResult<&'a str> {
+    optional_arg_value(args, name)
+        .ok_or_else(|| KEventError::InvalidEventId(format!("missing argument {name}")))
+}
+
+fn optional_arg_value<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
+    args.windows(2)
+        .find(|pair| pair[0] == name)
+        .map(|pair| pair[1].as_str())
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/test/kevent_kmsg/peer_container/main.py
+++ b/test/kevent_kmsg/peer_container/main.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+TEST_DIR = Path(__file__).resolve().parent
+HARNESS_MANIFEST = TEST_DIR / "harness" / "Cargo.toml"
+IMAGE = os.environ.get("KEVENT_PEER_CONTAINER_IMAGE", "ubuntu:24.04")
+PREFIX = f"kevent-peer-{os.getpid()}"
+NETWORK = f"{PREFIX}-net"
+NODE_A = f"{PREFIX}-node-a"
+NODE_B = f"{PREFIX}-node-b"
+
+
+def run(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print("+", " ".join(command), flush=True)
+    return subprocess.run(command, check=True, text=True, **kwargs)
+
+
+def output(command: list[str], **kwargs) -> str:
+    return run(command, stdout=subprocess.PIPE, **kwargs).stdout.strip()
+
+
+def docker_available() -> None:
+    run(["docker", "version"], stdout=subprocess.DEVNULL)
+
+
+def build_harness() -> Path:
+    target_dir = os.environ.get("CARGO_TARGET_DIR")
+    if not target_dir:
+        target_dir = str(ROOT / "src" / "target")
+    env = os.environ.copy()
+    env.setdefault("LIBCLANG_PATH", "/usr/lib/llvm-18/lib")
+    env["CARGO_TARGET_DIR"] = target_dir
+
+    run(
+        [
+            "cargo",
+            "build",
+            "--manifest-path",
+            str(HARNESS_MANIFEST),
+            "--bin",
+            "kevent_peer_harness",
+        ],
+        cwd=ROOT,
+        env=env,
+    )
+    binary = Path(target_dir) / "debug" / "kevent_peer_harness"
+    if not binary.exists():
+        raise RuntimeError(f"harness binary not found: {binary}")
+    return binary
+
+
+def remove_container(name: str) -> None:
+    subprocess.run(["docker", "rm", "-f", name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def remove_network(name: str) -> None:
+    subprocess.run(["docker", "network", "rm", name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def start_node(binary: Path, name: str, node_id: str, peer: str | None = None) -> None:
+    command = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--network",
+        NETWORK,
+        "-v",
+        f"{binary}:/usr/local/bin/kevent_peer_harness:ro",
+        IMAGE,
+        "/usr/local/bin/kevent_peer_harness",
+        "server",
+        "--node",
+        node_id,
+        "--listen",
+        "0.0.0.0:3183",
+    ]
+    if peer is not None:
+        command.extend(["--peer", peer])
+    run(command)
+
+
+def run_client(binary: Path) -> dict:
+    completed = run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            NETWORK,
+            "-v",
+            f"{binary}:/usr/local/bin/kevent_peer_harness:ro",
+            IMAGE,
+            "/usr/local/bin/kevent_peer_harness",
+            "client",
+            "--node-a",
+            f"{NODE_A}:3183",
+            "--node-b",
+            f"{NODE_B}:3183",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr, end="")
+    print(completed.stdout, end="")
+    lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError("client produced no output")
+    return json.loads(lines[-1])
+
+
+def main() -> int:
+    docker_available()
+    binary = build_harness()
+    remove_container(NODE_A)
+    remove_container(NODE_B)
+    remove_network(NETWORK)
+
+    try:
+        run(["docker", "network", "create", NETWORK])
+        start_node(binary, NODE_B, "node_b")
+        start_node(binary, NODE_A, "node_a", f"{NODE_B}:3183")
+        time.sleep(1)
+        result = run_client(binary)
+        if result.get("status") != "passed":
+            raise RuntimeError(f"unexpected result: {result}")
+        print(json.dumps({"status": "passed", "network": NETWORK, "image": IMAGE}, sort_keys=True))
+        return 0
+    finally:
+        remove_container(NODE_A)
+        remove_container(NODE_B)
+        remove_network(NETWORK)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/kevent_kmsg/peer_vm/main.py
+++ b/test/kevent_kmsg/peer_vm/main.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import functools
+import http.server
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import traceback
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+TEST_DIR = Path(__file__).resolve().parent
+HARNESS_MANIFEST = ROOT / "test" / "kevent_kmsg" / "peer_container" / "harness" / "Cargo.toml"
+CACHE_DIR = Path(os.environ.get("KEVENT_PEER_VM_CACHE", "/tmp/kevent_peer_vm_cache"))
+IMAGE_URL = os.environ.get(
+    "KEVENT_PEER_VM_IMAGE_URL",
+    "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-amd64.img",
+)
+QEMU = (
+    os.environ.get("QEMU_SYSTEM_X86_64")
+    or shutil.which("qemu-system-x86_64")
+    or "/snap/multipass/16300/usr/bin/qemu-system-x86_64"
+)
+QEMU_IMG = (
+    os.environ.get("QEMU_IMG")
+    or shutil.which("qemu-img")
+    or "/snap/multipass/16300/usr/bin/qemu-img"
+)
+GENISOIMAGE = os.environ.get("GENISOIMAGE", "genisoimage")
+
+
+def run(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print("+", " ".join(command), flush=True)
+    return subprocess.run(command, check=True, text=True, **kwargs)
+
+
+def build_harness() -> Path:
+    target_dir = os.environ.get("CARGO_TARGET_DIR") or str(ROOT / "src" / "target")
+    env = os.environ.copy()
+    env.setdefault("LIBCLANG_PATH", "/usr/lib/llvm-18/lib")
+    env["CARGO_TARGET_DIR"] = target_dir
+    run(
+        [
+            "cargo",
+            "build",
+            "--manifest-path",
+            str(HARNESS_MANIFEST),
+            "--bin",
+            "kevent_peer_harness",
+        ],
+        cwd=ROOT,
+        env=env,
+    )
+    binary = Path(target_dir) / "debug" / "kevent_peer_harness"
+    if not binary.exists():
+        raise RuntimeError(f"harness binary not found: {binary}")
+    return binary
+
+
+def ensure_base_image() -> Path:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    image = CACHE_DIR / "ubuntu-24.04-server-cloudimg-amd64.img"
+    if image.exists() and image.stat().st_size > 100 * 1024 * 1024:
+        return image
+    tmp = image.with_suffix(".img.tmp")
+    run(["curl", "-L", "--fail", "-o", str(tmp), IMAGE_URL])
+    tmp.replace(image)
+    return image
+
+
+def create_seed_iso(work_dir: Path, node: str, peer: str | None, http_port: int) -> Path:
+    seed_dir = work_dir / f"seed-{node}"
+    seed_dir.mkdir()
+    (seed_dir / "meta-data").write_text(
+        f"instance-id: {node}\nlocal-hostname: {node}\n",
+        encoding="utf-8",
+    )
+    peer_args = f" --peer {peer}" if peer else ""
+    user_data = f"""#cloud-config
+package_update: false
+runcmd:
+  - [ sh, -c, "until curl -fsS http://10.0.2.2:{http_port}/kevent_peer_harness -o /usr/local/bin/kevent_peer_harness; do sleep 1; done" ]
+  - [ chmod, "+x", /usr/local/bin/kevent_peer_harness ]
+  - [ sh, -c, "nohup /usr/local/bin/kevent_peer_harness server --node {node} --listen 0.0.0.0:3183{peer_args} > /var/log/kevent_peer_harness.log 2>&1 &" ]
+"""
+    (seed_dir / "user-data").write_text(user_data, encoding="utf-8")
+    seed_iso = work_dir / f"{node}-seed.iso"
+    run(
+        [
+            GENISOIMAGE,
+            "-quiet",
+            "-output",
+            str(seed_iso),
+            "-volid",
+            "cidata",
+            "-joliet",
+            "-rock",
+            str(seed_dir / "user-data"),
+            str(seed_dir / "meta-data"),
+        ]
+    )
+    return seed_iso
+
+
+def start_http_server(binary: Path) -> tuple[http.server.ThreadingHTTPServer, int, threading.Thread]:
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(binary.parent))
+    server = http.server.ThreadingHTTPServer(("0.0.0.0", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, port, thread
+
+
+def create_overlay(base_image: Path, work_dir: Path, name: str) -> Path:
+    overlay = work_dir / f"{name}.qcow2"
+    run(
+        [
+            QEMU_IMG,
+            "create",
+            "-f",
+            "qcow2",
+            "-F",
+            "qcow2",
+            "-b",
+            str(base_image),
+            str(overlay),
+        ]
+    )
+    return overlay
+
+
+def start_vm(
+    name: str,
+    disk: Path,
+    seed_iso: Path,
+    kevent_host_port: int,
+    ssh_host_port: int,
+    log_file: Path,
+) -> subprocess.Popen:
+    command = [
+        QEMU,
+        "-enable-kvm",
+        "-m",
+        "1024",
+        "-smp",
+        "1",
+        "-display",
+        "none",
+        "-serial",
+        f"file:{log_file}",
+        "-drive",
+        f"file={disk},format=qcow2,if=virtio",
+        "-drive",
+        f"file={seed_iso},format=raw,media=cdrom,readonly=on",
+        "-netdev",
+        f"user,id=net0,hostfwd=tcp::{kevent_host_port}-:3183,hostfwd=tcp::{ssh_host_port}-:22",
+        "-device",
+        "virtio-net-pci,netdev=net0",
+        "-name",
+        name,
+    ]
+    print("+", " ".join(command), flush=True)
+    return subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def wait_for_port(port: int, timeout_seconds: int = 420) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(1)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(1)
+    raise TimeoutError(f"port {port} did not open within {timeout_seconds}s")
+
+
+def main() -> int:
+    binary = build_harness()
+    base_image = ensure_base_image()
+    server, http_port, _ = start_http_server(binary)
+    procs: list[subprocess.Popen] = []
+    work_dir = Path(tempfile.mkdtemp(prefix="kevent-peer-vm-"))
+    keep_work_dir = False
+    try:
+        try:
+            node_b_disk = create_overlay(base_image, work_dir, "node-b")
+            node_a_disk = create_overlay(base_image, work_dir, "node-a")
+            node_b_seed = create_seed_iso(work_dir, "node_b", None, http_port)
+            node_a_seed = create_seed_iso(work_dir, "node_a", "10.0.2.2:23183", http_port)
+            procs.append(
+                start_vm(
+                    "kevent-peer-node-b",
+                    node_b_disk,
+                    node_b_seed,
+                    23183,
+                    22222,
+                    work_dir / "node-b.log",
+                )
+            )
+            procs.append(
+                start_vm(
+                    "kevent-peer-node-a",
+                    node_a_disk,
+                    node_a_seed,
+                    13183,
+                    12222,
+                    work_dir / "node-a.log",
+                )
+            )
+            wait_for_port(23183)
+            wait_for_port(13183)
+            completed = run(
+                [
+                    str(binary),
+                    "client",
+                    "--node-a",
+                    "127.0.0.1:13183",
+                    "--node-b",
+                    "127.0.0.1:23183",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            if completed.stderr:
+                print(completed.stderr, file=sys.stderr, end="")
+            print(completed.stdout, end="")
+            lines = [line for line in completed.stdout.splitlines() if line.strip()]
+            result = json.loads(lines[-1])
+            if result.get("status") != "passed":
+                raise RuntimeError(f"unexpected result: {result}")
+            print(
+                json.dumps(
+                    {
+                        "status": "passed",
+                        "backend": "qemu-kvm",
+                        "node_a_port": 13183,
+                        "node_b_port": 23183,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        except Exception:
+            keep_work_dir = True
+            print(f"VM test failed; preserving work directory: {work_dir}", file=sys.stderr)
+            for log_name in ("node-a.log", "node-b.log"):
+                log_path = work_dir / log_name
+                if log_path.exists():
+                    print(f"--- {log_name} tail ---", file=sys.stderr)
+                    try:
+                        print("\n".join(log_path.read_text(errors="replace").splitlines()[-120:]), file=sys.stderr)
+                    except Exception as log_error:
+                        print(f"failed to read {log_path}: {log_error}", file=sys.stderr)
+            traceback.print_exc()
+            return 1
+        finally:
+            server.shutdown()
+            for proc in procs:
+                proc.terminate()
+            for proc in procs:
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=10)
+    finally:
+        if not keep_work_dir:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/kevent_kmsg/restart/deno.json
+++ b/test/kevent_kmsg/restart/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "buckyos": "./node_modules/buckyos/dist/node.mjs"
+  }
+}

--- a/test/kevent_kmsg/restart/kevent_kmsg_restart_dv.ts
+++ b/test/kevent_kmsg/restart/kevent_kmsg_restart_dv.ts
@@ -1,0 +1,477 @@
+import { initTestRuntime } from "../../test_helpers/buckyos_client.ts";
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+type JsonObject = { [key: string]: JsonValue };
+
+type RpcClient = {
+  call: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+type Message = {
+  index: number;
+  created_at: number;
+  payload: number[];
+  headers: Record<string, string>;
+};
+
+type StreamReader = {
+  readFrame: (timeoutMs: number) => Promise<JsonObject>;
+  close: () => void;
+};
+
+const assert = {
+  ok(value: unknown, message?: string): void {
+    if (!value) throw new Error(message ?? "assertion failed");
+  },
+  equal(actual: unknown, expected: unknown, message?: string): void {
+    if (actual !== expected) {
+      throw new Error(
+        message ?? `expected ${String(expected)}, got ${String(actual)}`,
+      );
+    }
+  },
+};
+
+function getEnv(name: string, fallback?: string): string | undefined {
+  const value = Deno.env.get(name);
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  return fallback;
+}
+
+function repoRoot(): string {
+  return new URL("../../..", import.meta.url).pathname;
+}
+
+function nowTag(): string {
+  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function defaultQueueConfig(): JsonObject {
+  return {
+    max_messages: null,
+    retention_seconds: null,
+    sync_write: true,
+    other_app_can_read: true,
+    other_app_can_write: false,
+    other_user_can_read: false,
+    other_user_can_write: false,
+  };
+}
+
+function encodePayload(value: JsonValue): number[] {
+  return Array.from(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function decodePayload(message: Message): JsonValue {
+  return JSON.parse(new TextDecoder().decode(new Uint8Array(message.payload)));
+}
+
+function asObject(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} is not an object: ${JSON.stringify(value)}`);
+  }
+  return value as JsonObject;
+}
+
+function asMessages(value: unknown): Message[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`expected messages array, got ${JSON.stringify(value)}`);
+  }
+  return value as Message[];
+}
+
+async function rpcCall<T>(
+  rpc: RpcClient,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  return await rpc.call(method, params) as T;
+}
+
+async function prepareAppClientConfig(): Promise<void> {
+  const sourceDir = getEnv(
+    "BUCKYOS_TEST_APP_CLIENT_DIR",
+    "/opt/buckyos/etc/.buckycli",
+  )!;
+  const tempDir = await Deno.makeTempDir({ prefix: "buckyos-appclient-" });
+
+  await Deno.copyFile(
+    `${sourceDir}/user_private_key.pem`,
+    `${tempDir}/user_private_key.pem`,
+  );
+
+  const userConfig = JSON.parse(
+    await Deno.readTextFile(`${sourceDir}/user_config.json`),
+  ) as JsonObject;
+  if (Array.isArray(userConfig["@context"])) {
+    const contexts = userConfig["@context"].filter((item) =>
+      typeof item === "string"
+    );
+    userConfig["@context"] = contexts.at(-1) ??
+      "https://buckyos.org/ns/owner/v1";
+  }
+  await Deno.writeTextFile(
+    `${tempDir}/user_config.json`,
+    `${JSON.stringify(userConfig, null, 2)}\n`,
+  );
+
+  try {
+    await Deno.copyFile(
+      `${sourceDir}/zone_config.json`,
+      `${tempDir}/zone_config.json`,
+    );
+  } catch {
+    // zone_config.json is optional for the WebSDK private key loader.
+  }
+
+  Deno.env.set("BUCKYOS_TEST_APP_CLIENT_DIR", tempDir);
+}
+
+async function createQueue(
+  rpc: RpcClient,
+  name: string,
+  appId: string,
+  ownerUserId: string,
+): Promise<string> {
+  return await rpcCall<string>(rpc, "create_queue", {
+    name,
+    appid: appId,
+    app_owner: ownerUserId,
+    config: defaultQueueConfig(),
+  });
+}
+
+async function cleanupQueue(rpc: RpcClient, queueUrn: string | null) {
+  if (!queueUrn) return;
+  try {
+    await rpc.call("delete_queue", { queue_urn: queueUrn });
+  } catch (error) {
+    console.log("[warn] cleanup delete_queue failed", String(error));
+  }
+}
+
+async function openKeventStream(
+  gatewayBaseUrl: string,
+  pattern: string,
+): Promise<StreamReader> {
+  const controller = new AbortController();
+  const response = await fetch(`${gatewayBaseUrl}/kapi/kevent/stream`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ patterns: [pattern], keepalive_ms: 1000 }),
+    signal: controller.signal,
+  });
+
+  if (!response.ok || !response.body) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `kevent stream failed: status=${response.status}, body=${text}`,
+    );
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  async function readFrame(timeoutMs: number): Promise<JsonObject> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const newline = buffer.indexOf("\n");
+      if (newline >= 0) {
+        const line = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (line.length === 0) continue;
+        return asObject(JSON.parse(line), "kevent stream frame");
+      }
+
+      const remaining = deadline - Date.now();
+      const readPromise = reader.read();
+      const timeoutPromise = new Promise<ReadableStreamReadResult<Uint8Array>>(
+        (_resolve, reject) =>
+          setTimeout(
+            () => reject(new Error("kevent stream read timeout")),
+            remaining,
+          ),
+      );
+      const chunk = await Promise.race([readPromise, timeoutPromise]);
+      if (chunk.done) throw new Error("kevent stream closed");
+      buffer += decoder.decode(chunk.value, { stream: true });
+    }
+    throw new Error("kevent stream read timeout");
+  }
+
+  return {
+    readFrame,
+    close(): void {
+      controller.abort();
+      reader.cancel().catch(() => {});
+    },
+  };
+}
+
+async function publishKevent(
+  gatewayBaseUrl: string,
+  eventid: string,
+  data: JsonObject,
+): Promise<void> {
+  const response = await fetch(`${gatewayBaseUrl}/kapi/kevent/publish`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ eventid, data }),
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `kevent publish failed: status=${response.status}, body=${body}`,
+    );
+  }
+  assert.equal(JSON.parse(body).status, "ok");
+}
+
+async function runCommand(
+  args: string[],
+  options: { cwd?: string; timeoutMs?: number } = {},
+): Promise<string> {
+  const command = new Deno.Command(args[0], {
+    args: args.slice(1),
+    cwd: options.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const child = command.spawn();
+  const timeoutMs = options.timeoutMs ?? 120000;
+  const timeout = setTimeout(() => {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Process may have already exited.
+    }
+  }, timeoutMs);
+  const output = await child.output();
+  clearTimeout(timeout);
+
+  const stdout = new TextDecoder().decode(output.stdout);
+  const stderr = new TextDecoder().decode(output.stderr);
+  const text = `${stdout}${stderr}`;
+  if (!output.success) {
+    throw new Error(
+      `command failed: ${args.join(" ")}\nstatus=${output.code}\n${text}`,
+    );
+  }
+  return text;
+}
+
+async function waitForCheck(uv: string): Promise<string> {
+  let last = "";
+  for (let attempt = 0; attempt < 18; attempt += 1) {
+    try {
+      const output = await runCommand(
+        [uv, "run", "src/check.py"],
+        { cwd: repoRoot(), timeoutMs: 60000 },
+      );
+      last = output;
+      if (output.includes("Overall Status: Running")) {
+        return output;
+      }
+    } catch (error) {
+      last = String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+  throw new Error(`BuckyOS did not recover after restart:\n${last}`);
+}
+
+async function observeOldStream(stream: StreamReader): Promise<string> {
+  const deadline = Date.now() + 45000;
+  while (Date.now() < deadline) {
+    try {
+      const frame = await stream.readFrame(5000);
+      if (frame.type !== "keepalive") {
+        return `frame:${JSON.stringify(frame)}`;
+      }
+    } catch (error) {
+      return `closed:${String(error)}`;
+    }
+  }
+  return "timeout:old stream produced only keepalive frames";
+}
+
+async function run(): Promise<void> {
+  await prepareAppClientConfig();
+  const { buckyos, userId, ownerUserId, zoneHost } = await initTestRuntime();
+  const appId = getEnv("BUCKYOS_TEST_APP_ID", "buckycli")!;
+  const gatewayBaseUrl = getEnv(
+    "BUCKYOS_GATEWAY_BASE_URL",
+    `https://${zoneHost}`,
+  )!;
+  const uv = getEnv("BUCKYOS_TEST_UV", "uv")!;
+  const tag = nowTag();
+  const kmsg = buckyos.getServiceRpcClient("kmsg") as RpcClient;
+
+  let queueUrn: string | null = null;
+  let oldStream: StreamReader | null = null;
+  let newStream: StreamReader | null = null;
+  try {
+    queueUrn = await createQueue(
+      kmsg,
+      `kevent-kmsg-restart-${tag}`,
+      appId,
+      ownerUserId,
+    );
+    const firstPayload = {
+      case: "DV-MANUAL-01",
+      tag,
+      value: "before-restart",
+    };
+    const firstIndex = await rpcCall<number>(kmsg, "post_message", {
+      queue_urn: queueUrn,
+      message: {
+        index: 0,
+        created_at: 0,
+        payload: encodePayload(firstPayload),
+        headers: { test_case: "DV-MANUAL-01" },
+      },
+    });
+    const subId = await rpcCall<string>(kmsg, "subscribe", {
+      queue_urn: queueUrn,
+      userid: userId,
+      appid: appId,
+      sub_id: `kevent-kmsg-restart-sub-${tag}`,
+      position: "Earliest",
+    });
+    const fetched = asMessages(
+      await kmsg.call("fetch_messages", {
+        sub_id: subId,
+        length: 10,
+        auto_commit: false,
+      }),
+    );
+    assert.equal(fetched.length, 1);
+    assert.equal(fetched[0].index, firstIndex);
+    await kmsg.call("commit_ack", { sub_id: subId, index: firstIndex });
+
+    const eventid = `/kevent_kmsg/restart/${tag}`;
+    oldStream = await openKeventStream(gatewayBaseUrl, eventid);
+    const ack = await oldStream.readFrame(5000);
+    assert.equal(ack.type, "ack", "kevent stream should ack before restart");
+
+    const oldStreamOutcomePromise = observeOldStream(oldStream);
+    const startOutput = await runCommand(
+      [uv, "run", "src/start.py", "--skip-update"],
+      { cwd: repoRoot(), timeoutMs: 180000 },
+    );
+    const checkOutput = await waitForCheck(uv);
+    const oldStreamOutcome = await oldStreamOutcomePromise;
+
+    const kmsgAfterRestart = buckyos.getServiceRpcClient("kmsg") as RpcClient;
+    const reread = asMessages(
+      await kmsgAfterRestart.call("read_message", {
+        queue_urn: queueUrn,
+        cursor: firstIndex,
+        length: 1,
+      }),
+    );
+    assert.equal(reread.length, 1, "message should survive service restart");
+    assert.equal(
+      (decodePayload(reread[0]) as JsonObject).value,
+      "before-restart",
+    );
+
+    let activeSubId = subId;
+    let subscriptionAfterRestart = "preserved";
+    try {
+      const afterAck = asMessages(
+        await kmsgAfterRestart.call("fetch_messages", {
+          sub_id: subId,
+          length: 10,
+          auto_commit: false,
+        }),
+      );
+      assert.equal(
+        afterAck.length,
+        0,
+        "subscription cursor should not replay an acked message after restart",
+      );
+    } catch (error) {
+      subscriptionAfterRestart = `missing:${String(error)}`;
+      activeSubId = await rpcCall<string>(kmsgAfterRestart, "subscribe", {
+        queue_urn: queueUrn,
+        userid: userId,
+        appid: appId,
+        sub_id: `kevent-kmsg-restart-recovered-sub-${tag}`,
+        position: "Latest",
+      });
+    }
+
+    newStream = await openKeventStream(gatewayBaseUrl, eventid);
+    const newAck = await newStream.readFrame(5000);
+    assert.equal(newAck.type, "ack", "kevent stream should reconnect");
+
+    const fallbackIndex = await rpcCall<number>(
+      kmsgAfterRestart,
+      "post_message",
+      {
+        queue_urn: queueUrn,
+        message: {
+          index: 0,
+          created_at: 0,
+          payload: encodePayload({
+            case: "DV-MANUAL-02",
+            tag,
+            value: "after-restart",
+          }),
+          headers: { test_case: "DV-MANUAL-02" },
+        },
+      },
+    );
+    const fallbackFetched = asMessages(
+      await kmsgAfterRestart.call("fetch_messages", {
+        sub_id: activeSubId,
+        length: 10,
+        auto_commit: false,
+      }),
+    );
+    assert.equal(fallbackFetched.length, 1);
+    assert.equal(fallbackFetched[0].index, fallbackIndex);
+    await kmsgAfterRestart.call("commit_ack", {
+      sub_id: activeSubId,
+      index: fallbackIndex,
+    });
+
+    await publishKevent(gatewayBaseUrl, eventid, {
+      queue_urn: queueUrn,
+      index: fallbackIndex,
+      tag,
+    });
+    let eventFrame: JsonObject | null = null;
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const frame = await newStream.readFrame(5000);
+      if (frame.type === "event") {
+        eventFrame = frame;
+        break;
+      }
+    }
+    assert.ok(eventFrame, "kevent stream should work after restart");
+
+    console.log(
+      JSON.stringify({
+        status: "passed",
+        queue_urn: queueUrn,
+        indexes: { firstIndex, fallbackIndex },
+        old_stream: oldStreamOutcome,
+        subscription_after_restart: subscriptionAfterRestart,
+        restart_seen: startOutput.includes("BuckyOS Startup Complete"),
+        check_seen: checkOutput.includes("Overall Status: Running"),
+      }),
+    );
+  } finally {
+    if (oldStream) oldStream.close();
+    if (newStream) newStream.close();
+    await cleanupQueue(kmsg, queueUrn);
+  }
+}
+
+await run();

--- a/test/kevent_kmsg/restart/package.json
+++ b/test/kevent_kmsg/restart/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "kevent-kmsg-restart-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "deno run --config deno.json --allow-net --allow-read --allow-write --allow-env --allow-run --unsafely-ignore-certificate-errors kevent_kmsg_restart_dv.ts"
+  },
+  "dependencies": {
+    "buckyos": "github:buckyos/buckyos-websdk#beta2.2"
+  }
+}


### PR DESCRIPTION
## Summary

- add kevent/kmsg test plan and current test report
- move kevent/kmsg DV tests under test/kevent_kmsg
- add restart, container peer, and VM peer test entries
- extend kevent usage/performance coverage
- add node_daemon kevent native test coverage
- ignore local per-run test reports under test/kevent_kmsg/reports

## Verification

- cargo test -p kevent
- cargo test -p kmsg
- cargo test -p node_daemon kevent_server -- --nocapture
- cargo test -p kevent --test performance -- --ignored --nocapture --test-threads=1
- cargo test -p kmsg --test sled_contract -- --ignored --nocapture
- uv run src/test/test_boot_gatweay/run_debug_tests.py
- uv run test/run.py -p kevent_kmsg/dv
- uv run test/run.py -p kevent_kmsg/restart
- uv run test/run.py -p kevent_kmsg/peer_container
- uv run test/run.py -p kevent_kmsg/peer_vm