### PR TITLE
fix(build): build agent_tool from CLI package

### DIFF
--- a/src/bucky_project.yaml
+++ b/src/bucky_project.yaml
@@ -51,7 +51,7 @@ modules:
     name: opendan
   agent_tool:
     type: rust
-    name: agent_tool
+    name: agent_tool_cli_dev
   # control_panel_web:
   #   type: web
   #   name: control_panel


### PR DESCRIPTION
Fixes the BuckyOS package build for `agent_tool`.

`agent_tool` is the installed binary name, but the Cargo package that produces it is `agent_tool_cli_dev`. This updates `bucky_project.yaml` so the devkit builds the correct package while still copying the expected `agent_tool` binary.

It needs buckyos-devkit 1.0.23 or above