### PR TITLE
fix(build): use correct task_manager Cargo package name

### DIFF
--- a/src/bucky_project.yaml
+++ b/src/bucky_project.yaml
@@ -20,7 +20,7 @@ modules:
     name: workflow
   task_manager:
     type: rust
-    name: task-manager
+    name: task_manager
   kmsg:
     type: rust
     name: kmsg


### PR DESCRIPTION
Fixes the BuckyOS package build after devkit started using `modules.<key>.name` as the Cargo package name.

`task_manager` was configured with `name: task-manager`, but the actual Cargo package is `task_manager`. This updates the project config so devkit builds the correct package while keeping the installed module path unchanged.