### PR TITLE
修正 Gemini provider 命名并补充 AICC settings 管理员写权限

### DIFF
--- a/doc/aicc/aicc-mgr.md
+++ b/doc/aicc/aicc-mgr.md
@@ -43,7 +43,7 @@ Provider 注册流程：
 
 1. AICC 启动或 reload 时读取 `services/aicc/settings`。
 2. `apply_provider_settings()` 清空 registry 和 route。
-3. 依次调用 `register_openai_llm_providers`、`register_sn_ai_provider`、`register_google_gimini_providers`、`register_claude_providers`、`register_minimax_providers`、`register_fal_providers`。
+3. 依次调用 `register_openai_llm_providers`、`register_sn_ai_provider`、`register_google_gemini_providers`、`register_claude_providers`、`register_minimax_providers`、`register_fal_providers`。
 4. 应用默认 logical tree。
 
 ### 2.2 settings key
@@ -533,7 +533,7 @@ let next = config_client.get("services/aicc/settings").await?;
 - `src/frame/aicc/src/aicc.rs`
   - 在 `Provider` trait 暴露 `refresh_inventory`，并在 registry / model_registry 中提供按 `provider_instance_name` 刷新并 apply inventory 的方法。
   - 暴露 usage query helper，如不方便可先放在 `main.rs` 调用 `usage_log_db()`。
-- `src/frame/aicc/src/openai.rs`、`src/frame/aicc/src/claude.rs`、`src/frame/aicc/src/gimini.rs`、`src/frame/aicc/src/minimax.rs`、`src/frame/aicc/src/fal.rs`、`src/frame/aicc/src/sn_ai_provider.rs`
+- `src/frame/aicc/src/openai.rs`、`src/frame/aicc/src/claude.rs`、`src/frame/aicc/src/gemini.rs`、`src/frame/aicc/src/minimax.rs`、`src/frame/aicc/src/fal.rs`、`src/frame/aicc/src/sn_ai_provider.rs`
   - settings parser 改为从每个 instance 读取 `api_token` / `api_key`。
   - 旧 section 级 token 只用于一次性迁移到 instance 级。
   - 实现 `Provider::refresh_inventory`，复用现有 `refresh_inventory_once` 逻辑。

--- a/doc/aicc/aicc-models-todo.md
+++ b/doc/aicc/aicc-models-todo.md
@@ -66,7 +66,7 @@
   - 排查入口：
     - `src/frame/aicc/src/openai.rs`
     - `src/frame/aicc/src/claude.rs`
-    - `src/frame/aicc/src/gimini.rs`
+    - `src/frame/aicc/src/gemini.rs`
     - `src/frame/aicc/src/minimax.rs`
     - `src/frame/aicc/src/fal.rs`
   - 注意：不要一次性删除所有 role mounts，应先补测试确认用途目录仍可通过家族目录路由。

--- a/doc/aicc/aicc_provider修改.md
+++ b/doc/aicc/aicc_provider修改.md
@@ -88,7 +88,7 @@ pub struct ProviderInstance {
 
 ### 3.3 provider 注册仍在写 ModelCatalog alias
 
-`openai.rs`、`claude.rs`、`gimini.rs`、`minimax.rs` 都有 `register_default_aliases()` 和 `register_custom_aliases()`，直接写：
+`openai.rs`、`claude.rs`、`gemini.rs`、`minimax.rs` 都有 `register_default_aliases()` 和 `register_custom_aliases()`，直接写：
 
 ```rust
 center.model_catalog().set_mapping(...)
@@ -177,7 +177,7 @@ pub struct ProviderInstance {
 
 - `provider_instance_name`：provider instance 唯一名，精确模型名后缀使用它。
 - `provider_type`：使用 `model_types::ProviderType`，只表达 `local_inference`、`cloud_api`、`proxy_unknown` 这类可信部署类型。
-- `provider_driver`：字符串，表达 OpenAI、Claude、Gemini、MiniMax、Ollama 等具体 provider 实现或厂商类型。旧 settings 里的 `"openai"`、`"claude"`、`"google-gimini"`、`"minimax"` 应迁移到这个字段。
+- `provider_driver`：字符串，表达 OpenAI、Claude、Gemini、MiniMax、Ollama 等具体 provider 实现或厂商类型。旧 settings 里的 `"openai"`、`"claude"`、`"google-gemini"`、`"minimax"` 应迁移到这个字段。
 - `provider_origin` 枚举建议至少区分 `SystemConfig`、`UserConfig`、`BuiltIn`、`ProviderClaimed`、`Unknown`。
 - `provider_type_trusted_source` 用于 trace 和 `local_only` 硬过滤，例如 `system_config`、`admin_override`、`provider_inventory`、`default_unknown`。
 
@@ -296,7 +296,7 @@ pub struct CostEstimateOutput {
 1. 在 `AIComputeCenter` 接入新版 `ModelRegistry`，并从运行路径移除 `ModelCatalog`。
 2. 直接改 `Provider` trait：删除 `instance()` 和旧 `estimate_cost()`，新增 `inventory()` 与 `CostEstimateOutput` 版本成本估算。
 3. 直接改 `ProviderInstance`/inventory 相关字段：`instance_id` 改为 `provider_instance_name`，`provider_type` 改为可信部署类型 enum，新增 `provider_driver`、`provider_origin`、`provider_type_trusted_source`。
-4. 改 OpenAI/Claude/Gimini/MiniMax provider：注册时只 add provider + apply inventory，不写 alias。
+4. 改 OpenAI/Claude/Gemini/MiniMax provider：注册时只 add provider + apply inventory，不写 alias。
 5. 修掉 OpenAI 注册内部 clear，把全量 clear 收敛到 `apply_provider_settings()`。
 6. 把实际 route 路径切到 `ModelRouter + ModelScheduler`，旧 `ModelCatalog.resolve()` 路径删除。
 7. 用 global `SessionConfig` 表达默认角色目录和默认模型策略，替代 provider `default_model`/`alias_map` 副作用。
@@ -344,7 +344,7 @@ review 后进入实现阶段时，建议至少验证：
 - `src/frame/aicc/src/main.rs`
 - `src/frame/aicc/src/openai.rs`
 - `src/frame/aicc/src/claude.rs`
-- `src/frame/aicc/src/gimini.rs`
+- `src/frame/aicc/src/gemini.rs`
 - `src/frame/aicc/src/minimax.rs`
 - `src/frame/aicc/src/model_types.rs`
 - `src/frame/aicc/src/model_registry.rs`

--- a/doc/aicc/maintenance/acceptance/cases/cases_l1_provider_protocol_openai.md
+++ b/doc/aicc/maintenance/acceptance/cases/cases_l1_provider_protocol_openai.md
@@ -19,7 +19,7 @@ P0 Provider 最小集合按 `aicc_provider_plan.md`：
 
 - `openai.rs`
 - `claude.rs`
-- `gimini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
+- `gemini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
 - `fal.rs`
 
 OpenRouter 在 Mock 和 Provider adapter 单测中仍可作为 P1 optional provider；在 L4 gateway 发布强覆盖验收中纳入 Provider 覆盖矩阵，用于验证 OpenAI-compatible 长尾模型、成本 fallback 和兼容性。普通开发验收缺少 OpenRouter key 时应 skipped，不阻塞 P0。

--- a/doc/aicc/maintenance/acceptance/cases/cases_l4_gateway_llm_providers.md
+++ b/doc/aicc/maintenance/acceptance/cases/cases_l4_gateway_llm_providers.md
@@ -19,7 +19,7 @@ P0 Provider 最小集合按 `aicc_provider_plan.md`：
 
 - `openai.rs`
 - `claude.rs`
-- `gimini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
+- `gemini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
 - `fal.rs`
 
 OpenRouter 在 Mock 和 Provider adapter 单测中仍可作为 P1 optional provider；在 L4 gateway 发布强覆盖验收中纳入 Provider 覆盖矩阵，用于验证 OpenAI-compatible 长尾模型、成本 fallback 和兼容性。普通开发验收缺少 OpenRouter key 时应 skipped，不阻塞 P0。

--- a/doc/aicc/maintenance/acceptance/cases/cases_l4_gateway_media_providers.md
+++ b/doc/aicc/maintenance/acceptance/cases/cases_l4_gateway_media_providers.md
@@ -105,7 +105,7 @@ P0 Provider 最小集合按 `aicc_provider_plan.md`：
 
 - `openai.rs`
 - `claude.rs`
-- `gimini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
+- `gemini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
 - `fal.rs`
 
 OpenRouter 在 Mock 和 Provider adapter 单测中仍可作为 P1 optional provider；在 L4 gateway 发布强覆盖验收中纳入 Provider 覆盖矩阵，用于验证 OpenAI-compatible 长尾模型、成本 fallback 和兼容性。普通开发验收缺少 OpenRouter key 时应 skipped，不阻塞 P0。

--- a/doc/aicc/maintenance/acceptance/components/component_l4_matrix_runner.md
+++ b/doc/aicc/maintenance/acceptance/components/component_l4_matrix_runner.md
@@ -19,7 +19,7 @@ P0 Provider 最小集合按 `aicc_provider_plan.md`：
 
 - `openai.rs`
 - `claude.rs`
-- `gimini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
+- `gemini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
 - `fal.rs`
 
 OpenRouter 在 Mock 和 Provider adapter 单测中仍可作为 P1 optional provider；在 L4 gateway 发布强覆盖验收中纳入 Provider 覆盖矩阵，用于验证 OpenAI-compatible 长尾模型、成本 fallback 和兼容性。普通开发验收缺少 OpenRouter key 时应 skipped，不阻塞 P0。

--- a/doc/aicc/maintenance/acceptance/components/component_mock_provider_part_2.md
+++ b/doc/aicc/maintenance/acceptance/components/component_mock_provider_part_2.md
@@ -19,7 +19,7 @@ P0 Provider 最小集合按 `aicc_provider_plan.md`：
 
 - `openai.rs`
 - `claude.rs`
-- `gimini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
+- `gemini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
 - `fal.rs`
 
 OpenRouter 在 Mock 和 Provider adapter 单测中仍可作为 P1 optional provider；在 L4 gateway 发布强覆盖验收中纳入 Provider 覆盖矩阵，用于验证 OpenAI-compatible 长尾模型、成本 fallback 和兼容性。普通开发验收缺少 OpenRouter key 时应 skipped，不阻塞 P0。

--- a/doc/aicc/maintenance/acceptance/components/component_provider_protocol_coverage.md
+++ b/doc/aicc/maintenance/acceptance/components/component_provider_protocol_coverage.md
@@ -19,7 +19,7 @@ P0 Provider 最小集合按 `aicc_provider_plan.md`：
 
 - `openai.rs`
 - `claude.rs`
-- `gimini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
+- `gemini.rs` / `google-gemini` driver（代码中保留历史拼写，配置与 metadata 统一按 Google Gemini 语义验收）
 - `fal.rs`
 
 OpenRouter 在 Mock 和 Provider adapter 单测中仍可作为 P1 optional provider；在 L4 gateway 发布强覆盖验收中纳入 Provider 覆盖矩阵，用于验证 OpenAI-compatible 长尾模型、成本 fallback 和兼容性。普通开发验收缺少 OpenRouter key 时应 skipped，不阻塞 P0。

--- a/doc/aicc/maintenance/how_to_add_provider.md
+++ b/doc/aicc/maintenance/how_to_add_provider.md
@@ -48,7 +48,7 @@ claude-sonnet-4.5@claude-main
 
 ### 步骤 1：定义 settings 与 Provider 结构
 
-建议参考 `openai.rs`、`claude.rs`、`gimini.rs`、`minimax.rs`、`fal.rs`。
+建议参考 `openai.rs`、`claude.rs`、`gemini.rs`、`minimax.rs`、`fal.rs`。
 
 实例配置建议包含：
 
@@ -115,7 +115,7 @@ provider_model_metadata(
 
 AICC 会把多个 Provider 的 inventory 汇入 `ModelRegistry`，同一个逻辑模型名可以产生多个候选。
 
-> **能力 metadata 优先走 driver metadata resolver，而不是 Provider 自声明。** Provider 自发现只需负责发现 `provider_model_id`（例如 OpenAI 通过 `/models` 报告模型列表）；`metadata_resolver.rs` 再按 driver metadata（`openai.json` / `claude.json` / `gimini.json` 对应的 gemini / `fal.json` / `minimax.json`）把 model id 转成最终 `ModelMetadata` 的 `capabilities` / `logical_mounts` / `variants`。匹配优先级：exact `models` → `patterns` → `defaults` → conservative fallback；override 链：builtin → remote cache → local override → system-config override。unknown model 保守对待，不默认声明 `tool_call` / `web_search` / `vision` / `json_schema`。schema 见 `doc/aicc/driver_metadata_schema.md`。新接入 Provider 应把按模型名细分能力的规则收编到 driver metadata（参考 `claude.rs` 的 classifier 收编路径），而不是写死在 adapter 里，也不再依赖 legacy `ProviderInstance.features`。
+> **能力 metadata 优先走 driver metadata resolver，而不是 Provider 自声明。** Provider 自发现只需负责发现 `provider_model_id`（例如 OpenAI 通过 `/models` 报告模型列表）；`metadata_resolver.rs` 再按 driver metadata（`openai.json` / `claude.json` / `gemini.json` 对应的 gemini / `fal.json` / `minimax.json`）把 model id 转成最终 `ModelMetadata` 的 `capabilities` / `logical_mounts` / `variants`。匹配优先级：exact `models` → `patterns` → `defaults` → conservative fallback；override 链：builtin → remote cache → local override → system-config override。unknown model 保守对待，不默认声明 `tool_call` / `web_search` / `vision` / `json_schema`。schema 见 `doc/aicc/driver_metadata_schema.md`。新接入 Provider 应把按模型名细分能力的规则收编到 driver metadata（参考 `claude.rs` 的 classifier 收编路径），而不是写死在 adapter 里，也不再依赖 legacy `ProviderInstance.features`。
 >
 > reasoning effort 等档位用 driver metadata 的 `variants` 表达（展开成 `gpt-5.1:reasoning-high@instance` 这类带 variant 的精确模型 + 预置 `provider_options`），不要做成普通请求参数。
 

--- a/doc/aicc/maintenance/update_aicc_settings_via_system_config.md
+++ b/doc/aicc/maintenance/update_aicc_settings_via_system_config.md
@@ -245,7 +245,7 @@ POST /kapi/aicc
 - `src/frame/aicc/src/model_types.rs`
 - `src/frame/aicc/src/openai.rs`
 - `src/frame/aicc/src/claude.rs`
-- `src/frame/aicc/src/gimini.rs`
+- `src/frame/aicc/src/gemini.rs`
 - `src/frame/aicc/src/minimax.rs`
 - `src/kernel/buckyos-api/src/aicc_client.rs`
 - `src/kernel/buckyos-api/src/system_config.rs`

--- a/doc/arch/system_config_reference.md
+++ b/doc/arch/system_config_reference.md
@@ -108,7 +108,7 @@ verify-hub 的私钥不在 `services/verify-hub/settings`，而在 `security/ver
 | --- | --- | --- | --- |
 | `services/aicc/settings` | AICC provider 和路由配置。包含 provider 实例、模型、默认模型、alias、feature、image model、`routing_config` 等。 | scheduler 初始化；aicc 管理接口；control-panel AI provider 管理 | aicc 启动和 reload 时读取；Control Panel AI 设置页读取和更新。 |
 
-当前 AICC 代码识别的 provider section 包括 `sn-ai-provider`、`openai`、`google`、`gemini`、`google_gemini`、`google_gimini`、`claude`、`anthropic`、`minimax`、`fal`。
+当前 AICC 代码识别的 provider section 包括 `sn-ai-provider`、`openai`、`google`、`gemini`、`google_gemini`、`google_gemini`、`claude`、`anthropic`、`minimax`、`fal`。
 
 ### msg-center
 

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -2730,10 +2730,7 @@ fn provider_driver_mount_segment(provider_driver: &str) -> String {
     let stripped = normalized
         .strip_prefix("google-")
         .unwrap_or(normalized.as_str());
-    match stripped {
-        "gimini" => "gemini".to_string(),
-        _ => logical_mount_segment(stripped),
-    }
+    logical_mount_segment(stripped)
 }
 
 #[allow(dead_code)]
@@ -2748,7 +2745,7 @@ pub fn image_logical_mounts(provider_driver: &str, provider_model_id: &str) -> V
         mounts.push("image.txt2img.gpt_image".to_string());
     } else if lowered.contains("dall-e") {
         mounts.push("image.txt2img.dalle".to_string());
-    } else if lowered.contains("gemini") || lowered.contains("gimini") {
+    } else if lowered.contains("gemini") {
         mounts.push("image.txt2img.gemini".to_string());
     }
     mounts

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -25,18 +25,18 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::time;
 
-const DEFAULT_GIMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
-const DEFAULT_GIMINI_TIMEOUT_MS: u64 = 60_000;
-const DEFAULT_GIMINI_MODELS: &str = "gemini-2.5-flash,gemini-2.5-pro";
-const DEFAULT_GIMINI_IMAGE_MODELS: &str =
+const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
+const DEFAULT_GEMINI_TIMEOUT_MS: u64 = 60_000;
+const DEFAULT_GEMINI_MODELS: &str = "gemini-2.5-flash,gemini-2.5-pro";
+const DEFAULT_GEMINI_IMAGE_MODELS: &str =
     "gemini-2.0-flash-exp-image-generation,gemini-2.5-flash-image-preview";
-const DEFAULT_GIMINI_EMBEDDING_MODELS: &str = "gemini-embedding-001";
-const DEFAULT_GIMINI_TTS_MODELS: &str = "gemini-2.5-flash-preview-tts";
-const DEFAULT_GIMINI_MUSIC_MODELS: &str = "lyria-002";
-const DEFAULT_GIMINI_VIDEO_MODELS: &str = "veo-3.1-generate-preview";
-const DEFAULT_GIMINI_INVENTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
-const GIMINI_MODELS_PAGE_SIZE: u32 = 1000;
-const GIMINI_IMAGE_INPUT_ALLOWLIST: &[&str] = &[
+const DEFAULT_GEMINI_EMBEDDING_MODELS: &str = "gemini-embedding-001";
+const DEFAULT_GEMINI_TTS_MODELS: &str = "gemini-2.5-flash-preview-tts";
+const DEFAULT_GEMINI_MUSIC_MODELS: &str = "lyria-002";
+const DEFAULT_GEMINI_VIDEO_MODELS: &str = "veo-3.1-generate-preview";
+const DEFAULT_GEMINI_INVENTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+const GEMINI_MODELS_PAGE_SIZE: u32 = 1000;
+const GEMINI_IMAGE_INPUT_ALLOWLIST: &[&str] = &[
     "candidate_count",
     "max_output_tokens",
     "n",
@@ -49,7 +49,7 @@ const GIMINI_IMAGE_INPUT_ALLOWLIST: &[&str] = &[
     "top_k",
     "top_p",
 ];
-const GIMINI_IMAGE_OPTION_ALLOWLIST: &[&str] = &[
+const GEMINI_IMAGE_OPTION_ALLOWLIST: &[&str] = &[
     "candidate_count",
     "max_output_tokens",
     "n",
@@ -66,7 +66,7 @@ const GIMINI_IMAGE_OPTION_ALLOWLIST: &[&str] = &[
     "top_p",
     "user",
 ];
-const GIMINI_VIDEO_PARAMETER_ALLOWLIST: &[&str] = &[
+const GEMINI_VIDEO_PARAMETER_ALLOWLIST: &[&str] = &[
     "aspect_ratio",
     "duration_seconds",
     "negative_prompt",
@@ -76,7 +76,7 @@ const GIMINI_VIDEO_PARAMETER_ALLOWLIST: &[&str] = &[
 ];
 
 #[derive(Debug, Clone)]
-pub struct GoogleGiminiInstanceConfig {
+pub struct GoogleGeminiInstanceConfig {
     pub provider_instance_name: String,
     pub provider_type: String,
     pub provider_driver: String,
@@ -95,7 +95,7 @@ pub struct GoogleGiminiInstanceConfig {
 }
 
 #[derive(Debug, Clone)]
-pub struct GoogleGiminiProvider {
+pub struct GoogleGeminiProvider {
     instance: ProviderInstance,
     inventory: Arc<RwLock<ProviderInventory>>,
     client: Client,
@@ -108,7 +108,7 @@ pub struct GoogleGiminiProvider {
 }
 
 #[derive(Debug, Default)]
-struct GiminiModelBuckets {
+struct GeminiModelBuckets {
     llm: Vec<String>,
     image: Vec<String>,
     embedding: Vec<String>,
@@ -117,7 +117,7 @@ struct GiminiModelBuckets {
     video: Vec<String>,
 }
 
-impl GiminiModelBuckets {
+impl GeminiModelBuckets {
     fn is_empty(&self) -> bool {
         self.llm.is_empty()
             && self.image.is_empty()
@@ -136,7 +136,7 @@ impl GiminiModelBuckets {
         self.music.hash(&mut hasher);
         self.video.hash(&mut hasher);
         format!(
-            "gimini-models-{}-{}-{}-{}-{}-{}-{:x}",
+            "gemini-models-{}-{}-{}-{}-{}-{}-{:x}",
             self.llm.len(),
             self.image.len(),
             self.embedding.len(),
@@ -149,15 +149,15 @@ impl GiminiModelBuckets {
 }
 
 #[derive(Debug, Deserialize)]
-struct GiminiModelsResponse {
+struct GeminiModelsResponse {
     #[serde(default)]
-    models: Vec<GiminiModelEntry>,
+    models: Vec<GeminiModelEntry>,
     #[serde(default, alias = "nextPageToken")]
     next_page_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-struct GiminiModelEntry {
+struct GeminiModelEntry {
     #[serde(default)]
     name: String,
     #[serde(default, alias = "supportedGenerationMethods")]
@@ -171,10 +171,10 @@ struct GiminiModelEntry {
     description: String,
 }
 
-impl GoogleGiminiProvider {
-    pub fn new(cfg: GoogleGiminiInstanceConfig, api_token: String) -> Result<Self> {
+impl GoogleGeminiProvider {
+    pub fn new(cfg: GoogleGeminiInstanceConfig, api_token: String) -> Result<Self> {
         let timeout_ms = if cfg.timeout_ms == 0 {
-            DEFAULT_GIMINI_TIMEOUT_MS
+            DEFAULT_GEMINI_TIMEOUT_MS
         } else {
             cfg.timeout_ms
         };
@@ -182,7 +182,7 @@ impl GoogleGiminiProvider {
         let client = Client::builder()
             .timeout(Duration::from_millis(timeout_ms))
             .build()
-            .context("failed to build reqwest client for google gimini provider")?;
+            .context("failed to build reqwest client for google gemini provider")?;
 
         let provider_type = provider_type_from_settings(cfg.provider_type.as_str());
         let provider_instance_name = cfg.provider_instance_name.clone();
@@ -206,7 +206,7 @@ impl GoogleGiminiProvider {
             endpoint: Some(cfg.base_url.clone()),
             plugin_key: None,
         };
-        let buckets = GiminiModelBuckets {
+        let buckets = GeminiModelBuckets {
             llm: cfg
                 .models
                 .iter()
@@ -214,10 +214,10 @@ impl GoogleGiminiProvider {
                 .cloned()
                 .collect(),
             image: cfg.image_models.clone(),
-            embedding: parse_csv_list(DEFAULT_GIMINI_EMBEDDING_MODELS),
-            tts: parse_csv_list(DEFAULT_GIMINI_TTS_MODELS),
-            music: parse_csv_list(DEFAULT_GIMINI_MUSIC_MODELS),
-            video: parse_csv_list(DEFAULT_GIMINI_VIDEO_MODELS),
+            embedding: parse_csv_list(DEFAULT_GEMINI_EMBEDDING_MODELS),
+            tts: parse_csv_list(DEFAULT_GEMINI_TTS_MODELS),
+            music: parse_csv_list(DEFAULT_GEMINI_MUSIC_MODELS),
+            video: parse_csv_list(DEFAULT_GEMINI_VIDEO_MODELS),
         };
         let inventory = Self::build_inventory_from_buckets(
             provider_instance_name.as_str(),
@@ -245,7 +245,7 @@ impl GoogleGiminiProvider {
         provider_instance_name: &str,
         provider_type: ProviderType,
         provider_driver: &str,
-        buckets: &GiminiModelBuckets,
+        buckets: &GeminiModelBuckets,
         _features: &[Feature],
         inventory_revision: Option<String>,
     ) -> ProviderInventory {
@@ -315,18 +315,18 @@ impl GoogleGiminiProvider {
         tokio::spawn(async move {
             if let Err(err) = self.refresh_inventory_once().await {
                 warn!(
-                    "aicc.gimini.inventory.initial_refresh_failed provider_instance_name={} err={}",
+                    "aicc.gemini.inventory.initial_refresh_failed provider_instance_name={} err={}",
                     self.provider_instance_name, err
                 );
             }
 
-            let mut interval = time::interval(DEFAULT_GIMINI_INVENTORY_REFRESH_INTERVAL);
+            let mut interval = time::interval(DEFAULT_GEMINI_INVENTORY_REFRESH_INTERVAL);
             interval.tick().await;
             loop {
                 interval.tick().await;
                 if let Err(err) = self.refresh_inventory_once().await {
                     warn!(
-                        "aicc.gimini.inventory.refresh_failed provider_instance_name={} err={}",
+                        "aicc.gemini.inventory.refresh_failed provider_instance_name={} err={}",
                         self.provider_instance_name, err
                     );
                 }
@@ -335,7 +335,7 @@ impl GoogleGiminiProvider {
     }
 
     async fn refresh_inventory_once(&self) -> Result<ProviderInventory> {
-        let mut buckets = GiminiModelBuckets::default();
+        let mut buckets = GeminiModelBuckets::default();
         let mut llm_seen = HashSet::<String>::new();
         let mut image_seen = HashSet::<String>::new();
         let mut embedding_seen = HashSet::<String>::new();
@@ -345,7 +345,7 @@ impl GoogleGiminiProvider {
         let mut page_token: Option<String> = None;
 
         let endpoint = format!("{}/models", self.base_url);
-        let page_size = GIMINI_MODELS_PAGE_SIZE.to_string();
+        let page_size = GEMINI_MODELS_PAGE_SIZE.to_string();
         loop {
             let mut request = self
                 .client
@@ -359,31 +359,31 @@ impl GoogleGiminiProvider {
             let response = request
                 .send()
                 .await
-                .context("gimini inventory refresh request failed")?;
+                .context("gemini inventory refresh request failed")?;
 
             if !response.status().is_success() {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
                 return Err(anyhow!(
-                    "gimini inventory refresh failed status={} body={}",
+                    "gemini inventory refresh failed status={} body={}",
                     status,
                     body
                 ));
             }
 
             let parsed = response
-                .json::<GiminiModelsResponse>()
+                .json::<GeminiModelsResponse>()
                 .await
-                .context("failed to parse gimini models response")?;
+                .context("failed to parse gemini models response")?;
 
             for entry in parsed.models.iter() {
-                let id = strip_gimini_model_prefix(entry.name.as_str()).trim();
+                let id = strip_gemini_model_prefix(entry.name.as_str()).trim();
                 if id.is_empty() {
                     continue;
                 }
-                if is_deprecated_gimini_entry(id, &entry.display_name, &entry.description) {
+                if is_deprecated_gemini_entry(id, &entry.display_name, &entry.description) {
                     log::debug!(
-                        "aicc.gimini.inventory.skip_deprecated id={} display_name={:?} description={:?}",
+                        "aicc.gemini.inventory.skip_deprecated id={} display_name={:?} description={:?}",
                         id,
                         entry.display_name,
                         entry.description
@@ -396,33 +396,33 @@ impl GoogleGiminiProvider {
                     .map(|method| method.to_ascii_lowercase())
                     .collect::<HashSet<_>>();
                 let key = id.to_ascii_lowercase();
-                match classify_gimini_model(id, &methods) {
-                    Some(GiminiModelKind::Llm) => {
+                match classify_gemini_model(id, &methods) {
+                    Some(GeminiModelKind::Llm) => {
                         if llm_seen.insert(key) {
                             buckets.llm.push(id.to_string());
                         }
                     }
-                    Some(GiminiModelKind::Image) => {
+                    Some(GeminiModelKind::Image) => {
                         if image_seen.insert(key) {
                             buckets.image.push(id.to_string());
                         }
                     }
-                    Some(GiminiModelKind::Embedding) => {
+                    Some(GeminiModelKind::Embedding) => {
                         if embedding_seen.insert(key) {
                             buckets.embedding.push(id.to_string());
                         }
                     }
-                    Some(GiminiModelKind::Tts) => {
+                    Some(GeminiModelKind::Tts) => {
                         if tts_seen.insert(key) {
                             buckets.tts.push(id.to_string());
                         }
                     }
-                    Some(GiminiModelKind::Music) => {
+                    Some(GeminiModelKind::Music) => {
                         if music_seen.insert(key) {
                             buckets.music.push(id.to_string());
                         }
                     }
-                    Some(GiminiModelKind::Video) => {
+                    Some(GeminiModelKind::Video) => {
                         if video_seen.insert(key) {
                             buckets.video.push(id.to_string());
                         }
@@ -439,7 +439,7 @@ impl GoogleGiminiProvider {
 
         if buckets.is_empty() {
             return Err(anyhow!(
-                "gimini inventory refresh returned no supported models"
+                "gemini inventory refresh returned no supported models"
             ));
         }
 
@@ -470,16 +470,16 @@ impl GoogleGiminiProvider {
         // Categories that the API never returns (lyria/veo are typically not
         // listed) fall back to defaults so we don't drop them on refresh.
         if buckets.embedding.is_empty() {
-            buckets.embedding = parse_csv_list(DEFAULT_GIMINI_EMBEDDING_MODELS);
+            buckets.embedding = parse_csv_list(DEFAULT_GEMINI_EMBEDDING_MODELS);
         }
         if buckets.tts.is_empty() {
-            buckets.tts = parse_csv_list(DEFAULT_GIMINI_TTS_MODELS);
+            buckets.tts = parse_csv_list(DEFAULT_GEMINI_TTS_MODELS);
         }
         if buckets.music.is_empty() {
-            buckets.music = parse_csv_list(DEFAULT_GIMINI_MUSIC_MODELS);
+            buckets.music = parse_csv_list(DEFAULT_GEMINI_MUSIC_MODELS);
         }
         if buckets.video.is_empty() {
-            buckets.video = parse_csv_list(DEFAULT_GIMINI_VIDEO_MODELS);
+            buckets.video = parse_csv_list(DEFAULT_GEMINI_VIDEO_MODELS);
         }
 
         let revision = Some(buckets.fingerprint());
@@ -496,11 +496,11 @@ impl GoogleGiminiProvider {
             let mut current = self
                 .inventory
                 .write()
-                .map_err(|_| anyhow!("gimini inventory lock poisoned"))?;
+                .map_err(|_| anyhow!("gemini inventory lock poisoned"))?;
             *current = inventory.clone();
         }
         info!(
-            "aicc.gimini.inventory.refreshed provider_instance_name={} llm={} image={} embedding={} tts={} music={} video={}",
+            "aicc.gemini.inventory.refreshed provider_instance_name={} llm={} image={} embedding={} tts={} music={} video={}",
             self.provider_instance_name,
             buckets.llm.len(),
             buckets.image.len(),
@@ -651,7 +651,7 @@ impl GoogleGiminiProvider {
         })
     }
 
-    fn role_to_gimini(role: &str) -> &'static str {
+    fn role_to_gemini(role: &str) -> &'static str {
         match role.trim().to_ascii_lowercase().as_str() {
             "assistant" => "model",
             _ => "user",
@@ -663,7 +663,7 @@ impl GoogleGiminiProvider {
             ResourceRef::Url { url, .. } => Ok(format!("resource_url: {}", url)),
             ResourceRef::NamedObject { obj_id } => Ok(format!("named_object: {}", obj_id)),
             ResourceRef::Base64 { .. } => Err(ProviderError::fatal(
-                "google gimini provider does not support base64 resources in this version",
+                "google gemini provider does not support base64 resources in this version",
             )),
         }
     }
@@ -781,7 +781,7 @@ impl GoogleGiminiProvider {
         if contents.is_empty() {
             for (role, content) in Self::canonical_message_texts(req)? {
                 contents.push(json!({
-                    "role": Self::role_to_gimini(role.as_str()),
+                    "role": Self::role_to_gemini(role.as_str()),
                     "parts": [
                         {
                             "text": content
@@ -834,7 +834,7 @@ impl GoogleGiminiProvider {
     /// Lower a single `AiMessage` to Gemini `Content` shape. Tool results
     /// land in a separate `role: "user"` content with a `functionResponse`
     /// part (Gemini's tool-result convention). System/Developer are folded
-    /// into the `user` role — mirroring the legacy `role_to_gimini` default —
+    /// into the `user` role — mirroring the legacy `role_to_gemini` default —
     /// because this provider doesn't currently surface `systemInstruction`.
     fn lower_message_to_gemini(
         msg: &AiMessage,
@@ -1211,7 +1211,7 @@ impl GoogleGiminiProvider {
         };
 
         for (key, value) in input_map.iter() {
-            if !GIMINI_IMAGE_INPUT_ALLOWLIST.contains(&key.as_str()) {
+            if !GEMINI_IMAGE_INPUT_ALLOWLIST.contains(&key.as_str()) {
                 continue;
             }
             match key.as_str() {
@@ -1279,7 +1279,7 @@ impl GoogleGiminiProvider {
                 ignored.push(key.clone());
                 continue;
             }
-            if !GIMINI_IMAGE_OPTION_ALLOWLIST.contains(&key.as_str()) && key != "prompt" {
+            if !GEMINI_IMAGE_OPTION_ALLOWLIST.contains(&key.as_str()) && key != "prompt" {
                 ignored.push(key.clone());
                 continue;
             }
@@ -1353,7 +1353,7 @@ impl GoogleGiminiProvider {
 
         let mut ignored = vec![];
         for (key, item) in map.iter() {
-            if !GIMINI_VIDEO_PARAMETER_ALLOWLIST.contains(&key.as_str())
+            if !GEMINI_VIDEO_PARAMETER_ALLOWLIST.contains(&key.as_str())
                 && Self::normalize_video_parameter_key(key.as_str()).is_none()
             {
                 ignored.push(key.clone());
@@ -1371,7 +1371,7 @@ impl GoogleGiminiProvider {
     ) -> Result<(Vec<AiArtifact>, Option<String>), ProviderError> {
         let Some(candidates) = body.get("candidates").and_then(|value| value.as_array()) else {
             return Err(ProviderError::fatal(
-                "google gimini image response is missing candidates array",
+                "google gemini image response is missing candidates array",
             ));
         };
 
@@ -1421,7 +1421,7 @@ impl GoogleGiminiProvider {
                             .unwrap_or("image/png");
                         if general_purpose::STANDARD.decode(data_base64).is_err() {
                             warn!(
-                                "aicc.gimini received invalid inlineData base64 in image response"
+                                "aicc.gemini received invalid inlineData base64 in image response"
                             );
                             continue;
                         }
@@ -1450,7 +1450,7 @@ impl GoogleGiminiProvider {
 
         if artifacts.is_empty() {
             return Err(ProviderError::fatal(
-                "google gimini image response has no usable image outputs",
+                "google gemini image response has no usable image outputs",
             ));
         }
 
@@ -1481,9 +1481,9 @@ impl GoogleGiminiProvider {
             .await
             .map_err(|err| {
                 if err.is_timeout() || err.is_connect() {
-                    ProviderError::retryable(format!("google gimini request failed: {}", err))
+                    ProviderError::retryable(format!("google gemini request failed: {}", err))
                 } else {
-                    ProviderError::fatal(format!("google gimini request failed: {}", err))
+                    ProviderError::fatal(format!("google gemini request failed: {}", err))
                 }
             })?;
         let latency_ms = started_at.elapsed().as_millis() as u64;
@@ -1492,12 +1492,12 @@ impl GoogleGiminiProvider {
         let body: Value = response.json().await.map_err(|err| {
             if status.as_u16() == 429 || status.is_server_error() {
                 ProviderError::retryable(format!(
-                    "failed to parse google gimini response body: {}",
+                    "failed to parse google gemini response body: {}",
                     err
                 ))
             } else {
                 ProviderError::fatal(format!(
-                    "failed to parse google gimini response body: {}",
+                    "failed to parse google gemini response body: {}",
                     err
                 ))
             }
@@ -1523,9 +1523,9 @@ impl GoogleGiminiProvider {
             .await
             .map_err(|err| {
                 if err.is_timeout() || err.is_connect() {
-                    ProviderError::retryable(format!("google gimini request failed: {}", err))
+                    ProviderError::retryable(format!("google gemini request failed: {}", err))
                 } else {
-                    ProviderError::fatal(format!("google gimini request failed: {}", err))
+                    ProviderError::fatal(format!("google gemini request failed: {}", err))
                 }
             })?;
         let latency_ms = started_at.elapsed().as_millis() as u64;
@@ -1533,7 +1533,7 @@ impl GoogleGiminiProvider {
         let body: Value = response.json().await.map_err(|err| {
             Self::classify_api_error(
                 status,
-                format!("failed to parse google gimini response body: {}", err),
+                format!("failed to parse google gemini response body: {}", err),
             )
         })?;
         Ok((status, body, latency_ms))
@@ -1566,7 +1566,7 @@ impl GoogleGiminiProvider {
                 }
             })),
             ResourceRef::NamedObject { obj_id } => Err(ProviderError::fatal(format!(
-                "google gimini provider cannot resolve named object resource {} without resolver bytes",
+                "google gemini provider cannot resolve named object resource {} without resolver bytes",
                 obj_id
             ))),
         }
@@ -1674,14 +1674,14 @@ impl GoogleGiminiProvider {
 
         if !ignored_options.is_empty() {
             warn!(
-                "aicc.gimini ignored unsupported llm options: provider_instance_name={} model={} trace_id={:?} ignored={:?}",
+                "aicc.gemini ignored unsupported llm options: provider_instance_name={} model={} trace_id={:?} ignored={:?}",
                 self.instance.provider_instance_name, provider_model, ctx.trace_id, ignored_options
             );
         }
 
         let request_log = redacted_json_log(&Value::Object(request_obj.clone()));
         info!(
-            "aicc.gimini.llm.input provider_instance_name={} model={} trace_id={:?} request={}",
+            "aicc.gemini.llm.input provider_instance_name={} model={} trace_id={:?} request={}",
             self.instance.provider_instance_name, provider_model, ctx.trace_id, request_log
         );
 
@@ -1692,7 +1692,7 @@ impl GoogleGiminiProvider {
 
         if !status.is_success() {
             warn!(
-                "aicc.gimini.llm.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
+                "aicc.gemini.llm.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
                 self.instance.provider_instance_name,
                 provider_model,
                 ctx.trace_id,
@@ -1702,7 +1702,7 @@ impl GoogleGiminiProvider {
             let message = body
                 .pointer("/error/message")
                 .and_then(|value| value.as_str())
-                .unwrap_or("google gimini api returned non-success status")
+                .unwrap_or("google gemini api returned non-success status")
                 .to_string();
             let code = body
                 .pointer("/error/status")
@@ -1710,12 +1710,12 @@ impl GoogleGiminiProvider {
                 .unwrap_or("unknown");
             return Err(Self::classify_api_error(
                 status,
-                format!("google gimini api error [{}]: {}", code, message),
+                format!("google gemini api error [{}]: {}", code, message),
             ));
         }
 
         info!(
-            "aicc.gimini.llm.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
+            "aicc.gemini.llm.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
             self.instance.provider_instance_name,
             provider_model,
             ctx.trace_id,
@@ -1799,7 +1799,7 @@ impl GoogleGiminiProvider {
         }
         if !ignored_options.is_empty() {
             warn!(
-                "aicc.gimini ignored unsupported text2image options: provider_instance_name={} model={} trace_id={:?} ignored={:?}",
+                "aicc.gemini ignored unsupported text2image options: provider_instance_name={} model={} trace_id={:?} ignored={:?}",
                 self.instance.provider_instance_name, provider_model, ctx.trace_id, ignored_options
             );
         }
@@ -1829,7 +1829,7 @@ impl GoogleGiminiProvider {
 
         let request_log = redacted_json_log(&Value::Object(request_obj.clone()));
         info!(
-            "aicc.gimini.text2image.input provider_instance_name={} model={} trace_id={:?} request={}",
+            "aicc.gemini.text2image.input provider_instance_name={} model={} trace_id={:?} request={}",
             self.instance.provider_instance_name, provider_model, ctx.trace_id, request_log
         );
 
@@ -1840,7 +1840,7 @@ impl GoogleGiminiProvider {
 
         if !status.is_success() {
             warn!(
-                "aicc.gimini.text2image.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
+                "aicc.gemini.text2image.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
                 self.instance.provider_instance_name,
                 provider_model,
                 ctx.trace_id,
@@ -1850,7 +1850,7 @@ impl GoogleGiminiProvider {
             let message = body
                 .pointer("/error/message")
                 .and_then(|value| value.as_str())
-                .unwrap_or("google gimini api returned non-success status")
+                .unwrap_or("google gemini api returned non-success status")
                 .to_string();
             let code = body
                 .pointer("/error/status")
@@ -1858,12 +1858,12 @@ impl GoogleGiminiProvider {
                 .unwrap_or("unknown");
             return Err(Self::classify_api_error(
                 status,
-                format!("google gimini api error [{}]: {}", code, message),
+                format!("google gemini api error [{}]: {}", code, message),
             ));
         }
 
         info!(
-            "aicc.gimini.text2image.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
+            "aicc.gemini.text2image.output provider_instance_name={} model={} trace_id={:?} status={} response={}",
             self.instance.provider_instance_name,
             provider_model,
             ctx.trace_id,
@@ -1947,7 +1947,7 @@ impl GoogleGiminiProvider {
             let message = body
                 .pointer("/error/message")
                 .and_then(|value| value.as_str())
-                .unwrap_or("google gimini image edit returned non-success status");
+                .unwrap_or("google gemini image edit returned non-success status");
             return Err(Self::classify_api_error(status, message.to_string()));
         }
         let (artifacts, text) = Self::parse_text2image_result(&body)?;
@@ -2026,7 +2026,7 @@ impl GoogleGiminiProvider {
             let message = body
                 .pointer("/error/message")
                 .and_then(|value| value.as_str())
-                .unwrap_or("google gimini embedding returned non-success status");
+                .unwrap_or("google gemini embedding returned non-success status");
             return Err(Self::classify_api_error(status, message.to_string()));
         }
         let dimensions = body
@@ -2093,7 +2093,7 @@ impl GoogleGiminiProvider {
             let message = body
                 .pointer("/error/message")
                 .and_then(|value| value.as_str())
-                .unwrap_or("google gimini vision returned non-success status");
+                .unwrap_or("google gemini vision returned non-success status");
             return Err(Self::classify_api_error(status, message.to_string()));
         }
         let text = Self::extract_text_content(&body);
@@ -2167,7 +2167,7 @@ impl GoogleGiminiProvider {
             let message = body
                 .pointer("/error/message")
                 .and_then(|value| value.as_str())
-                .unwrap_or("google gimini audio returned non-success status");
+                .unwrap_or("google gemini audio returned non-success status");
             return Err(Self::classify_api_error(status, message.to_string()));
         }
         let artifacts = Self::parse_media_artifacts(&body, "audio/mpeg");
@@ -2233,7 +2233,7 @@ impl GoogleGiminiProvider {
         }
         if !ignored_parameters.is_empty() {
             warn!(
-                "aicc.gimini ignored unsupported video parameters: provider_instance_name={} model={} trace_id={:?} ignored={:?}",
+                "aicc.gemini ignored unsupported video parameters: provider_instance_name={} model={} trace_id={:?} ignored={:?}",
                 self.instance.provider_instance_name, provider_model, ctx.trace_id, ignored_parameters
             );
         }
@@ -2244,7 +2244,7 @@ impl GoogleGiminiProvider {
             let message = body
                 .pointer("/error/message")
                 .and_then(|value| value.as_str())
-                .unwrap_or("google gimini video returned non-success status");
+                .unwrap_or("google gemini video returned non-success status");
             return Err(Self::classify_api_error(status, message.to_string()));
         }
         let mut extra = Map::new();
@@ -2281,7 +2281,7 @@ impl GoogleGiminiProvider {
 }
 
 #[async_trait]
-impl Provider for GoogleGiminiProvider {
+impl Provider for GoogleGeminiProvider {
     fn inventory(&self) -> ProviderInventory {
         self.inventory
             .read()
@@ -2291,7 +2291,7 @@ impl Provider for GoogleGiminiProvider {
                     self.provider_instance_name.as_str(),
                     self.provider_type.clone(),
                     self.provider_driver.as_str(),
-                    &GiminiModelBuckets::default(),
+                    &GeminiModelBuckets::default(),
                     self.features.as_slice(),
                     Some("inventory-lock-poisoned".to_string()),
                 )
@@ -2403,7 +2403,7 @@ impl Provider for GoogleGiminiProvider {
                 .await
             }
             method => Err(ProviderError::fatal(format!(
-                "google gimini provider does not support method '{}'",
+                "google gemini provider does not support method '{}'",
                 method
             ))),
         }
@@ -2437,8 +2437,8 @@ fn json_text_len(value: &Value) -> usize {
 }
 
 #[derive(Debug, Deserialize, Default)]
-struct GiminiSettings {
-    #[serde(default = "default_gimini_enabled")]
+struct GeminiSettings {
+    #[serde(default = "default_gemini_enabled")]
     enabled: bool,
     #[serde(default, alias = "api_key", alias = "apiKey")]
     api_token: String,
@@ -2446,11 +2446,11 @@ struct GiminiSettings {
     #[allow(dead_code)]
     alias_map: HashMap<String, String>,
     #[serde(default)]
-    instances: Vec<SettingsGoogleGiminiInstanceConfig>,
+    instances: Vec<SettingsGoogleGeminiInstanceConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct SettingsGoogleGiminiInstanceConfig {
+struct SettingsGoogleGeminiInstanceConfig {
     #[serde(default = "default_instance_id")]
     provider_instance_name: String,
     #[serde(default = "default_provider_type")]
@@ -2477,7 +2477,7 @@ struct SettingsGoogleGiminiInstanceConfig {
     alias_map: HashMap<String, String>,
 }
 
-fn default_gimini_enabled() -> bool {
+fn default_gemini_enabled() -> bool {
     true
 }
 
@@ -2494,11 +2494,11 @@ fn default_provider_driver() -> String {
 }
 
 fn default_base_url() -> String {
-    DEFAULT_GIMINI_BASE_URL.to_string()
+    DEFAULT_GEMINI_BASE_URL.to_string()
 }
 
 fn default_timeout_ms() -> u64 {
-    DEFAULT_GIMINI_TIMEOUT_MS
+    DEFAULT_GEMINI_TIMEOUT_MS
 }
 
 fn default_features() -> Vec<String> {
@@ -2514,7 +2514,7 @@ fn is_text2image_model_name(model: &str) -> bool {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum GiminiModelKind {
+enum GeminiModelKind {
     Llm,
     Image,
     Embedding,
@@ -2523,7 +2523,7 @@ enum GiminiModelKind {
     Video,
 }
 
-fn strip_gimini_model_prefix(name: &str) -> &str {
+fn strip_gemini_model_prefix(name: &str) -> &str {
     name.strip_prefix("models/")
         .or_else(|| name.strip_prefix("tunedModels/"))
         .unwrap_or(name)
@@ -2623,7 +2623,7 @@ fn strip_numeric_version_suffix(name: &str) -> Option<&str> {
 ///
 /// 这只是描述文字层面的过滤；如果 Google 哪天没在文案里写明就停服，最终还是要
 /// 由运行期 health 反馈再降级一次（属于另外一条独立的链路）。
-fn is_deprecated_gimini_entry(id: &str, display_name: &str, description: &str) -> bool {
+fn is_deprecated_gemini_entry(id: &str, display_name: &str, description: &str) -> bool {
     const SIGNALS: &[&str] = &[
         "deprecat",   // deprecated / deprecation
         "discontinu", // discontinued / discontinuation
@@ -2638,27 +2638,27 @@ fn is_deprecated_gimini_entry(id: &str, display_name: &str, description: &str) -
     SIGNALS.iter().any(|signal| haystack.contains(signal))
 }
 
-fn classify_gimini_model(id: &str, methods: &HashSet<String>) -> Option<GiminiModelKind> {
+fn classify_gemini_model(id: &str, methods: &HashSet<String>) -> Option<GeminiModelKind> {
     let lowered = id.to_ascii_lowercase();
 
     if lowered.contains("embedding") || methods.contains("embedcontent") {
-        return Some(GiminiModelKind::Embedding);
+        return Some(GeminiModelKind::Embedding);
     }
     if lowered.contains("tts") {
-        return Some(GiminiModelKind::Tts);
+        return Some(GeminiModelKind::Tts);
     }
     if lowered.contains("lyria") {
-        return Some(GiminiModelKind::Music);
+        return Some(GeminiModelKind::Music);
     }
     if lowered.contains("veo") {
-        return Some(GiminiModelKind::Video);
+        return Some(GeminiModelKind::Video);
     }
     if is_text2image_model_name(id) {
-        return Some(GiminiModelKind::Image);
+        return Some(GeminiModelKind::Image);
     }
     if lowered.starts_with("gemini") && (methods.contains("generatecontent") || methods.is_empty())
     {
-        return Some(GiminiModelKind::Llm);
+        return Some(GeminiModelKind::Llm);
     }
     None
 }
@@ -2688,12 +2688,10 @@ fn parse_csv_list(value: &str) -> Vec<String> {
         .collect::<Vec<_>>()
 }
 
-fn parse_gimini_settings(settings: &Value) -> Result<Option<GiminiSettings>> {
+fn parse_gemini_settings(settings: &Value) -> Result<Option<GeminiSettings>> {
     let raw = settings
         .get("gemini")
         .or_else(|| settings.get("google_gemini"))
-        .or_else(|| settings.get("gimini"))
-        .or_else(|| settings.get("google_gimini"))
         .or_else(|| settings.get("google"));
     let Some(raw_settings) = raw else {
         return Ok(None);
@@ -2702,34 +2700,18 @@ fn parse_gimini_settings(settings: &Value) -> Result<Option<GiminiSettings>> {
         return Ok(None);
     }
 
-    let gimini_settings = serde_json::from_value::<GiminiSettings>(raw_settings.clone())
-        .map_err(|err| anyhow!("failed to parse gimini settings: {}", err))?;
-    if !gimini_settings.enabled {
+    let gemini_settings = serde_json::from_value::<GeminiSettings>(raw_settings.clone())
+        .map_err(|err| anyhow!("failed to parse gemini settings: {}", err))?;
+    if !gemini_settings.enabled {
         return Ok(None);
     }
 
-    Ok(Some(gimini_settings))
+    Ok(Some(gemini_settings))
 }
 
-fn normalize_legacy_gemini_instance_name(value: String) -> String {
-    if value == "google-gimini-default" {
-        "google-gemini-default".to_string()
-    } else {
-        value
-    }
-}
-
-fn normalize_legacy_gemini_driver(value: String) -> String {
-    if value == "google-gimini" {
-        "google-gemini".to_string()
-    } else {
-        value
-    }
-}
-
-fn build_gimini_instances(settings: &GiminiSettings) -> Result<Vec<GoogleGiminiInstanceConfig>> {
+fn build_gemini_instances(settings: &GeminiSettings) -> Result<Vec<GoogleGeminiInstanceConfig>> {
     let raw_instances = if settings.instances.is_empty() {
-        vec![SettingsGoogleGiminiInstanceConfig {
+        vec![SettingsGoogleGeminiInstanceConfig {
             provider_instance_name: default_instance_id(),
             provider_type: default_provider_type(),
             provider_driver: default_provider_driver(),
@@ -2751,11 +2733,11 @@ fn build_gimini_instances(settings: &GiminiSettings) -> Result<Vec<GoogleGiminiI
     for raw_instance in raw_instances.into_iter() {
         let mut models = normalize_model_list(raw_instance.models);
         if models.is_empty() {
-            models = normalize_model_list(parse_csv_list(DEFAULT_GIMINI_MODELS));
+            models = normalize_model_list(parse_csv_list(DEFAULT_GEMINI_MODELS));
         }
         if models.is_empty() {
             return Err(anyhow!(
-                "gimini instance {} has no models configured",
+                "gemini instance {} has no models configured",
                 raw_instance.provider_instance_name
             ));
         }
@@ -2778,7 +2760,7 @@ fn build_gimini_instances(settings: &GiminiSettings) -> Result<Vec<GoogleGiminiI
                 .collect::<Vec<_>>();
         }
         if image_models.is_empty() {
-            image_models = normalize_model_list(parse_csv_list(DEFAULT_GIMINI_IMAGE_MODELS));
+            image_models = normalize_model_list(parse_csv_list(DEFAULT_GEMINI_IMAGE_MODELS));
         }
         let default_image_model = raw_instance
             .default_image_model
@@ -2789,12 +2771,10 @@ fn build_gimini_instances(settings: &GiminiSettings) -> Result<Vec<GoogleGiminiI
             raw_instance.features
         };
 
-        instances.push(GoogleGiminiInstanceConfig {
-            provider_instance_name: normalize_legacy_gemini_instance_name(
-                raw_instance.provider_instance_name,
-            ),
+        instances.push(GoogleGeminiInstanceConfig {
+            provider_instance_name: raw_instance.provider_instance_name,
             provider_type: raw_instance.provider_type,
-            provider_driver: normalize_legacy_gemini_driver(raw_instance.provider_driver),
+            provider_driver: raw_instance.provider_driver,
             api_token: if raw_instance.api_token.trim().is_empty() {
                 settings.api_token.clone()
             } else {
@@ -2919,24 +2899,24 @@ fn register_custom_aliases(
     }
 }
 
-pub fn register_google_gimini_providers(
+pub fn register_google_gemini_providers(
     center: &AIComputeCenter,
     settings: &Value,
 ) -> Result<usize> {
-    let Some(gimini_settings) = parse_gimini_settings(settings)? else {
-        info!("aicc google gimini provider is disabled (gimini settings missing or disabled)");
+    let Some(gemini_settings) = parse_gemini_settings(settings)? else {
+        info!("aicc google gemini provider is disabled (gemini settings missing or disabled)");
         return Ok(0);
     };
-    let instances = build_gimini_instances(&gimini_settings)?;
-    let mut prepared = Vec::<(GoogleGiminiInstanceConfig, Arc<GoogleGiminiProvider>)>::new();
+    let instances = build_gemini_instances(&gemini_settings)?;
+    let mut prepared = Vec::<(GoogleGeminiInstanceConfig, Arc<GoogleGeminiProvider>)>::new();
     for config in instances.iter() {
         if config.api_token.trim().is_empty() {
             return Err(anyhow!(
-                "gimini instance {} api_token (or api_key) is required",
+                "gemini instance {} api_token (or api_key) is required",
                 config.provider_instance_name
             ));
         }
-        let provider = Arc::new(GoogleGiminiProvider::new(
+        let provider = Arc::new(GoogleGeminiProvider::new(
             config.clone(),
             config.api_token.clone(),
         )?);
@@ -2947,7 +2927,7 @@ pub fn register_google_gimini_providers(
     for (config, provider) in prepared.into_iter() {
         let inventory = center.registry().add_provider(provider);
         info!(
-            "registered google gimini base_url={} inventory={:?}",
+            "registered google gemini base_url={} inventory={:?}",
             config.base_url, inventory
         );
         center
@@ -2955,7 +2935,7 @@ pub fn register_google_gimini_providers(
             .write()
             .map_err(|_| anyhow!("model registry lock poisoned"))?
             .apply_inventory(inventory)
-            .map_err(|err| anyhow!("failed to apply gimini inventory: {}", err))?;
+            .map_err(|err| anyhow!("failed to apply gemini inventory: {}", err))?;
     }
 
     Ok(instances.len())
@@ -3153,36 +3133,36 @@ mod tests {
     }
 
     #[test]
-    fn deprecated_gimini_entries_are_filtered() {
+    fn deprecated_gemini_entries_are_filtered() {
         // 描述里出现 deprecation 信号 → 必须过滤
-        assert!(is_deprecated_gimini_entry(
+        assert!(is_deprecated_gemini_entry(
             "gemini-2.0-flash-001",
             "Gemini 2.0 Flash (Discontinued)",
             "Stable version of Gemini 2.0 Flash."
         ));
-        assert!(is_deprecated_gimini_entry(
+        assert!(is_deprecated_gemini_entry(
             "gemini-1.5-pro-002",
             "Gemini 1.5 Pro",
             "This model is deprecated. Please migrate to gemini-2.5-pro."
         ));
-        assert!(is_deprecated_gimini_entry(
+        assert!(is_deprecated_gemini_entry(
             "gemini-1.0-pro",
             "Gemini 1.0 Pro",
             "Legacy: gemini-1.0-pro is no longer available to new users.",
         ));
-        assert!(is_deprecated_gimini_entry(
+        assert!(is_deprecated_gemini_entry(
             "gemini-2.0-flash-lite",
             "Gemini 2.0 Flash-Lite",
             "Will be retired on 2026-01-01."
         ));
 
         // 健康的当前模型不能误伤
-        assert!(!is_deprecated_gimini_entry(
+        assert!(!is_deprecated_gemini_entry(
             "gemini-2.5-flash",
             "Gemini 2.5 Flash",
             "Fast and versatile multimodal model."
         ));
-        assert!(!is_deprecated_gimini_entry(
+        assert!(!is_deprecated_gemini_entry(
             "gemini-2.5-pro",
             "Gemini 2.5 Pro",
             "Most capable Gemini model for complex reasoning tasks."
@@ -3190,15 +3170,15 @@ mod tests {
     }
 
     #[test]
-    fn build_gimini_instances_infers_image_models() {
-        let settings = GiminiSettings {
+    fn build_gemini_instances_infers_image_models() {
+        let settings = GeminiSettings {
             enabled: true,
             api_token: "token".to_string(),
             alias_map: HashMap::new(),
-            instances: vec![SettingsGoogleGiminiInstanceConfig {
-                provider_instance_name: "gimini-1".to_string(),
+            instances: vec![SettingsGoogleGeminiInstanceConfig {
+                provider_instance_name: "gemini-1".to_string(),
                 provider_type: "cloud_api".to_string(),
-                provider_driver: "google-gimini".to_string(),
+                provider_driver: "google-gemini".to_string(),
                 api_token: String::new(),
                 base_url: default_base_url(),
                 timeout_ms: default_timeout_ms(),
@@ -3214,7 +3194,7 @@ mod tests {
             }],
         };
 
-        let instances = build_gimini_instances(&settings).expect("instances should be built");
+        let instances = build_gemini_instances(&settings).expect("instances should be built");
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].provider_driver, "google-gemini");
         assert_eq!(
@@ -3228,22 +3208,22 @@ mod tests {
     }
 
     #[test]
-    fn build_gimini_instances_uses_gemini_default_names() {
-        let settings = GiminiSettings {
+    fn build_gemini_instances_uses_gemini_default_names() {
+        let settings = GeminiSettings {
             enabled: true,
             api_token: "token".to_string(),
             alias_map: HashMap::new(),
             instances: vec![],
         };
 
-        let instances = build_gimini_instances(&settings).expect("instances should be built");
+        let instances = build_gemini_instances(&settings).expect("instances should be built");
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].provider_instance_name, "google-gemini-default");
         assert_eq!(instances[0].provider_driver, "google-gemini");
     }
 
     #[test]
-    fn register_gimini_inventory_exposes_stable_gemini_mounts() {
+    fn register_gemini_inventory_exposes_stable_gemini_mounts() {
         let center = AIComputeCenter::default();
         let settings = json!({
             "gemini": {
@@ -3251,9 +3231,9 @@ mod tests {
                 "api_token": "token",
                 "instances": [
                     {
-                        "provider_instance_name": "google-gimini-default",
+                        "provider_instance_name": "google-gemini-default",
                         "provider_type": "cloud_api",
-                        "provider_driver": "google-gimini",
+                        "provider_driver": "google-gemini",
                         "base_url": "https://generativelanguage.googleapis.com/v1beta",
                         "models": ["gemini-2.5-flash", "gemini-2.5-pro"],
                         "image_models": ["gemini-2.5-flash-image-preview"]
@@ -3263,7 +3243,7 @@ mod tests {
         });
 
         let count =
-            register_google_gimini_providers(&center, &settings).expect("register should work");
+            register_google_gemini_providers(&center, &settings).expect("register should work");
         assert_eq!(count, 1);
 
         let registry = center.model_registry().read().expect("model registry lock");
@@ -3275,8 +3255,6 @@ mod tests {
         assert!(pro_items
             .values()
             .any(|item| item.target == "gemini-2.5-pro@google-gemini-default"));
-        let legacy_items = registry.default_items_for_path("llm.gimini");
-        assert!(legacy_items.is_empty());
         let image_items = registry.default_items_for_path("image.txt2img.gemini");
         assert!(image_items
             .values()
@@ -3354,7 +3332,7 @@ mod tests {
     fn estimate_text2image_cost_covers_current_image_models() {
         let preview = build_text2image_request(Some(json!({ "n": 2 })));
         assert_eq!(
-            GoogleGiminiProvider::estimate_text2image_cost(
+            GoogleGeminiProvider::estimate_text2image_cost(
                 &preview,
                 "gemini-2.5-flash-image-preview"
             ),
@@ -3363,7 +3341,7 @@ mod tests {
 
         let legacy = build_text2image_request(None);
         assert_eq!(
-            GoogleGiminiProvider::estimate_text2image_cost(
+            GoogleGeminiProvider::estimate_text2image_cost(
                 &legacy,
                 "gemini-2.0-flash-exp-image-generation"
             ),
@@ -3391,7 +3369,7 @@ mod tests {
         });
 
         let (artifacts, text) =
-            GoogleGiminiProvider::parse_text2image_result(&body).expect("artifacts should parse");
+            GoogleGeminiProvider::parse_text2image_result(&body).expect("artifacts should parse");
         assert_eq!(artifacts.len(), 1);
         assert!(text.is_none());
         match &artifacts[0].resource {

--- a/src/frame/aicc/src/lib.rs
+++ b/src/frame/aicc/src/lib.rs
@@ -5,7 +5,7 @@ pub mod claude_protocol;
 pub mod complete_request_queue;
 pub mod default_logical_tree;
 pub mod fal;
-pub mod gimini;
+pub mod gemini;
 pub mod metadata_resolver;
 pub mod minimax;
 pub mod model_registry;

--- a/src/frame/aicc/src/main.rs
+++ b/src/frame/aicc/src/main.rs
@@ -5,7 +5,7 @@ mod claude_protocol;
 mod complete_request_queue;
 mod default_logical_tree;
 mod fal;
-mod gimini;
+mod gemini;
 mod metadata_resolver;
 mod minimax;
 mod model_registry;
@@ -46,7 +46,7 @@ use crate::aicc::{AIComputeCenter, NamedStoreResourceResolver};
 use crate::aicc_usage_log_db::AiccUsageLogDb;
 use crate::claude::register_claude_providers;
 use crate::fal::register_fal_providers;
-use crate::gimini::register_google_gimini_providers;
+use crate::gemini::register_google_gemini_providers;
 use crate::minimax::register_minimax_providers;
 use crate::openai::register_openai_llm_providers;
 use crate::sn_ai_provider::register_sn_ai_provider;
@@ -71,9 +71,7 @@ const PROVIDER_SECTIONS: &[&str] = &[
     "openai",
     "google",
     "gemini",
-    "gimini",
     "google_gemini",
-    "google_gimini",
     "claude",
     "anthropic",
     "minimax",
@@ -124,12 +122,12 @@ fn apply_provider_settings(
         }
     }
 
-    match register_google_gimini_providers(center, settings) {
+    match register_google_gemini_providers(center, settings) {
         Ok(count) => {
             registered_total = registered_total.saturating_add(count);
         }
         Err(err) => {
-            errors.push(format!("gimini: {}", err));
+            errors.push(format!("gemini: {}", err));
         }
     }
 

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -383,9 +383,7 @@ fn load_builtin_driver_metadata(provider_driver: &str) -> Option<DriverMetadataD
     let raw = match normalized.as_str() {
         "openai" | "sn-ai-provider" => include_str!("../driver_metadata/openai.json"),
         "claude" | "anthropic" => include_str!("../driver_metadata/claude.json"),
-        "google-gemini" | "google-gimini" | "gemini" | "gimini" => {
-            include_str!("../driver_metadata/gemini.json")
-        }
+        "google-gemini" | "gemini" => include_str!("../driver_metadata/gemini.json"),
         "fal" => include_str!("../driver_metadata/fal.json"),
         "minimax" => include_str!("../driver_metadata/minimax.json"),
         _ => return None,

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use aicc::claude::{ClaudeInstanceConfig, ClaudeProvider};
-use aicc::gimini::{GoogleGiminiInstanceConfig, GoogleGiminiProvider};
+use aicc::gemini::{GoogleGeminiInstanceConfig, GoogleGeminiProvider};
 use aicc::openai::{OpenAIInstanceConfig, OpenAIProvider};
 use aicc::{InvokeCtx, Provider, ProviderStartResult, ResolvedRequest};
 use buckyos_api::Capability;
@@ -24,10 +24,10 @@ fn openai_provider(base_url: String, timeout_ms: u64) -> OpenAIProvider {
     .expect("openai provider")
 }
 
-fn gimini_provider(base_url: String, timeout_ms: u64) -> GoogleGiminiProvider {
-    GoogleGiminiProvider::new(
-        GoogleGiminiInstanceConfig {
-            provider_instance_name: "gimini-test".to_string(),
+fn gemini_provider(base_url: String, timeout_ms: u64) -> GoogleGeminiProvider {
+    GoogleGeminiProvider::new(
+        GoogleGeminiInstanceConfig {
+            provider_instance_name: "gemini-test".to_string(),
             provider_type: "cloud_api".to_string(),
             provider_driver: "google-gemini".to_string(),
             api_token: "token".to_string(),
@@ -42,7 +42,7 @@ fn gimini_provider(base_url: String, timeout_ms: u64) -> GoogleGiminiProvider {
         },
         "token".to_string(),
     )
-    .expect("gimini provider")
+    .expect("gemini provider")
 }
 
 fn claude_provider(base_url: String, timeout_ms: u64) -> ClaudeProvider {
@@ -227,11 +227,11 @@ async fn adapter_openai_06_timeout_or_network_error_classified() {
 
 #[tokio::test]
 // 鐢ㄤ緥璇存槑锛?
-// - 楠岃瘉鍦烘櫙锛歚adapter_gimini_01_http_200_success` 鐢ㄤ緥锛岃鐩栧嚱鏁板悕瀵瑰簲鐨勪笟鍔¤矾寰勩€?
+// - 楠岃瘉鍦烘櫙锛歚adapter_gemini_01_http_200_success` 鐢ㄤ緥锛岃鐩栧嚱鏁板悕瀵瑰簲鐨勪笟鍔¤矾寰勩€?
 // - 杈撳叆鍙傛暟锛氶€氳繃 mock HTTP 鏈嶅姟鏋勯€犵姸鎬佺爜/鍝嶅簲浣?瓒呮椂銆?
 // - 澶勭悊娴佺▼锛氳皟鐢ㄥ叿浣?provider adapter锛岃姹?mock 鏈嶅姟骞舵墽琛屽搷搴旇В鏋愪笌閿欒鍒嗙被銆?
 // - 棰勬湡杈撳嚭锛氳繑鍥炴垚鍔熺粨鏋滐紝鍏抽敭瀛楁涓庢柇瑷€涓€鑷淬€?
-async fn adapter_gimini_01_http_200_success() {
+async fn adapter_gemini_01_http_200_success() {
     let base_url = spawn_fake_http_server(vec![MockHttpReply {
         status_code: 200,
         body: r#"{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}"#.to_string(),
@@ -239,7 +239,7 @@ async fn adapter_gimini_01_http_200_success() {
         delay_ms: 0,
     }])
     .await;
-    let provider = gimini_provider(base_url, 500);
+    let provider = gemini_provider(base_url, 500);
     let result = provider
         .start(
             InvokeCtx::default(),
@@ -248,7 +248,7 @@ async fn adapter_gimini_01_http_200_success() {
             Arc::new(NoopSink),
         )
         .await
-        .expect("gimini 200 should succeed");
+        .expect("gemini 200 should succeed");
     match result {
         ProviderStartResult::Immediate(summary) => {
             assert_eq!(summary.text_content(), "ok");
@@ -260,11 +260,11 @@ async fn adapter_gimini_01_http_200_success() {
 
 #[tokio::test]
 // 鐢ㄤ緥璇存槑锛?
-// - 楠岃瘉鍦烘櫙锛歚adapter_gimini_02_http_429_retryable` 鐢ㄤ緥锛岃鐩栧彲閲嶈瘯閿欒鍒嗘敮銆侀檺娴侀敊璇垎绫汇€?
+// - 楠岃瘉鍦烘櫙锛歚adapter_gemini_02_http_429_retryable` 鐢ㄤ緥锛岃鐩栧彲閲嶈瘯閿欒鍒嗘敮銆侀檺娴侀敊璇垎绫汇€?
 // - 杈撳叆鍙傛暟锛氭瀯閫犲涓?provider 鍊欓€夛紝骞舵敞鍏?Started/Queued/澶辫触缁撴灉锛涢€氳繃 mock HTTP 鏈嶅姟鏋勯€犵姸鎬佺爜/鍝嶅簲浣?瓒呮椂銆?
 // - 澶勭悊娴佺▼锛氳皟鐢ㄥ叿浣?provider adapter锛岃姹?mock 鏈嶅姟骞舵墽琛屽搷搴旇В鏋愪笌閿欒鍒嗙被銆?
 // - 棰勬湡杈撳嚭锛氶敊璇褰掔被涓哄彲閲嶈瘯骞惰Е鍙戝搴旂瓥鐣ャ€?
-async fn adapter_gimini_02_http_429_retryable() {
+async fn adapter_gemini_02_http_429_retryable() {
     let base_url = spawn_fake_http_server(vec![MockHttpReply {
         status_code: 429,
         body: r#"{"error":{"status":"RESOURCE_EXHAUSTED","message":"too many requests"}}"#
@@ -273,7 +273,7 @@ async fn adapter_gimini_02_http_429_retryable() {
         delay_ms: 0,
     }])
     .await;
-    let provider = gimini_provider(base_url, 500);
+    let provider = gemini_provider(base_url, 500);
     let err = provider
         .start(
             InvokeCtx::default(),
@@ -283,7 +283,7 @@ async fn adapter_gimini_02_http_429_retryable() {
         )
         .await
         .expect_err("must fail");
-    assert!(err.is_retryable(), "assert failed in adapter_gimini_02_http_429_retryable: condition is false; check preconditions and expected branch outcome.");
+    assert!(err.is_retryable(), "assert failed in adapter_gemini_02_http_429_retryable: condition is false; check preconditions and expected branch outcome.");
 }
 
 #[tokio::test]
@@ -399,11 +399,11 @@ async fn adapter_claude_04_timeout_or_network_error_classified() {
 
 #[tokio::test]
 // 鐢ㄤ緥璇存槑锛?
-// - 楠岃瘉鍦烘櫙锛歚adapter_gimini_03_http_503_retryable` 鐢ㄤ緥锛岃鐩栧彲閲嶈瘯閿欒鍒嗘敮銆佹湇鍔′笉鍙敤閿欒鍒嗙被銆?
+// - 楠岃瘉鍦烘櫙锛歚adapter_gemini_03_http_503_retryable` 鐢ㄤ緥锛岃鐩栧彲閲嶈瘯閿欒鍒嗘敮銆佹湇鍔′笉鍙敤閿欒鍒嗙被銆?
 // - 杈撳叆鍙傛暟锛氭瀯閫犲涓?provider 鍊欓€夛紝骞舵敞鍏?Started/Queued/澶辫触缁撴灉锛涢€氳繃 mock HTTP 鏈嶅姟鏋勯€犵姸鎬佺爜/鍝嶅簲浣?瓒呮椂銆?
 // - 澶勭悊娴佺▼锛氳皟鐢ㄥ叿浣?provider adapter锛岃姹?mock 鏈嶅姟骞舵墽琛屽搷搴旇В鏋愪笌閿欒鍒嗙被銆?
 // - 棰勬湡杈撳嚭锛氶敊璇褰掔被涓哄彲閲嶈瘯骞惰Е鍙戝搴旂瓥鐣ャ€?
-async fn adapter_gimini_03_http_503_retryable() {
+async fn adapter_gemini_03_http_503_retryable() {
     let base_url = spawn_fake_http_server(vec![MockHttpReply {
         status_code: 503,
         body: r#"{"error":{"status":"UNAVAILABLE","message":"service unavailable"}}"#.to_string(),
@@ -411,7 +411,7 @@ async fn adapter_gimini_03_http_503_retryable() {
         delay_ms: 0,
     }])
     .await;
-    let provider = gimini_provider(base_url, 500);
+    let provider = gemini_provider(base_url, 500);
     let err = provider
         .start(
             InvokeCtx::default(),
@@ -421,16 +421,16 @@ async fn adapter_gimini_03_http_503_retryable() {
         )
         .await
         .expect_err("must fail");
-    assert!(err.is_retryable(), "assert failed in adapter_gimini_03_http_503_retryable: condition is false; check preconditions and expected branch outcome.");
+    assert!(err.is_retryable(), "assert failed in adapter_gemini_03_http_503_retryable: condition is false; check preconditions and expected branch outcome.");
 }
 
 #[tokio::test]
 // 鐢ㄤ緥璇存槑锛?
-// - 楠岃瘉鍦烘櫙锛歚adapter_gimini_04_http_400_fatal` 鐢ㄤ緥锛岃鐩栬嚧鍛介敊璇垎鏀€佸弬鏁伴敊璇垎绫汇€?
+// - 楠岃瘉鍦烘櫙锛歚adapter_gemini_04_http_400_fatal` 鐢ㄤ緥锛岃鐩栬嚧鍛介敊璇垎鏀€佸弬鏁伴敊璇垎绫汇€?
 // - 杈撳叆鍙傛暟锛氭瀯閫犲涓?provider 鍊欓€夛紝骞舵敞鍏?Started/Queued/澶辫触缁撴灉锛涢€氳繃 mock HTTP 鏈嶅姟鏋勯€犵姸鎬佺爜/鍝嶅簲浣?瓒呮椂銆?
 // - 澶勭悊娴佺▼锛氳皟鐢ㄥ叿浣?provider adapter锛岃姹?mock 鏈嶅姟骞舵墽琛屽搷搴旇В鏋愪笌閿欒鍒嗙被銆?
 // - 棰勬湡杈撳嚭锛氳繑鍥炴嫆缁濇垨鑷村懡閿欒锛岄敊璇爜/閿欒娑堟伅绗﹀悎棰勬湡銆?
-async fn adapter_gimini_04_http_400_fatal() {
+async fn adapter_gemini_04_http_400_fatal() {
     let base_url = spawn_fake_http_server(vec![MockHttpReply {
         status_code: 400,
         body: r#"{"error":{"status":"INVALID_ARGUMENT","message":"bad request"}}"#.to_string(),
@@ -438,7 +438,7 @@ async fn adapter_gimini_04_http_400_fatal() {
         delay_ms: 0,
     }])
     .await;
-    let provider = gimini_provider(base_url, 500);
+    let provider = gemini_provider(base_url, 500);
     let err = provider
         .start(
             InvokeCtx::default(),
@@ -448,16 +448,16 @@ async fn adapter_gimini_04_http_400_fatal() {
         )
         .await
         .expect_err("must fail");
-    assert!(!err.is_retryable(), "assert failed in adapter_gimini_04_http_400_fatal: condition is false; check preconditions and expected branch outcome.");
+    assert!(!err.is_retryable(), "assert failed in adapter_gemini_04_http_400_fatal: condition is false; check preconditions and expected branch outcome.");
 }
 
 #[tokio::test]
 // 鐢ㄤ緥璇存槑锛?
-// - 楠岃瘉鍦烘櫙锛歚adapter_gimini_05_invalid_json_fatal` 鐢ㄤ緥锛岃鐩栬嚧鍛介敊璇垎鏀€侀潪娉?JSON 鍝嶅簲鍒嗙被銆?
+// - 楠岃瘉鍦烘櫙锛歚adapter_gemini_05_invalid_json_fatal` 鐢ㄤ緥锛岃鐩栬嚧鍛介敊璇垎鏀€侀潪娉?JSON 鍝嶅簲鍒嗙被銆?
 // - 杈撳叆鍙傛暟锛氭瀯閫犲涓?provider 鍊欓€夛紝骞舵敞鍏?Started/Queued/澶辫触缁撴灉锛涢€氳繃 mock HTTP 鏈嶅姟鏋勯€犵姸鎬佺爜/鍝嶅簲浣?瓒呮椂銆?
 // - 澶勭悊娴佺▼锛氳皟鐢ㄥ叿浣?provider adapter锛岃姹?mock 鏈嶅姟骞舵墽琛屽搷搴旇В鏋愪笌閿欒鍒嗙被銆?
 // - 棰勬湡杈撳嚭锛氳繑鍥炴垚鍔熺粨鏋滐紝鍏抽敭瀛楁涓庢柇瑷€涓€鑷达紱杩斿洖鎷掔粷鎴栬嚧鍛介敊璇紝閿欒鐮?閿欒娑堟伅绗﹀悎棰勬湡銆?
-async fn adapter_gimini_05_invalid_json_fatal() {
+async fn adapter_gemini_05_invalid_json_fatal() {
     let base_url = spawn_fake_http_server(vec![MockHttpReply {
         status_code: 200,
         body: "not-json".to_string(),
@@ -465,7 +465,7 @@ async fn adapter_gimini_05_invalid_json_fatal() {
         delay_ms: 0,
     }])
     .await;
-    let provider = gimini_provider(base_url, 500);
+    let provider = gemini_provider(base_url, 500);
     let err = provider
         .start(
             InvokeCtx::default(),
@@ -475,17 +475,17 @@ async fn adapter_gimini_05_invalid_json_fatal() {
         )
         .await
         .expect_err("must fail");
-    assert!(!err.is_retryable(), "assert failed in adapter_gimini_05_invalid_json_fatal: condition is false; check preconditions and expected branch outcome.");
+    assert!(!err.is_retryable(), "assert failed in adapter_gemini_05_invalid_json_fatal: condition is false; check preconditions and expected branch outcome.");
 }
 
 #[tokio::test]
 // 鐢ㄤ緥璇存槑锛?
-// - 楠岃瘉鍦烘櫙锛歚adapter_gimini_06_timeout_or_network_error_classified` 鐢ㄤ緥锛岃鐩栬秴鏃?缃戠粶寮傚父鍒嗙被銆?
+// - 楠岃瘉鍦烘櫙锛歚adapter_gemini_06_timeout_or_network_error_classified` 鐢ㄤ緥锛岃鐩栬秴鏃?缃戠粶寮傚父鍒嗙被銆?
 // - 杈撳叆鍙傛暟锛氶€氳繃 mock HTTP 鏈嶅姟鏋勯€犵姸鎬佺爜/鍝嶅簲浣?瓒呮椂銆?
 // - 澶勭悊娴佺▼锛氳皟鐢ㄥ叿浣?provider adapter锛岃姹?mock 鏈嶅姟骞舵墽琛屽搷搴旇В鏋愪笌閿欒鍒嗙被銆?
 // - 棰勬湡杈撳嚭锛氭柇瑷€涓殑鐘舵€併€侀敊璇爜銆佽矾鐢遍€夋嫨鎴栦簨浠跺瓧娈靛叏閮ㄦ弧瓒抽鏈熴€?
-async fn adapter_gimini_06_timeout_or_network_error_classified() {
-    let provider = gimini_provider("http://127.0.0.1:9".to_string(), 80);
+async fn adapter_gemini_06_timeout_or_network_error_classified() {
+    let provider = gemini_provider("http://127.0.0.1:9".to_string(), 80);
     let err = provider
         .start(
             InvokeCtx::default(),
@@ -495,7 +495,7 @@ async fn adapter_gimini_06_timeout_or_network_error_classified() {
         )
         .await
         .expect_err("must fail");
-    assert!(err.is_retryable(), "assert failed in adapter_gimini_06_timeout_or_network_error_classified: condition is false; check preconditions and expected branch outcome.");
+    assert!(err.is_retryable(), "assert failed in adapter_gemini_06_timeout_or_network_error_classified: condition is false; check preconditions and expected branch outcome.");
 }
 
 #[tokio::test]

--- a/src/frame/control_panel/src/aicc_settings.rs
+++ b/src/frame/control_panel/src/aicc_settings.rs
@@ -285,7 +285,6 @@ impl ControlPanelServer {
         const AICC_PROVIDER_SECTIONS: &[&str] = &[
             "openai",
             "google",
-            "gimini",
             "gemini",
             "claude",
             "anthropic",
@@ -458,7 +457,6 @@ impl ControlPanelServer {
     fn ai_google_provider_card(settings: &Value) -> Value {
         let google = settings
             .get("google")
-            .or_else(|| settings.get("gimini"))
             .or_else(|| settings.get("gemini"))
             .cloned()
             .unwrap_or_else(|| json!({}));
@@ -689,7 +687,6 @@ impl ControlPanelServer {
         let openai = settings.get("openai").cloned().unwrap_or_else(|| json!({}));
         let google = settings
             .get("google")
-            .or_else(|| settings.get("gimini"))
             .or_else(|| settings.get("gemini"))
             .cloned()
             .unwrap_or_else(|| json!({}));
@@ -844,9 +841,7 @@ impl ControlPanelServer {
             "openai",
             "google",
             "gemini",
-            "gimini",
             "google_gemini",
-            "google_gimini",
             "claude",
             "anthropic",
             "minimax",

--- a/src/frame/desktop/src/api/aicc_mgr.ts
+++ b/src/frame/desktop/src/api/aicc_mgr.ts
@@ -1547,7 +1547,7 @@ function inferProviderType(driver: string, instanceName: string): ProviderType {
   if (value.includes('sn')) return 'sn_router'
   if (value.includes('openai')) return 'openai'
   if (value.includes('anthropic') || value.includes('claude')) return 'anthropic'
-  if (value.includes('google') || value.includes('gimini') || value.includes('gemini')) return 'google'
+  if (value.includes('google') || value.includes('gemini')) return 'google'
   if (value.includes('openrouter')) return 'openrouter'
   return 'custom'
 }

--- a/src/kernel/buckyos-api/src/rbac_config.rs
+++ b/src/kernel/buckyos-api/src/rbac_config.rs
@@ -116,6 +116,7 @@ p, admin,obj://config/users/{admin}/*,read,allow
 p, admin,obj://config/users/{admin}/profile,read|write,allow
 p, admin,obj://config/users/{admin}/apps/{app}/{key},read|write,allow
 p, admin,obj://config/users/{admin}/agents/{agent}/{key},read|write,allow
+p, admin,obj://config/services/aicc/settings,read|write,allow
 p, admin,obj://config/services/*,read,allow
 
 p, users,obj://config/boot/*, read,allow
@@ -460,6 +461,51 @@ g, su_alice, su_admin
                 "bob",
                 "buckycli",
                 "obj://config/users/alice/profile",
+                "write",
+                None,
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_can_write_aicc_settings() {
+        let _guard = TEST_LOCK.lock().await;
+
+        let policy_tail = r#"
+g, alice, admin
+g, bob, users
+"#;
+        let config = build_current_rbac_config(Some(policy_tail));
+        rbac::create_enforcer(&config.model, &config.policy)
+            .await
+            .unwrap();
+
+        assert!(
+            rbac::enforce(
+                "alice",
+                "control-panel",
+                "obj://config/services/aicc/settings",
+                "write",
+                None,
+            )
+            .await
+        );
+        assert!(
+            !rbac::enforce(
+                "bob",
+                "control-panel",
+                "obj://config/services/aicc/settings",
+                "write",
+                None,
+            )
+            .await
+        );
+        assert!(
+            !rbac::enforce(
+                "alice",
+                "control-panel",
+                "obj://config/services/msg-center/settings",
                 "write",
                 None,
             )

--- a/src/kernel/scheduler/src/system_config_builder.rs
+++ b/src/kernel/scheduler/src/system_config_builder.rs
@@ -829,8 +829,8 @@ fn build_aicc_settings_with_sn_models(
                 },
                 "instances": [
                     {
-                        "instance_id": "google-gimini-default",
-                        "provider_type": "google-gimini",
+                        "instance_id": "google-gemini-default",
+                        "provider_type": "google-gemini",
                         "base_url": "https://generativelanguage.googleapis.com/v1beta",
                         "timeout_ms": DEFAULT_PROVIDER_TIMEOUT_MS,
                         "models": ["gemini-2.5-flash", "gemini-2.5-pro"],
@@ -1368,7 +1368,7 @@ mod tests {
         );
         assert_eq!(
             settings["google"]["instances"][0]["provider_type"],
-            "google-gimini"
+            "google-gemini"
         );
         assert_eq!(settings["google"]["instances"][0]["timeout_ms"], 600000);
         assert_eq!(settings["claude"]["api_token"], "claude-token");


### PR DESCRIPTION
## 更新内容

汇总提交范围：`b0a88930` 到 `07705728`。

- `b0a88930`：统一修正 AICC 中 Gemini provider 的拼写，从历史误拼 `gimini` 收敛为 `gemini`。
  - Rust 模块从 `gimini.rs` 重命名为 `gemini.rs`，并同步更新注册函数、provider 类型推断、logical mount 判断和测试命名。
  - scheduler 默认 AICC settings 中的 Google Gemini provider id/type 改为 `google-gemini`。
  - control-panel / desktop / AICC 文档里的 provider section 和说明同步改为 `gemini` / `google_gemini`，移除旧误拼入口。
- `07705728`：修复 AICC settings 的管理员写权限。
  - 在默认 RBAC policy 中为 `admin` 增加 `obj://config/services/aicc/settings` 的 `read|write` 权限。
  - 新增单测覆盖 admin 可写、普通 users 不可写、admin 不会因此获得其它 service settings 写权限。

## 重点 Review

请重点 review `07705728`：它调整了默认 RBAC 权限边界，允许 admin 写入 `obj://config/services/aicc/settings`。需要确认：

- 该路径是否就是 control-panel 更新 AICC provider settings 的唯一/正确 system-config 路径。
- admin 写权限是否应仅限 AICC settings，而不是扩展到 `obj://config/services/*/settings`。
- 新增 policy 与现有 scheduler、control-panel 写入流程是否一致。

## 验证

- 已运行：`cargo test -p buckyos-api admin_can_write_aicc_settings`
