### PR TITLE
增加 AICC 路由追踪持久化与用量关联

### DIFF
--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -14,7 +14,7 @@ use crate::model_types::{
     LatencyClass, LogicalModelDefinition, ModelAttributes, ModelCandidate, ModelCapabilities,
     ModelHealth, ModelMetadata, ModelPricing, PolicyConfig, PricingMode, PrivacyClass,
     ProviderInventory, ProviderOrigin, ProviderType, ProviderTypeTrustedSource, QuotaState,
-    RequiredModelFeatures, RouteError, RouteErrorCode, RoutePolicy, RouteTrace,
+    RequestedModelType, RequiredModelFeatures, RouteError, RouteErrorCode, RoutePolicy, RouteTrace,
     UserFacingProviderOrigin, UserFacingRouteSummary,
 };
 use ::kRPC::*;
@@ -24,11 +24,11 @@ use base64::Engine as _;
 use buckyos_api::{
     ai_methods, get_buckyos_api_runtime, AiContent, AiMethodRequest, AiMethodResponse,
     AiMethodStatus, AiPayload, AiResponse, AiccComputeProgress, AiccComputeTaskData,
-    AiccComputeTaskRequest, AiccHandler, AiccRouteOverlay, AiccUsageEvent, CancelResponse,
-    Capability, CreateTaskOptions, Feature, LlmChatInvokeRequest, LlmChatInvokeResponse, ModelSpec,
-    Requirements, ResourceRef, RouteFallbackAttempt, RouteResolveRequest, RouteResolveResponse,
-    TaskManagerClient, TaskStatus, TextToImageInvokeRequest, TextToImageInvokeResponse,
-    TypedTaskData, AICC_SERVICE_SERVICE_NAME,
+    AiccComputeTaskRequest, AiccHandler, AiccRouteOverlay, AiccRouteTraceEvent, AiccUsageEvent,
+    CancelResponse, Capability, CreateTaskOptions, Feature, LlmChatInvokeRequest,
+    LlmChatInvokeResponse, ModelSpec, Requirements, ResourceRef, RouteFallbackAttempt,
+    RouteResolveRequest, RouteResolveResponse, TaskManagerClient, TaskStatus,
+    TextToImageInvokeRequest, TextToImageInvokeResponse, TypedTaskData, AICC_SERVICE_SERVICE_NAME,
 };
 use log::{debug, error, info, warn};
 use ndn_lib::{
@@ -2965,6 +2965,68 @@ impl AIComputeCenter {
         self.usage_log_db.clone()
     }
 
+    fn record_route_trace(
+        &self,
+        decision: &RouteDecision,
+        tenant_id: &str,
+        caller_app_id: Option<String>,
+    ) {
+        let Some(db) = self.usage_log_db.clone() else {
+            return;
+        };
+        let Ok(trace) = decision.route_trace.lock() else {
+            return;
+        };
+        if trace.requested_model_type != RequestedModelType::Logical {
+            return;
+        }
+        let Ok(trace) = serde_json::to_value(&*trace) else {
+            return;
+        };
+        let trace_id = trace
+            .get("request_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if trace_id.is_empty() {
+            return;
+        }
+        let event = AiccRouteTraceEvent {
+            trace_id: trace_id.clone(),
+            tenant_id: tenant_id.to_string(),
+            caller_app_id,
+            task_id: trace_id,
+            request_model: trace
+                .get("requested_model")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            selected_exact_model: trace
+                .get("selected_exact_model")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            provider_instance_name: trace
+                .get("selected_provider_instance_name")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            api_type: trace
+                .get("api_type")
+                .and_then(Value::as_str)
+                .unwrap_or("llm")
+                .to_string(),
+            route_trace_json: trace,
+            created_at_ms: now_ms_i64(),
+        };
+        tokio::spawn(async move {
+            if let Err(err) = db.insert_route_trace_event(&event).await {
+                warn!(
+                    "aicc.route_trace_log write_failed: trace_id={} tenant={} err={}",
+                    event.trace_id, event.tenant_id, err
+                );
+            }
+        });
+    }
+
     pub fn registry(&self) -> &Registry {
         &self.registry
     }
@@ -3718,7 +3780,13 @@ impl AIComputeCenter {
             &route_cfg,
             request_id.as_str(),
         )?;
-        self.route_decision_response(&decision)
+        let response = self.route_decision_response(&decision)?;
+        self.record_route_trace(
+            &decision,
+            invoke_ctx.tenant_id.as_str(),
+            invoke_ctx.caller_app_id.clone(),
+        );
+        Ok(response)
     }
 
     pub async fn create_chat_completion(
@@ -4025,6 +4093,11 @@ impl AIComputeCenter {
                 event_sink.clone(),
             )
             .await;
+        self.record_route_trace(
+            &decision,
+            invoke_ctx.tenant_id.as_str(),
+            invoke_ctx.caller_app_id.clone(),
+        );
         match start_result {
             Ok((ProviderStartResult::Immediate(mut summary), instance_id)) => {
                 let prepared_task = self

--- a/src/frame/aicc/src/aicc_usage_log_db.rs
+++ b/src/frame/aicc/src/aicc_usage_log_db.rs
@@ -419,15 +419,27 @@ WHERE created_at_ms >= ? AND created_at_ms < ?
     ) -> Result<QueryRouteTraceResponse, RPCErrors> {
         let limit = req.limit.unwrap_or(20).clamp(1, 128) as usize;
         let offset = parse_cursor(req.cursor.as_deref())?;
-        let sql = self.render_sql(
+        let mut sql = String::from(
             r#"
 SELECT route_trace_json
 FROM aicc_route_trace
+WHERE 1 = 1
+"#,
+        );
+        let mut string_binds: Vec<String> = vec![];
+        push_trace_id_filter(&mut sql, &mut string_binds, req);
+        sql.push_str(
+            r#"
 ORDER BY created_at_ms DESC, trace_id DESC
 LIMIT ? OFFSET ?
 "#,
         );
-        let rows = sqlx::query(&sql)
+        let sql = self.render_sql(&sql);
+        let mut query = sqlx::query(&sql);
+        for value in string_binds {
+            query = query.bind(value);
+        }
+        let rows = query
             .bind(to_sql_i64(limit as u64))
             .bind(to_sql_i64(offset as u64))
             .fetch_all(self.pool())
@@ -450,6 +462,43 @@ LIMIT ? OFFSET ?
             next_cursor,
         })
     }
+}
+
+fn push_trace_id_filter(sql: &mut String, binds: &mut Vec<String>, req: &QueryRouteTraceRequest) {
+    let task_ids = normalized_values(&req.task_ids);
+    let request_ids = normalized_values(&req.request_ids);
+    if task_ids.is_empty() && request_ids.is_empty() {
+        return;
+    }
+
+    let mut clauses = Vec::new();
+    if !task_ids.is_empty() {
+        clauses.push(format!("task_id IN ({})", placeholders(task_ids.len())));
+        binds.extend(task_ids);
+    }
+    if !request_ids.is_empty() {
+        clauses.push(format!("trace_id IN ({})", placeholders(request_ids.len())));
+        binds.extend(request_ids);
+    }
+    sql.push_str("\nAND (");
+    sql.push_str(&clauses.join(" OR "));
+    sql.push_str(")\n");
+}
+
+fn normalized_values(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn placeholders(count: usize) -> String {
+    std::iter::repeat("?")
+        .take(count)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn resolve_time_window(range: &UsageQueryTimeRange, now_ms: i64) -> (i64, i64) {
@@ -1013,18 +1062,63 @@ mod tests {
 
         assert!(db.insert_route_trace_event(&trace).await.unwrap());
         assert!(!db.insert_route_trace_event(&trace).await.unwrap());
+        let sibling = AiccRouteTraceEvent {
+            trace_id: "trace-two".to_string(),
+            task_id: "trace-one".to_string(),
+            route_trace_json: json!({
+                "request_id": "trace-two",
+                "api_type": "llm",
+                "requested_model": "llm.plan.default",
+                "selected_exact_model": "gpt-5-mini@test"
+            }),
+            created_at_ms: now + 1,
+            ..trace.clone()
+        };
+        assert!(db.insert_route_trace_event(&sibling).await.unwrap());
 
         let resp = db
             .query_route_traces(&QueryRouteTraceRequest {
                 limit: Some(20),
                 cursor: None,
+                task_ids: vec![],
+                request_ids: vec![],
             })
             .await
             .unwrap();
-        assert_eq!(resp.traces.len(), 1);
+        assert_eq!(resp.traces.len(), 2);
         assert_eq!(
             resp.traces[0].get("request_id").and_then(Value::as_str),
+            Some("trace-two")
+        );
+        assert_eq!(
+            resp.traces[1].get("request_id").and_then(Value::as_str),
             Some("trace-one")
+        );
+
+        let task_resp = db
+            .query_route_traces(&QueryRouteTraceRequest {
+                limit: Some(20),
+                cursor: None,
+                task_ids: vec!["trace-one".to_string()],
+                request_ids: vec![],
+            })
+            .await
+            .unwrap();
+        assert_eq!(task_resp.traces.len(), 2);
+
+        let request_resp = db
+            .query_route_traces(&QueryRouteTraceRequest {
+                limit: Some(20),
+                cursor: None,
+                task_ids: vec![],
+                request_ids: vec!["trace-two".to_string()],
+            })
+            .await
+            .unwrap();
+        assert_eq!(request_resp.traces.len(), 1);
+        assert_eq!(
+            request_resp.traces[0].get("request_id").and_then(Value::as_str),
+            Some("trace-two")
         );
     }
 

--- a/src/frame/aicc/src/aicc_usage_log_db.rs
+++ b/src/frame/aicc/src/aicc_usage_log_db.rs
@@ -15,9 +15,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Once};
 
 use buckyos_api::{
-    aicc_usage_log_default_rdb_instance_config, get_rdb_instance, AiccUsageEvent,
-    QueryUsageRequest, QueryUsageResponse, RdbBackend, UsageAggregate, UsageBucketedRow,
-    UsageGroupedRow, UsageQueryBucket, UsageQueryGroup, UsageQueryOutputMode, UsageQueryTimeRange,
+    aicc_usage_log_default_rdb_instance_config, get_rdb_instance, AiccRouteTraceEvent,
+    AiccUsageEvent, QueryRouteTraceRequest, QueryRouteTraceResponse, QueryUsageRequest,
+    QueryUsageResponse, RdbBackend, UsageAggregate, UsageBucketedRow, UsageGroupedRow,
+    UsageQueryBucket, UsageQueryGroup, UsageQueryOutputMode, UsageQueryTimeRange,
     AICC_SERVICE_SERVICE_NAME, AICC_USAGE_LOG_RDB_INSTANCE_ID, AICC_USAGE_LOG_RDB_SCHEMA_POSTGRES,
     AICC_USAGE_LOG_RDB_SCHEMA_SQLITE,
 };
@@ -116,14 +117,17 @@ impl AiccUsageLogDb {
     }
 
     async fn apply_schema(&self, override_ddl: Option<&str>) -> Result<(), RPCErrors> {
-        let ddl: &str =
-            override_ddl
-                .filter(|s| !s.trim().is_empty())
-                .unwrap_or(match self.backend() {
-                    RdbBackend::Sqlite => AICC_USAGE_LOG_RDB_SCHEMA_SQLITE,
-                    RdbBackend::Postgres => AICC_USAGE_LOG_RDB_SCHEMA_POSTGRES,
-                });
-        for statement in split_sql_statements(ddl) {
+        let default_ddl = match self.backend() {
+            RdbBackend::Sqlite => AICC_USAGE_LOG_RDB_SCHEMA_SQLITE,
+            RdbBackend::Postgres => AICC_USAGE_LOG_RDB_SCHEMA_POSTGRES,
+        };
+        let ddl = override_ddl
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or(default_ddl);
+        for statement in split_sql_statements(ddl)
+            .into_iter()
+            .chain(split_sql_statements(default_ddl).into_iter())
+        {
             self.pool().execute(statement.as_str()).await.map_err(|e| {
                 RPCErrors::ReasonError(format!("apply aicc usage-log schema failed: {}", e))
             })?;
@@ -209,6 +213,57 @@ ON CONFLICT DO NOTHING
                 RPCErrors::ReasonError(format!(
                     "failed to insert aicc usage event {}: {}",
                     event.event_id, error
+                ))
+            })?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn insert_route_trace_event(
+        &self,
+        event: &AiccRouteTraceEvent,
+    ) -> Result<bool, RPCErrors> {
+        let route_trace_json = serde_json::to_string(&event.route_trace_json).map_err(|err| {
+            RPCErrors::ReasonError(format!(
+                "serialize route_trace_json for event {} failed: {}",
+                event.trace_id, err
+            ))
+        })?;
+        let sql = self.render_sql(
+            r#"
+INSERT INTO aicc_route_trace (
+    trace_id,
+    tenant_id,
+    caller_app_id,
+    task_id,
+    request_model,
+    selected_exact_model,
+    provider_instance_name,
+    api_type,
+    route_trace_json,
+    created_at_ms
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT DO NOTHING
+"#,
+        );
+
+        let result = sqlx::query(&sql)
+            .bind(event.trace_id.clone())
+            .bind(event.tenant_id.clone())
+            .bind(event.caller_app_id.clone())
+            .bind(event.task_id.clone())
+            .bind(event.request_model.clone())
+            .bind(event.selected_exact_model.clone())
+            .bind(event.provider_instance_name.clone())
+            .bind(event.api_type.clone())
+            .bind(route_trace_json)
+            .bind(event.created_at_ms)
+            .execute(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to insert aicc route trace event {}: {}",
+                    event.trace_id, error
                 ))
             })?;
 
@@ -357,6 +412,44 @@ WHERE created_at_ms >= ? AND created_at_ms < ?
 
         Ok(response)
     }
+
+    pub async fn query_route_traces(
+        &self,
+        req: &QueryRouteTraceRequest,
+    ) -> Result<QueryRouteTraceResponse, RPCErrors> {
+        let limit = req.limit.unwrap_or(20).clamp(1, 128) as usize;
+        let offset = parse_cursor(req.cursor.as_deref())?;
+        let sql = self.render_sql(
+            r#"
+SELECT route_trace_json
+FROM aicc_route_trace
+ORDER BY created_at_ms DESC, trace_id DESC
+LIMIT ? OFFSET ?
+"#,
+        );
+        let rows = sqlx::query(&sql)
+            .bind(to_sql_i64(limit as u64))
+            .bind(to_sql_i64(offset as u64))
+            .fetch_all(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!("failed to query aicc route traces: {}", error))
+            })?;
+
+        let traces = rows
+            .iter()
+            .map(decode_route_trace_row)
+            .collect::<Result<Vec<Value>, RPCErrors>>()?;
+        let next_cursor = if traces.len() == limit {
+            Some(offset.saturating_add(traces.len()).to_string())
+        } else {
+            None
+        };
+        Ok(QueryRouteTraceResponse {
+            traces,
+            next_cursor,
+        })
+    }
 }
 
 fn resolve_time_window(range: &UsageQueryTimeRange, now_ms: i64) -> (i64, i64) {
@@ -495,6 +588,18 @@ fn decode_row(row: &AnyRow) -> Result<AiccUsageEvent, RPCErrors> {
         usage_json,
         finance_snapshot_json,
         created_at_ms,
+    })
+}
+
+fn decode_route_trace_row(row: &AnyRow) -> Result<Value, RPCErrors> {
+    let raw: String = row.try_get("route_trace_json").map_err(|err| {
+        RPCErrors::ReasonError(format!(
+            "failed to decode aicc_route_trace.route_trace_json: {}",
+            err
+        ))
+    })?;
+    serde_json::from_str(&raw).map_err(|err| {
+        RPCErrors::ReasonError(format!("failed to parse route_trace_json: {}", err))
     })
 }
 
@@ -699,7 +804,8 @@ mod tests {
     async fn setup() -> (AiccUsageLogDb, tempfile::TempDir) {
         let dir = tempdir().unwrap();
         let path = dir.path().join("usage.db");
-        let conn = format!("sqlite://{}?mode=rwc", path.to_str().unwrap());
+        let db_path = path.to_string_lossy().replace('\\', "/");
+        let conn = format!("sqlite:///{}?mode=rwc", db_path);
         let db = AiccUsageLogDb::open_default_sqlite(&conn).await.unwrap();
         (db, dir)
     }
@@ -881,6 +987,45 @@ mod tests {
             .unwrap();
         assert_eq!(second.events.len(), 2);
         assert!(second.next_cursor.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn insert_and_query_route_traces() {
+        let (db, _tmp) = setup().await;
+        let now = current_time_ms();
+        let trace = AiccRouteTraceEvent {
+            trace_id: "trace-one".to_string(),
+            tenant_id: "alice".to_string(),
+            caller_app_id: Some("sys_test".to_string()),
+            task_id: "trace-one".to_string(),
+            request_model: "llm.plan.default".to_string(),
+            selected_exact_model: Some("gpt-5@test".to_string()),
+            provider_instance_name: Some("test".to_string()),
+            api_type: "llm".to_string(),
+            route_trace_json: json!({
+                "request_id": "trace-one",
+                "api_type": "llm",
+                "requested_model": "llm.plan.default",
+                "selected_exact_model": "gpt-5@test"
+            }),
+            created_at_ms: now,
+        };
+
+        assert!(db.insert_route_trace_event(&trace).await.unwrap());
+        assert!(!db.insert_route_trace_event(&trace).await.unwrap());
+
+        let resp = db
+            .query_route_traces(&QueryRouteTraceRequest {
+                limit: Some(20),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(resp.traces.len(), 1);
+        assert_eq!(
+            resp.traces[0].get("request_id").and_then(Value::as_str),
+            Some("trace-one")
+        );
     }
 
     #[test]

--- a/src/frame/aicc/src/main.rs
+++ b/src/frame/aicc/src/main.rs
@@ -21,8 +21,8 @@ use ::kRPC::*;
 use anyhow::Result;
 use buckyos_api::{
     get_buckyos_api_runtime, init_buckyos_api_runtime, set_buckyos_api_runtime, AiccServerHandler,
-    BuckyOSRuntimeType, QueryUsageRequest, QueryUsageResponse, SystemConfigClient,
-    SystemConfigError, AICC_SERVICE_SERVICE_NAME,
+    BuckyOSRuntimeType, QueryRouteTraceRequest, QueryRouteTraceResponse, QueryUsageRequest,
+    QueryUsageResponse, SystemConfigClient, SystemConfigError, AICC_SERVICE_SERVICE_NAME,
 };
 use buckyos_http_server::Runner;
 use buckyos_http_server::{
@@ -63,6 +63,7 @@ const METHOD_PROVIDER_ADD: &str = "provider.add";
 const METHOD_PROVIDER_DELETE: &str = "provider.delete";
 const METHOD_PROVIDER_REFRESH_MODELS: &str = "provider.refresh_models";
 const METHOD_USAGE_QUERY: &str = "usage.query";
+const METHOD_TRACE_QUERY: &str = "trace.query";
 const AICC_SETTINGS_KEY: &str = "services/aicc/settings";
 const REDACTED_SECRET: &str = "***";
 const PROVIDER_VALIDATION_CACHE_TTL: Duration = Duration::from_secs(300);
@@ -1206,6 +1207,18 @@ impl AiccHttpServer {
         serde_json::to_value(response)
             .map_err(|err| RPCErrors::ReasonError(format!("serialize usage response: {}", err)))
     }
+
+    async fn handle_trace_query(&self, params: &Value) -> std::result::Result<Value, RPCErrors> {
+        let query: QueryRouteTraceRequest = serde_json::from_value(params.clone()).map_err(|err| {
+            RPCErrors::ReasonError(format!("invalid trace.query request: {}", err))
+        })?;
+        let response = match self.rpc_handler.0.usage_log_db() {
+            Some(db) => db.query_route_traces(&query).await?,
+            None => QueryRouteTraceResponse::default(),
+        };
+        serde_json::to_value(response)
+            .map_err(|err| RPCErrors::ReasonError(format!("serialize trace response: {}", err)))
+    }
 }
 
 fn filter_model_directory_by_path(mut value: Value, logical_path: &str) -> Value {
@@ -1320,6 +1333,10 @@ impl RPCHandler for AiccHttpServer {
         }
         if req.method == METHOD_USAGE_QUERY {
             let result = self.handle_usage_query(&req.params).await?;
+            return Ok(rpc_success(&req, result));
+        }
+        if req.method == METHOD_TRACE_QUERY {
+            let result = self.handle_trace_query(&req.params).await?;
             return Ok(rpc_success(&req, result));
         }
         self.rpc_handler.handle_rpc_call(req, ip_from).await

--- a/src/frame/desktop/src/api/aicc_mgr.ts
+++ b/src/frame/desktop/src/api/aicc_mgr.ts
@@ -18,6 +18,7 @@ import type {
   ProviderStatus,
   ProviderType,
   ProviderView,
+  RouteTrace,
   RoutePolicy,
   SchedulerProfile,
   GlobalRoutingView,
@@ -208,6 +209,10 @@ interface RawUsageQueryResponse {
   buckets?: RawUsageBucketedRow[]
   events?: RawUsageEvent[]
   next_cursor?: unknown
+}
+
+interface RawTraceQueryResponse {
+  traces?: unknown[]
 }
 
 interface AiccDataProvider {
@@ -452,7 +457,7 @@ class BuckyOSAiccProvider implements AiccDataProvider {
     const dashboardRange = localTrailingDaysRange(30)
     const todayRange = localTodayRange()
     const monthRange = localCurrentMonthRange()
-    const [directory, usageByModel, usageByCapability, usageByApp, usageTrend, usageToday, usageThisMonth] = await Promise.all([
+    const [directory, usageByModel, usageByCapability, usageByApp, usageTrend, usageToday, usageThisMonth, traceQuery] = await Promise.all([
       this.call<RawModelDirectory>('models.list', {}),
       this.queryUsage({
         time_range: toRawTimeRange(dashboardRange),
@@ -488,6 +493,7 @@ class BuckyOSAiccProvider implements AiccDataProvider {
         filters: {},
         output_mode: 'summary',
       }),
+      this.queryRouteTraces(20),
     ])
     this.usageSummary = toUsageSummary({
       byModel: usageByModel,
@@ -498,7 +504,7 @@ class BuckyOSAiccProvider implements AiccDataProvider {
     })
     this.usageTrend = toUsageTrend(usageTrend)
     const rawProviders = Array.isArray(directory.providers) ? directory.providers : []
-    return toStoreSnapshot(directory, rawProviders, [])
+    return toStoreSnapshot(directory, rawProviders, [], toRouteTraces(traceQuery))
   }
 
   async addProvider(draft: WizardDraft): Promise<void> {
@@ -643,6 +649,15 @@ class BuckyOSAiccProvider implements AiccDataProvider {
       return await this.call<RawUsageQueryResponse>('usage.query', params)
     } catch (error) {
       console.error('aicc.usage.query failed', error)
+      return {}
+    }
+  }
+
+  private async queryRouteTraces(limit: number): Promise<RawTraceQueryResponse> {
+    try {
+      return await this.call<RawTraceQueryResponse>('trace.query', { limit })
+    } catch (error) {
+      console.error('aicc.trace.query failed', error)
       return {}
     }
   }
@@ -928,6 +943,129 @@ function toUsageFinanceSnapshot(value: unknown): StoreSnapshot['usageEvents'][nu
   }
 }
 
+function toRouteTraces(raw: RawTraceQueryResponse): RouteTrace[] {
+  const traces = Array.isArray(raw.traces) ? raw.traces : []
+  return traces
+    .map((trace, index) => toRouteTrace(trace, index))
+    .filter((trace): trace is RouteTrace => trace !== null)
+}
+
+function toRouteTrace(value: unknown, index: number): RouteTrace | null {
+  const trace = asRecord(value)
+  const requestedModel = asOptionalString(trace.requested_model)
+  if (!requestedModel) return null
+  const selectedExactModel = asOptionalString(trace.selected_exact_model)
+  return {
+    request_id: asNonEmptyString(trace.request_id, `route-trace-${index}`),
+    session_id: asOptionalString(trace.session_id),
+    api_type: normalizeApiType(trace.api_type),
+    requested_model: requestedModel,
+    requested_model_type: trace.requested_model_type === 'exact' ? 'exact' : 'logical',
+    resolved_logical_path: asOptionalString(trace.resolved_logical_path),
+    selected_exact_model: selectedExactModel,
+    selected_provider_instance_name: asOptionalString(trace.selected_provider_instance_name)
+      ?? (selectedExactModel ? providerInstanceFromExactModel(selectedExactModel) : undefined),
+    ranked_candidates: toRankedCandidates(trace.ranked_candidates),
+    filtered_candidates: toFilteredCandidates(trace.filtered_candidates),
+    fallback_applied: asBoolean(trace.fallback_applied, false),
+    fallback_chain: toFallbackChain(trace.fallback_chain),
+    session_sticky_hit: asBoolean(trace.session_sticky_hit, false),
+    scheduler_profile: normalizeSchedulerProfile(trace.scheduler_profile) ?? 'balanced',
+    runtime_failover_count: asNumber(trace.runtime_failover_count, 0),
+    user_summary: toRouteUserSummary(trace.user_summary),
+    warnings: toStringArray(trace.warnings),
+  }
+}
+
+function toRankedCandidates(value: unknown): RouteTrace['ranked_candidates'] {
+  return Array.isArray(value)
+    ? value.map((item) => {
+      const candidate = asRecord(item)
+      return {
+        exact_model: asNonEmptyString(candidate.exact_model, 'unknown-model'),
+        final_score: asOptionalNumber(candidate.final_score),
+        selected: asBoolean(candidate.selected, false),
+        exact_model_weight: asOptionalNumber(candidate.exact_model_weight),
+        provider_weight: asOptionalNumber(candidate.provider_weight),
+        preference_score_inputs: toPreferenceScoreInputs(candidate.preference_score_inputs),
+      }
+    })
+    : []
+}
+
+function toPreferenceScoreInputs(value: unknown): RouteTrace['ranked_candidates'][number]['preference_score_inputs'] {
+  const inputs = asRecord(value)
+  const exactModelWeight = asOptionalNumber(inputs.exact_model_weight)
+  const providerWeight = asOptionalNumber(inputs.provider_weight)
+  const combinedWeight = asOptionalNumber(inputs.combined_weight)
+  const preferencePenalty = asOptionalNumber(inputs.preference_penalty)
+  if (
+    exactModelWeight == null ||
+    providerWeight == null ||
+    combinedWeight == null ||
+    preferencePenalty == null
+  ) {
+    return undefined
+  }
+  return {
+    exact_model_weight: exactModelWeight,
+    provider_weight: providerWeight,
+    combined_weight: combinedWeight,
+    preference_penalty: preferencePenalty,
+    exact_model_weight_effect: asNonEmptyString(inputs.exact_model_weight_effect, 'neutral'),
+    provider_weight_effect: asNonEmptyString(inputs.provider_weight_effect, 'neutral'),
+  }
+}
+
+function toFilteredCandidates(value: unknown): RouteTrace['filtered_candidates'] {
+  return Array.isArray(value)
+    ? value.map((item) => {
+      const candidate = asRecord(item)
+      return {
+        exact_model: asNonEmptyString(candidate.exact_model, 'unknown-model'),
+        reason: asNonEmptyString(candidate.reason, 'filtered'),
+      }
+    })
+    : []
+}
+
+function toFallbackChain(value: unknown): RouteTrace['fallback_chain'] {
+  return Array.isArray(value)
+    ? value.map((item) => {
+      const fallback = asRecord(item)
+      return {
+        from: asNonEmptyString(fallback.from, ''),
+        to: asNonEmptyString(fallback.to, ''),
+        reason: asNonEmptyString(fallback.reason, 'fallback'),
+      }
+    })
+    : []
+}
+
+function toRouteUserSummary(value: unknown): RouteTrace['user_summary'] {
+  const summary = asRecord(value)
+  const displayName = asOptionalString(summary.display_name)
+  const modelFamily = asOptionalString(summary.model_family)
+  const reasonShort = asOptionalString(summary.reason_short)
+  if (!displayName || !modelFamily || !reasonShort) return undefined
+  const providerOrigin = summary.provider_origin === 'local' || summary.provider_origin === 'proxy_unknown'
+    ? summary.provider_origin
+    : 'cloud'
+  return {
+    display_name: displayName,
+    model_family: modelFamily,
+    provider_origin: providerOrigin,
+    reason_short: reasonShort,
+    was_fallback: asBoolean(summary.was_fallback, false),
+    was_failover: asBoolean(summary.was_failover, false),
+  }
+}
+
+function normalizeApiType(value: unknown): ApiType {
+  const apiType = asOptionalString(value)
+  return apiType && API_TYPES.includes(apiType as ApiType) ? apiType as ApiType : 'llm'
+}
+
 function aggregateTokens(raw?: RawUsageAggregate): number {
   if (!raw) return 0
   return asNumber(raw.total_tokens, 0)
@@ -1039,6 +1177,7 @@ function toStoreSnapshot(
   directory: RawModelDirectory,
   rawProviders: RawProviderInventory[],
   usageEvents: StoreSnapshot['usageEvents'] = [],
+  routeTraces: RouteTrace[] = [],
 ): StoreSnapshot {
   const inventories = rawProviders.map(toProviderInventory)
   const cloudProviders = inventories
@@ -1062,7 +1201,7 @@ function toStoreSnapshot(
     providers: cloudProviders,
     usageEvents,
     routingView,
-    routeTraces: [],
+    routeTraces,
     localModels,
     aiStatus: computeAIStatus(cloudProviders, localModels, routingView),
   }

--- a/src/frame/desktop/src/api/aicc_mgr.ts
+++ b/src/frame/desktop/src/api/aicc_mgr.ts
@@ -282,6 +282,8 @@ export interface RoutingDirectoryView {
 export interface RouteTracesQuery {
   cursor?: string
   limit: number
+  taskIds?: string[]
+  requestIds?: string[]
 }
 
 export interface RouteTracesPage {
@@ -449,6 +451,7 @@ class MockAiccProvider implements AiccDataProvider {
 
   async queryRouteTraces(params: RouteTracesQuery): Promise<RouteTracesPage> {
     const traces = this.store.getSnapshot().routeTraces
+      .filter((trace) => routeTraceMatchesQuery(trace, params))
     const cursor = Number(params.cursor ?? 0)
     const offset = Number.isFinite(cursor) && cursor > 0 ? cursor : 0
     const page = traces.slice(offset, offset + params.limit)
@@ -687,6 +690,8 @@ class BuckyOSAiccProvider implements AiccDataProvider {
       const raw = await this.call<RawTraceQueryResponse>('trace.query', {
         limit: params.limit,
         cursor: params.cursor,
+        task_ids: params.taskIds,
+        request_ids: params.requestIds,
       })
       return {
         traces: toRouteTraces(raw),
@@ -1183,6 +1188,15 @@ function usageEventMatchesQuery(event: StoreSnapshot['usageEvents'][number], par
   if (filters.appIds?.length && !filters.appIds.some((id) => id === (event.app_id ?? 'system') || id === event.agent_id)) return false
   if (filters.appQuery?.trim() && !includesFuzzy(appValue, filters.appQuery)) return false
   return true
+}
+
+function routeTraceMatchesQuery(trace: RouteTrace, params: RouteTracesQuery): boolean {
+  const taskIds = params.taskIds?.filter(Boolean) ?? []
+  const requestIds = params.requestIds?.filter(Boolean) ?? []
+  if (taskIds.length === 0 && requestIds.length === 0) return true
+  return taskIds.includes(trace.request_id) ||
+    (trace.session_id != null && taskIds.includes(trace.session_id)) ||
+    requestIds.includes(trace.request_id)
 }
 
 function includesFuzzy(value: string, query: string): boolean {

--- a/src/frame/desktop/src/api/aicc_mgr.ts
+++ b/src/frame/desktop/src/api/aicc_mgr.ts
@@ -213,6 +213,7 @@ interface RawUsageQueryResponse {
 
 interface RawTraceQueryResponse {
   traces?: unknown[]
+  next_cursor?: unknown
 }
 
 interface AiccDataProvider {
@@ -227,6 +228,7 @@ interface AiccDataProvider {
   getUsageTrend(granularity?: string): UsageTrendPoint[]
   queryUsageEvents(params: UsageEventsQuery): Promise<UsageEventsPage>
   queryRoutingDirectory(path: string | null): Promise<RoutingDirectoryView>
+  queryRouteTraces(params: RouteTracesQuery): Promise<RouteTracesPage>
 }
 
 export interface AICCMgr {
@@ -244,6 +246,7 @@ export interface AICCMgr {
   validateConnection(draft: WizardDraft): Promise<ValidationResult>
   queryUsageEvents(params: UsageEventsQuery): Promise<UsageEventsPage>
   queryRoutingDirectory(path: string | null): Promise<RoutingDirectoryView>
+  queryRouteTraces(params: RouteTracesQuery): Promise<RouteTracesPage>
 }
 
 export interface UsageTimeRange {
@@ -274,6 +277,16 @@ export interface UsageEventsPage {
 export interface RoutingDirectoryView {
   routingView: GlobalRoutingView
   models: ModelMetadata[]
+}
+
+export interface RouteTracesQuery {
+  cursor?: string
+  limit: number
+}
+
+export interface RouteTracesPage {
+  traces: RouteTrace[]
+  nextCursor?: string
 }
 
 export class AICCModelStore implements AICCMgr {
@@ -359,6 +372,10 @@ export class AICCModelStore implements AICCMgr {
     return this.provider.queryRoutingDirectory(path)
   }
 
+  queryRouteTraces(params: RouteTracesQuery): Promise<RouteTracesPage> {
+    return this.provider.queryRouteTraces(params)
+  }
+
   private emit() {
     this.listeners.forEach((listener) => listener())
   }
@@ -430,6 +447,18 @@ class MockAiccProvider implements AiccDataProvider {
     }
   }
 
+  async queryRouteTraces(params: RouteTracesQuery): Promise<RouteTracesPage> {
+    const traces = this.store.getSnapshot().routeTraces
+    const cursor = Number(params.cursor ?? 0)
+    const offset = Number.isFinite(cursor) && cursor > 0 ? cursor : 0
+    const page = traces.slice(offset, offset + params.limit)
+    const nextOffset = offset + page.length
+    return {
+      traces: page,
+      nextCursor: nextOffset < traces.length ? nextOffset.toString() : undefined,
+    }
+  }
+
   async queryRoutingDirectory(path: string | null): Promise<RoutingDirectoryView> {
     const snapshot = this.store.getSnapshot()
     return {
@@ -493,7 +522,7 @@ class BuckyOSAiccProvider implements AiccDataProvider {
         filters: {},
         output_mode: 'summary',
       }),
-      this.queryRouteTraces(20),
+      this.queryRouteTraces({ limit: 20 }),
     ])
     this.usageSummary = toUsageSummary({
       byModel: usageByModel,
@@ -504,7 +533,7 @@ class BuckyOSAiccProvider implements AiccDataProvider {
     })
     this.usageTrend = toUsageTrend(usageTrend)
     const rawProviders = Array.isArray(directory.providers) ? directory.providers : []
-    return toStoreSnapshot(directory, rawProviders, [], toRouteTraces(traceQuery))
+    return toStoreSnapshot(directory, rawProviders, [], traceQuery.traces)
   }
 
   async addProvider(draft: WizardDraft): Promise<void> {
@@ -653,12 +682,19 @@ class BuckyOSAiccProvider implements AiccDataProvider {
     }
   }
 
-  private async queryRouteTraces(limit: number): Promise<RawTraceQueryResponse> {
+  async queryRouteTraces(params: RouteTracesQuery): Promise<RouteTracesPage> {
     try {
-      return await this.call<RawTraceQueryResponse>('trace.query', { limit })
+      const raw = await this.call<RawTraceQueryResponse>('trace.query', {
+        limit: params.limit,
+        cursor: params.cursor,
+      })
+      return {
+        traces: toRouteTraces(raw),
+        nextCursor: asOptionalString(raw.next_cursor),
+      }
     } catch (error) {
       console.error('aicc.trace.query failed', error)
-      return {}
+      return { traces: [] }
     }
   }
 

--- a/src/frame/desktop/src/app/ai-center/RoutingPage.tsx
+++ b/src/frame/desktop/src/app/ai-center/RoutingPage.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Braces,
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
   ChevronUp,
   Cloud,
@@ -97,7 +98,8 @@ export function RoutingPage() {
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [currentPath, setCurrentPath] = useState<string | null>(null)
   const [traces, setTraces] = useState<RouteTrace[]>(snapshotTraces)
-  const [traceCursor, setTraceCursor] = useState<string | undefined>()
+  const [traceNextCursor, setTraceNextCursor] = useState<string | undefined>()
+  const [tracePageIndex, setTracePageIndex] = useState(0)
   const [traceLoading, setTraceLoading] = useState(false)
   const [traceError, setTraceError] = useState<'initial' | 'more' | null>(null)
 
@@ -144,14 +146,16 @@ export function RoutingPage() {
         const page = await store.queryRouteTraces({ limit: ROUTE_TRACE_PAGE_SIZE })
         if (!cancelled) {
           setTraces(page.traces)
-          setTraceCursor(page.nextCursor)
+          setTraceNextCursor(page.nextCursor)
+          setTracePageIndex(0)
           setTraceError(null)
         }
       } catch (error) {
         console.error('aicc.trace.query initial page failed', error)
         if (!cancelled) {
           setTraces(snapshotTraces)
-          setTraceCursor(snapshotTraces.length >= ROUTE_TRACE_PAGE_SIZE ? String(ROUTE_TRACE_PAGE_SIZE) : undefined)
+          setTraceNextCursor(snapshotTraces.length >= ROUTE_TRACE_PAGE_SIZE ? String(ROUTE_TRACE_PAGE_SIZE) : undefined)
+          setTracePageIndex(0)
           setTraceError('initial')
         }
       }
@@ -212,17 +216,38 @@ export function RoutingPage() {
     setFilters((current) => ({ ...current, [key]: value }))
   }
 
-  const loadMoreTraces = async () => {
-    if (!traceCursor || traceLoading) return
+  const loadTracePage = async (pageIndex: number) => {
+    if (traceLoading) return
+    const nextPageIndex = Math.max(0, pageIndex)
     setTraceLoading(true)
     setTraceError(null)
     try {
       const page = await store.queryRouteTraces({
         limit: ROUTE_TRACE_PAGE_SIZE,
-        cursor: traceCursor,
+        cursor: nextPageIndex > 0 ? String(nextPageIndex * ROUTE_TRACE_PAGE_SIZE) : undefined,
+      })
+      setTraces(page.traces)
+      setTraceNextCursor(page.nextCursor)
+      setTracePageIndex(nextPageIndex)
+    } catch (error) {
+      console.error('aicc.trace.query page failed', error)
+      setTraceError('initial')
+    } finally {
+      setTraceLoading(false)
+    }
+  }
+
+  const loadMoreTraces = async () => {
+    if (!traceNextCursor || traceLoading) return
+    setTraceLoading(true)
+    setTraceError(null)
+    try {
+      const page = await store.queryRouteTraces({
+        limit: ROUTE_TRACE_PAGE_SIZE,
+        cursor: traceNextCursor,
       })
       setTraces((current) => mergeRouteTraces(current, page.traces))
-      setTraceCursor(page.nextCursor)
+      setTraceNextCursor(page.nextCursor)
     } catch (error) {
       console.error('aicc.trace.query next page failed', error)
       setTraceError('more')
@@ -281,10 +306,15 @@ export function RoutingPage() {
           <TraceExplorer
             traces={traces}
             compact={isMobile}
-            hasMore={Boolean(traceCursor)}
+            hasMore={isMobile && Boolean(traceNextCursor)}
+            pageIndex={tracePageIndex}
+            canGoPrevious={!isMobile && tracePageIndex > 0}
+            canGoNext={!isMobile && Boolean(traceNextCursor)}
             loading={traceLoading}
             error={traceError}
             onLoadMore={loadMoreTraces}
+            onPreviousPage={() => void loadTracePage(tracePageIndex - 1)}
+            onNextPage={() => void loadTracePage(tracePageIndex + 1)}
           />
         </aside>
       </div>
@@ -741,16 +771,26 @@ function TraceExplorer({
   traces,
   compact,
   hasMore,
+  pageIndex,
+  canGoPrevious,
+  canGoNext,
   loading,
   error,
   onLoadMore,
+  onPreviousPage,
+  onNextPage,
 }: {
   traces: RouteTrace[]
   compact: boolean
   hasMore: boolean
+  pageIndex: number
+  canGoPrevious: boolean
+  canGoNext: boolean
   loading: boolean
   error: 'initial' | 'more' | null
   onLoadMore: () => void
+  onPreviousPage: () => void
+  onNextPage: () => void
 }) {
   const { t } = useI18n()
   return (
@@ -803,7 +843,7 @@ function TraceExplorer({
             : t('aiCenter.routing.traceLoadFailed', 'Failed to load route traces')}
         </div>
       )}
-      {hasMore && (
+      {compact && hasMore && (
         <button
           type="button"
           onClick={onLoadMore}
@@ -816,6 +856,35 @@ function TraceExplorer({
             ? t('aiCenter.routing.traceLoading', 'Loading...')
             : t('aiCenter.routing.traceLoadMore', 'Load more')}
         </button>
+      )}
+      {!compact && (
+        <div className="mt-3 flex items-center justify-between gap-3 rounded-lg px-3 py-2" style={{ background: 'var(--cp-bg)', border: '1px solid var(--cp-border)' }}>
+          <button
+            type="button"
+            onClick={onPreviousPage}
+            disabled={!canGoPrevious || loading}
+            className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium disabled:opacity-50"
+            style={{ color: 'var(--cp-accent)' }}
+          >
+            <ChevronLeft size={14} />
+            {t('aiCenter.routing.tracePreviousPage', 'Previous')}
+          </button>
+          <div className="text-xs tabular-nums" style={{ color: 'var(--cp-muted)' }}>
+            {loading
+              ? t('aiCenter.routing.traceLoading', 'Loading...')
+              : t('aiCenter.routing.tracePage', 'Page {{page}}', { page: pageIndex + 1 })}
+          </div>
+          <button
+            type="button"
+            onClick={onNextPage}
+            disabled={!canGoNext || loading}
+            className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium disabled:opacity-50"
+            style={{ color: 'var(--cp-accent)' }}
+          >
+            {t('aiCenter.routing.traceNextPage', 'Next')}
+            <ChevronRight size={14} />
+          </button>
+        </div>
       )}
     </section>
   )

--- a/src/frame/desktop/src/app/ai-center/RoutingPage.tsx
+++ b/src/frame/desktop/src/app/ai-center/RoutingPage.tsx
@@ -65,6 +65,7 @@ type ModelGroup = {
 }
 
 type UseCaseKind = 'chat' | 'code' | 'plan' | 'image' | 'embed' | 'vision' | 'audio' | 'other'
+type TraceOutcomeFilter = 'all' | 'selected' | 'fallback' | 'unresolved' | 'warning'
 
 function emptyMultiFilter(): MultiFilter {
   return { query: '', selected: [] }
@@ -102,6 +103,9 @@ export function RoutingPage() {
   const [tracePageIndex, setTracePageIndex] = useState(0)
   const [traceLoading, setTraceLoading] = useState(false)
   const [traceError, setTraceError] = useState<'initial' | 'more' | null>(null)
+  const [traceQuery, setTraceQuery] = useState('')
+  const [traceOutcomeFilter, setTraceOutcomeFilter] = useState<TraceOutcomeFilter>('all')
+  const [traceProviderFilter, setTraceProviderFilter] = useState('')
 
   const snapshotModels = useMemo(() => [
     ...providers.flatMap((provider) => provider.status.discovered_models),
@@ -200,6 +204,19 @@ export function RoutingPage() {
   const selectedScenario = visibleScenarios.find((scenario) => scenario.node.path === selectedPath)
     ?? directoryEntries[0]
     ?? visibleScenarios[0]
+  const traceProviderOptions = useMemo(
+    () => uniqueSorted(traces
+      .map((trace) => trace.selected_provider_instance_name)
+      .filter((provider): provider is string => Boolean(provider))),
+    [traces],
+  )
+  const visibleTraces = useMemo(
+    () => traces
+      .filter((trace) => traceMatchesQuery(trace, traceQuery))
+      .filter((trace) => traceMatchesOutcome(trace, traceOutcomeFilter))
+      .filter((trace) => !traceProviderFilter || trace.selected_provider_instance_name === traceProviderFilter),
+    [traceOutcomeFilter, traceProviderFilter, traceQuery, traces],
+  )
 
   if (routingView.logical_tree.length === 0) {
     return (
@@ -303,21 +320,30 @@ export function RoutingPage() {
           {selectedScenario && (
             <ScenarioInspector scenario={selectedScenario} providerNames={providerNames} />
           )}
-          <TraceExplorer
-            traces={traces}
-            compact={isMobile}
-            hasMore={isMobile && Boolean(traceNextCursor)}
-            pageIndex={tracePageIndex}
-            canGoPrevious={!isMobile && tracePageIndex > 0}
-            canGoNext={!isMobile && Boolean(traceNextCursor)}
-            loading={traceLoading}
-            error={traceError}
-            onLoadMore={loadMoreTraces}
-            onPreviousPage={() => void loadTracePage(tracePageIndex - 1)}
-            onNextPage={() => void loadTracePage(tracePageIndex + 1)}
-          />
         </aside>
       </div>
+
+      <TraceExplorer
+        traces={visibleTraces}
+        totalCount={traces.length}
+        compact={isMobile}
+        query={traceQuery}
+        outcomeFilter={traceOutcomeFilter}
+        providerFilter={traceProviderFilter}
+        providerOptions={traceProviderOptions}
+        hasMore={isMobile && Boolean(traceNextCursor)}
+        pageIndex={tracePageIndex}
+        canGoPrevious={!isMobile && tracePageIndex > 0}
+        canGoNext={!isMobile && Boolean(traceNextCursor)}
+        loading={traceLoading}
+        error={traceError}
+        onQueryChange={setTraceQuery}
+        onOutcomeFilterChange={setTraceOutcomeFilter}
+        onProviderFilterChange={setTraceProviderFilter}
+        onLoadMore={loadMoreTraces}
+        onPreviousPage={() => void loadTracePage(tracePageIndex - 1)}
+        onNextPage={() => void loadTracePage(tracePageIndex + 1)}
+      />
     </div>
   )
 }
@@ -769,25 +795,41 @@ function ModelGroupRow({
 
 function TraceExplorer({
   traces,
+  totalCount,
   compact,
+  query,
+  outcomeFilter,
+  providerFilter,
+  providerOptions,
   hasMore,
   pageIndex,
   canGoPrevious,
   canGoNext,
   loading,
   error,
+  onQueryChange,
+  onOutcomeFilterChange,
+  onProviderFilterChange,
   onLoadMore,
   onPreviousPage,
   onNextPage,
 }: {
   traces: RouteTrace[]
+  totalCount: number
   compact: boolean
+  query: string
+  outcomeFilter: TraceOutcomeFilter
+  providerFilter: string
+  providerOptions: string[]
   hasMore: boolean
   pageIndex: number
   canGoPrevious: boolean
   canGoNext: boolean
   loading: boolean
   error: 'initial' | 'more' | null
+  onQueryChange: (value: string) => void
+  onOutcomeFilterChange: (value: TraceOutcomeFilter) => void
+  onProviderFilterChange: (value: string) => void
   onLoadMore: () => void
   onPreviousPage: () => void
   onNextPage: () => void
@@ -795,46 +837,62 @@ function TraceExplorer({
   const { t } = useI18n()
   return (
     <section className="rounded-xl p-4" style={{ background: 'var(--cp-surface)', border: '1px solid var(--cp-border)' }}>
-      <div className="flex items-center gap-2 mb-3">
-        <Route size={16} style={{ color: 'var(--cp-accent)' }} />
-        <h3 className="text-sm font-medium" style={{ color: 'var(--cp-text)' }}>{t('aiCenter.routing.routeTrace', 'Route Trace')}</h3>
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+        <div className="flex items-center gap-2">
+          <Route size={16} style={{ color: 'var(--cp-accent)' }} />
+          <h3 className="text-sm font-medium" style={{ color: 'var(--cp-text)' }}>{t('aiCenter.routing.routeTraceAudit', 'Route Trace Audit')}</h3>
+        </div>
+        <div className="text-xs" style={{ color: 'var(--cp-muted)' }}>
+          {t('aiCenter.routing.traceVisibleCount', '{{visible}} / {{total}} traces', { visible: traces.length, total: totalCount })}
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-[minmax(220px,1fr)_180px_220px] gap-2 mb-3">
+        <div className="flex min-h-9 items-center gap-2 rounded-md px-2" style={{ background: 'var(--cp-bg)', border: '1px solid var(--cp-border)' }}>
+          <Search size={15} style={{ color: 'var(--cp-muted)' }} />
+          <input
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder={t('aiCenter.routing.traceSearch', 'Search path, model, provider, reason...')}
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+            style={{ color: 'var(--cp-text)' }}
+          />
+        </div>
+        <select
+          value={outcomeFilter}
+          onChange={(event) => onOutcomeFilterChange(event.target.value as TraceOutcomeFilter)}
+          className="min-h-9 rounded-md px-2 text-sm outline-none"
+          style={{ background: 'var(--cp-bg)', color: 'var(--cp-text)', border: '1px solid var(--cp-border)' }}
+        >
+          <option value="all">{t('aiCenter.routing.traceOutcomeAll', 'All outcomes')}</option>
+          <option value="selected">{t('aiCenter.routing.traceOutcomeSelected', 'Selected')}</option>
+          <option value="fallback">{t('aiCenter.routing.traceOutcomeFallback', 'Fallback')}</option>
+          <option value="unresolved">{t('aiCenter.routing.traceOutcomeUnresolved', 'Unresolved')}</option>
+          <option value="warning">{t('aiCenter.routing.traceOutcomeWarning', 'Warnings')}</option>
+        </select>
+        <select
+          value={providerFilter}
+          onChange={(event) => onProviderFilterChange(event.target.value)}
+          className="min-h-9 rounded-md px-2 text-sm outline-none"
+          style={{ background: 'var(--cp-bg)', color: 'var(--cp-text)', border: '1px solid var(--cp-border)' }}
+        >
+          <option value="">{t('aiCenter.routing.traceProviderAll', 'All providers')}</option>
+          {providerFilter && !providerOptions.includes(providerFilter) && (
+            <option value={providerFilter}>{providerFilter}</option>
+          )}
+          {providerOptions.map((provider) => (
+            <option key={provider} value={provider}>{provider}</option>
+          ))}
+        </select>
       </div>
       <div className={compact ? 'flex flex-col gap-3' : 'grid grid-cols-1 gap-3'}>
         {traces.map((trace) => (
-          <article key={trace.request_id} className="rounded-lg p-3" style={{ background: 'var(--cp-bg)' }}>
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="text-sm font-mono" style={{ color: 'var(--cp-text)' }}>{trace.requested_model}</div>
-              <StatusBadge status={trace.selected_exact_model ? (trace.fallback_applied ? 'warning' : 'ok') : 'error'} label={trace.scheduler_profile} />
-            </div>
-            <div className="text-xs mt-1" style={{ color: 'var(--cp-muted)' }}>
-              {trace.selected_exact_model
-                ? `${trace.selected_exact_model} / ${trace.selected_provider_instance_name}`
-                : t('aiCenter.routing.noExactResolved', 'No exact model resolved')}
-            </div>
-            <p className="text-sm mt-2" style={{ color: 'var(--cp-text)' }}>{trace.user_summary?.reason_short}</p>
-            <div className="flex flex-col gap-1 mt-3">
-              {trace.ranked_candidates.length > 0 ? trace.ranked_candidates.map((candidate) => (
-                <div key={candidate.exact_model} className="flex justify-between gap-3 text-xs">
-                  <span className="min-w-0" style={{ color: candidate.selected ? 'var(--cp-accent)' : 'var(--cp-muted)' }}>
-                    <span className="block truncate">{candidate.exact_model}</span>
-                    <span className="block" style={{ color: 'var(--cp-muted)' }}>
-                      {candidateWeightSummary(candidate)}
-                    </span>
-                  </span>
-                  <span className="shrink-0" style={{ color: 'var(--cp-muted)' }}>{candidate.final_score?.toFixed(2)}</span>
-                </div>
-              )) : trace.filtered_candidates.map((candidate) => (
-                <div key={candidate.exact_model} className="flex flex-col gap-0.5 text-xs">
-                  <span style={{ color: 'var(--cp-warning)' }}>{candidate.exact_model}</span>
-                  <span style={{ color: 'var(--cp-muted)' }}>{candidate.reason}</span>
-                </div>
-              ))}
-            </div>
-            {trace.warnings.length > 0 && (
-              <div className="text-xs mt-2" style={{ color: 'var(--cp-warning)' }}>{trace.warnings.join(' / ')}</div>
-            )}
-          </article>
+          <TraceCard key={trace.request_id} trace={trace} />
         ))}
+        {traces.length === 0 && (
+          <div className="rounded-lg px-3 py-8 text-center text-xs" style={{ color: 'var(--cp-muted)', background: 'var(--cp-bg)' }}>
+            {t('aiCenter.routing.traceNoMatches', 'No route traces match the current search and filters.')}
+          </div>
+        )}
       </div>
       {error && (
         <div className="mt-3 rounded-lg px-3 py-2 text-xs" style={{ color: 'var(--cp-warning)', background: 'var(--cp-bg)' }}>
@@ -887,6 +945,100 @@ function TraceExplorer({
         </div>
       )}
     </section>
+  )
+}
+
+function TraceCard({ trace }: { trace: RouteTrace }) {
+  const { t } = useI18n()
+  const [expanded, setExpanded] = useState(false)
+  const selectedCandidate = selectedTraceCandidate(trace)
+  const visibleCandidates = expanded
+    ? trace.ranked_candidates
+    : selectedCandidate ? [selectedCandidate] : []
+  const hiddenCandidateCount = Math.max(0, trace.ranked_candidates.length - visibleCandidates.length)
+
+  return (
+    <article className="rounded-lg p-3" style={{ background: 'var(--cp-bg)' }}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-mono" style={{ color: 'var(--cp-text)' }}>{trace.requested_model}</div>
+          <div className="mt-1 text-xs" style={{ color: 'var(--cp-muted)' }}>
+            {trace.selected_exact_model
+              ? `${trace.selected_exact_model} / ${trace.selected_provider_instance_name}`
+              : t('aiCenter.routing.noExactResolved', 'No exact model resolved')}
+          </div>
+        </div>
+        <StatusBadge status={trace.selected_exact_model ? (trace.fallback_applied ? 'warning' : 'ok') : 'error'} label={trace.scheduler_profile} />
+      </div>
+      <p className="text-sm mt-2" style={{ color: 'var(--cp-text)' }}>{trace.user_summary?.reason_short}</p>
+
+      <div className="mt-3 rounded-md p-2" style={{ background: 'var(--cp-surface)' }}>
+        <div className="mb-1 text-xs font-medium" style={{ color: 'var(--cp-muted)' }}>
+          {t('aiCenter.routing.traceFinalSelection', 'Final selection')}
+        </div>
+        {selectedCandidate ? (
+          <TraceCandidateRow candidate={selectedCandidate} selected />
+        ) : (
+          <div className="text-xs" style={{ color: trace.selected_exact_model ? 'var(--cp-text)' : 'var(--cp-warning)' }}>
+            {trace.selected_exact_model ?? t('aiCenter.routing.noExactResolved', 'No exact model resolved')}
+          </div>
+        )}
+      </div>
+
+      {expanded && visibleCandidates.length > 0 && (
+        <div className="mt-3 flex flex-col gap-1">
+          {visibleCandidates.map((candidate) => (
+            <TraceCandidateRow key={candidate.exact_model} candidate={candidate} selected={candidate.selected} />
+          ))}
+        </div>
+      )}
+      {expanded && trace.filtered_candidates.length > 0 && (
+        <div className="mt-3 flex flex-col gap-1">
+          {trace.filtered_candidates.map((candidate) => (
+            <div key={candidate.exact_model} className="flex flex-col gap-0.5 text-xs">
+              <span style={{ color: 'var(--cp-warning)' }}>{candidate.exact_model}</span>
+              <span style={{ color: 'var(--cp-muted)' }}>{candidate.reason}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {(trace.ranked_candidates.length > 1 || trace.filtered_candidates.length > 0) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="mt-3 inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium"
+          style={{ color: 'var(--cp-accent)', border: '1px solid var(--cp-border)' }}
+        >
+          {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+          {expanded
+            ? t('aiCenter.routing.traceHideCandidates', 'Hide candidates')
+            : t('aiCenter.routing.traceShowCandidates', 'Show candidates ({{count}})', { count: hiddenCandidateCount + trace.filtered_candidates.length })}
+        </button>
+      )}
+      {trace.warnings.length > 0 && (
+        <div className="text-xs mt-2" style={{ color: 'var(--cp-warning)' }}>{trace.warnings.join(' / ')}</div>
+      )}
+    </article>
+  )
+}
+
+function TraceCandidateRow({
+  candidate,
+  selected,
+}: {
+  candidate: RouteTrace['ranked_candidates'][number]
+  selected: boolean
+}) {
+  return (
+    <div className="flex justify-between gap-3 text-xs">
+      <span className="min-w-0" style={{ color: selected ? 'var(--cp-accent)' : 'var(--cp-muted)' }}>
+        <span className="block truncate">{candidate.exact_model}</span>
+        <span className="block" style={{ color: 'var(--cp-muted)' }}>
+          {candidateWeightSummary(candidate)}
+        </span>
+      </span>
+      <span className="shrink-0" style={{ color: 'var(--cp-muted)' }}>{candidate.final_score?.toFixed(2)}</span>
+    </div>
   )
 }
 
@@ -1299,6 +1451,38 @@ function formatLatency(model: ModelMetadata): string {
 
 function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values.filter(Boolean))).sort((left, right) => left.localeCompare(right))
+}
+
+function selectedTraceCandidate(trace: RouteTrace): RouteTrace['ranked_candidates'][number] | undefined {
+  return trace.ranked_candidates.find((candidate) => candidate.selected)
+    ?? trace.ranked_candidates.find((candidate) => candidate.exact_model === trace.selected_exact_model)
+}
+
+function traceMatchesQuery(trace: RouteTrace, query: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) return true
+  const haystack = [
+    trace.request_id,
+    trace.requested_model,
+    trace.resolved_logical_path ?? '',
+    trace.selected_exact_model ?? '',
+    trace.selected_provider_instance_name ?? '',
+    trace.scheduler_profile,
+    trace.user_summary?.reason_short ?? '',
+    ...trace.warnings,
+    ...trace.ranked_candidates.map((candidate) => candidate.exact_model),
+    ...trace.filtered_candidates.flatMap((candidate) => [candidate.exact_model, candidate.reason]),
+  ].join(' ').toLowerCase()
+  return haystack.includes(normalizedQuery)
+}
+
+function traceMatchesOutcome(trace: RouteTrace, filter: TraceOutcomeFilter): boolean {
+  if (filter === 'all') return true
+  if (filter === 'selected') return Boolean(trace.selected_exact_model)
+  if (filter === 'fallback') return trace.fallback_applied
+  if (filter === 'unresolved') return !trace.selected_exact_model
+  if (filter === 'warning') return trace.warnings.length > 0
+  return true
 }
 
 function candidateWeightSummary(candidate: RouteTrace['ranked_candidates'][number]): string {

--- a/src/frame/desktop/src/app/ai-center/RoutingPage.tsx
+++ b/src/frame/desktop/src/app/ai-center/RoutingPage.tsx
@@ -82,12 +82,13 @@ function defaultRoutingFilters(): RoutingFilters {
 }
 
 const USE_CASE_ORDER: UseCaseKind[] = ['chat', 'code', 'plan', 'image', 'embed', 'vision', 'audio', 'other']
+const ROUTE_TRACE_PAGE_SIZE = 20
 
 export function RoutingPage() {
   const { t } = useI18n()
   const store = useAICCStore()
   const routingView = useGlobalRoutingView()
-  const traces = useRouteTraces()
+  const snapshotTraces = useRouteTraces()
   const providers = useProviders()
   const localModels = useLocalModels()
   const isMobile = useMediaQuery('(max-width: 767px)')
@@ -95,6 +96,10 @@ export function RoutingPage() {
   const [filters, setFilters] = useState<RoutingFilters>(() => defaultRoutingFilters())
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [currentPath, setCurrentPath] = useState<string | null>(null)
+  const [traces, setTraces] = useState<RouteTrace[]>(snapshotTraces)
+  const [traceCursor, setTraceCursor] = useState<string | undefined>()
+  const [traceLoading, setTraceLoading] = useState(false)
+  const [traceError, setTraceError] = useState<'initial' | 'more' | null>(null)
 
   const snapshotModels = useMemo(() => [
     ...providers.flatMap((provider) => provider.status.discovered_models),
@@ -131,6 +136,31 @@ export function RoutingPage() {
       cancelled = true
     }
   }, [currentPath, routingView, snapshotModels, store])
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadInitialTraces() {
+      try {
+        const page = await store.queryRouteTraces({ limit: ROUTE_TRACE_PAGE_SIZE })
+        if (!cancelled) {
+          setTraces(page.traces)
+          setTraceCursor(page.nextCursor)
+          setTraceError(null)
+        }
+      } catch (error) {
+        console.error('aicc.trace.query initial page failed', error)
+        if (!cancelled) {
+          setTraces(snapshotTraces)
+          setTraceCursor(snapshotTraces.length >= ROUTE_TRACE_PAGE_SIZE ? String(ROUTE_TRACE_PAGE_SIZE) : undefined)
+          setTraceError('initial')
+        }
+      }
+    }
+    void loadInitialTraces()
+    return () => {
+      cancelled = true
+    }
+  }, [snapshotTraces, store])
 
   const activeRoutingView = directoryView.routingView
   const models = directoryView.models
@@ -182,6 +212,25 @@ export function RoutingPage() {
     setFilters((current) => ({ ...current, [key]: value }))
   }
 
+  const loadMoreTraces = async () => {
+    if (!traceCursor || traceLoading) return
+    setTraceLoading(true)
+    setTraceError(null)
+    try {
+      const page = await store.queryRouteTraces({
+        limit: ROUTE_TRACE_PAGE_SIZE,
+        cursor: traceCursor,
+      })
+      setTraces((current) => mergeRouteTraces(current, page.traces))
+      setTraceCursor(page.nextCursor)
+    } catch (error) {
+      console.error('aicc.trace.query next page failed', error)
+      setTraceError('more')
+    } finally {
+      setTraceLoading(false)
+    }
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <RoutingHeader revision={activeRoutingView.revision} scenarioCount={visibleScenarios.length} />
@@ -229,7 +278,14 @@ export function RoutingPage() {
           {selectedScenario && (
             <ScenarioInspector scenario={selectedScenario} providerNames={providerNames} />
           )}
-          <TraceExplorer traces={traces} compact={isMobile} />
+          <TraceExplorer
+            traces={traces}
+            compact={isMobile}
+            hasMore={Boolean(traceCursor)}
+            loading={traceLoading}
+            error={traceError}
+            onLoadMore={loadMoreTraces}
+          />
         </aside>
       </div>
     </div>
@@ -681,7 +737,21 @@ function ModelGroupRow({
   )
 }
 
-function TraceExplorer({ traces, compact }: { traces: RouteTrace[]; compact: boolean }) {
+function TraceExplorer({
+  traces,
+  compact,
+  hasMore,
+  loading,
+  error,
+  onLoadMore,
+}: {
+  traces: RouteTrace[]
+  compact: boolean
+  hasMore: boolean
+  loading: boolean
+  error: 'initial' | 'more' | null
+  onLoadMore: () => void
+}) {
   const { t } = useI18n()
   return (
     <section className="rounded-xl p-4" style={{ background: 'var(--cp-surface)', border: '1px solid var(--cp-border)' }}>
@@ -726,6 +796,27 @@ function TraceExplorer({ traces, compact }: { traces: RouteTrace[]; compact: boo
           </article>
         ))}
       </div>
+      {error && (
+        <div className="mt-3 rounded-lg px-3 py-2 text-xs" style={{ color: 'var(--cp-warning)', background: 'var(--cp-bg)' }}>
+          {error === 'more'
+            ? t('aiCenter.routing.traceLoadMoreFailed', 'Failed to load more route traces')
+            : t('aiCenter.routing.traceLoadFailed', 'Failed to load route traces')}
+        </div>
+      )}
+      {hasMore && (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          disabled={loading}
+          className="mt-3 inline-flex min-h-9 w-full items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium disabled:opacity-60"
+          style={{ color: 'var(--cp-accent)', background: 'var(--cp-bg)', border: '1px solid var(--cp-border)' }}
+        >
+          <ChevronDown size={15} />
+          {loading
+            ? t('aiCenter.routing.traceLoading', 'Loading...')
+            : t('aiCenter.routing.traceLoadMore', 'Load more')}
+        </button>
+      )}
     </section>
   )
 }
@@ -814,6 +905,18 @@ function buildScenarios(nodes: LogicalNode[], models: ModelMetadata[], traces: R
     })
 
   return scenarios
+}
+
+function mergeRouteTraces(current: RouteTrace[], next: RouteTrace[]): RouteTrace[] {
+  const seen = new Set(current.map((trace) => trace.request_id))
+  const merged = [...current]
+  for (const trace of next) {
+    if (!seen.has(trace.request_id)) {
+      seen.add(trace.request_id)
+      merged.push(trace)
+    }
+  }
+  return merged
 }
 
 function scenarioCandidates(node: LogicalNode, models: ModelMetadata[], trace?: RouteTrace): ModelMetadata[] {

--- a/src/frame/desktop/src/app/ai-center/components/home/UsageDashboard.tsx
+++ b/src/frame/desktop/src/app/ai-center/components/home/UsageDashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Activity, ChevronDown, CreditCard, DollarSign, HelpCircle, Route, Wallet } from 'lucide-react'
+import { Activity, ChevronDown, ChevronUp, CreditCard, DollarSign, HelpCircle, Route, Wallet } from 'lucide-react'
 import { useI18n } from '../../../../i18n/provider'
 import { useAICCStore, useAIStatus, useProviders, useRouteTraces, useUsageSummary, useUsageTrend } from '../../hooks/use-aicc-store'
 import { SummaryCard } from '../shared/SummaryCard'
@@ -133,6 +133,7 @@ type MultiFilter = {
   selected: string[]
 }
 const PAGE_SIZE = 10
+const HOME_TRACE_LIMIT = 5
 const EMPTY_MULTI_FILTER: MultiFilter = { query: '', selected: [] }
 
 export function UsageDashboard() {
@@ -155,7 +156,13 @@ export function UsageDashboard() {
   const [usagePage, setUsagePage] = useState<UsageEventsPage>({ events: [], totalRequests: 0 })
   const [usageLoading, setUsageLoading] = useState(false)
   const [usageError, setUsageError] = useState<string | null>(null)
+  const [linkedTraceTaskId, setLinkedTraceTaskId] = useState<string | null>(null)
+  const [linkedTraces, setLinkedTraces] = useState<RouteTrace[]>([])
+  const [linkedTraceCursor, setLinkedTraceCursor] = useState<string | undefined>()
+  const [linkedTraceLoading, setLinkedTraceLoading] = useState(false)
+  const [linkedTraceError, setLinkedTraceError] = useState<string | null>(null)
   const detailRef = useRef<HTMLElement | null>(null)
+  const linkedTraceRef = useRef<HTMLElement | null>(null)
 
   const snProvider = providers.find((p) => p.config.provider_type === 'sn_router')
   const snCredit = snProvider?.account.balance_value
@@ -189,6 +196,7 @@ export function UsageDashboard() {
     appQuery: appAgentFilter.query,
   }), [appAgentFilter, modelFilter, providerFilter])
   const currentCursor = pageCursors[detailPage]
+  const recentTraces = traces.slice(0, HOME_TRACE_LIMIT)
   const effectiveDetailPage = detailPage
   const pageStart = (effectiveDetailPage - 1) * PAGE_SIZE
   const pagedEvents = usagePage.events
@@ -289,6 +297,35 @@ export function UsageDashboard() {
     window.requestAnimationFrame(() => {
       detailRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     })
+  }
+
+  const loadLinkedTraces = async (taskId: string, cursor?: string) => {
+    const normalizedTaskId = taskId.trim()
+    if (!normalizedTaskId || linkedTraceLoading) return
+    setLinkedTraceLoading(true)
+    setLinkedTraceError(null)
+    try {
+      const page = await store.queryRouteTraces({
+        limit: 20,
+        cursor,
+        taskIds: [normalizedTaskId],
+        requestIds: [normalizedTaskId],
+      })
+      setLinkedTraceTaskId(normalizedTaskId)
+      setLinkedTraces((current) => cursor ? mergeRouteTraces(current, page.traces) : page.traces)
+      setLinkedTraceCursor(page.nextCursor)
+      window.requestAnimationFrame(() => {
+        linkedTraceRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      })
+    } catch (error) {
+      console.error('aicc.trace.query linked task failed', error)
+      setLinkedTraceTaskId(normalizedTaskId)
+      setLinkedTraces([])
+      setLinkedTraceCursor(undefined)
+      setLinkedTraceError(t('aiCenter.home.linkedTraceLoadFailed', 'Could not load route traces for this task.'))
+    } finally {
+      setLinkedTraceLoading(false)
+    }
   }
 
   return (
@@ -411,35 +448,21 @@ export function UsageDashboard() {
         />
       </div>
 
-      {traces[0] && (
+      {recentTraces.length > 0 && (
         <section className="rounded-xl p-4" style={{ background: 'var(--cp-surface)', border: '1px solid var(--cp-border)' }}>
-          <div className="flex items-center gap-2 mb-3">
-            <Route size={16} style={{ color: 'var(--cp-accent)' }} />
-            <h3 className="text-sm font-medium" style={{ color: 'var(--cp-text)' }}>
-              {t('aiCenter.home.recentRouteTrace', 'Recent Route Trace')}
-            </h3>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Route size={16} style={{ color: 'var(--cp-accent)' }} />
+              <h3 className="text-sm font-medium" style={{ color: 'var(--cp-text)' }}>
+                {t('aiCenter.home.recentRouteTrace', 'Recent Route Traces')}
+              </h3>
+            </div>
+            <span className="text-xs" style={{ color: 'var(--cp-muted)' }}>{recentTraces.length}</span>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-[1.2fr_2fr] gap-4">
-            <div>
-              <div className="text-xs" style={{ color: 'var(--cp-muted)' }}>{traces[0].requested_model} → {traces[0].selected_exact_model}</div>
-              <div className="text-sm mt-1" style={{ color: 'var(--cp-text)' }}>
-                {traces[0].user_summary?.reason_short}
-              </div>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {traces[0].ranked_candidates.map((candidate) => (
-                <span
-                  key={candidate.exact_model}
-                  className="text-xs rounded-md px-2 py-1"
-                  style={{
-                    background: candidate.selected ? 'color-mix(in oklch, var(--cp-accent), transparent 84%)' : 'var(--cp-bg)',
-                    color: candidate.selected ? 'var(--cp-accent)' : 'var(--cp-muted)',
-                  }}
-                >
-                  {candidate.exact_model} · {candidate.final_score?.toFixed(2)} · {candidateWeightSummary(candidate)}
-                </span>
-              ))}
-            </div>
+          <div className="grid grid-cols-1 gap-2">
+            {recentTraces.map((trace) => (
+              <RecentTraceCard key={trace.request_id} trace={trace} />
+            ))}
           </div>
         </section>
       )}
@@ -545,7 +568,21 @@ export function UsageDashboard() {
                     <td className="px-4 py-2 text-xs" style={{ color: 'var(--cp-text)' }}>
                       <TruncatedText value={`${event.app_id ?? 'system'}${event.agent_id ? ` / ${event.agent_id}` : ''}`} className="max-w-[180px]" />
                     </td>
-                    <td className="px-4 py-2 text-xs" style={{ color: 'var(--cp-muted)' }}>{event.session_id}</td>
+                    <td className="px-4 py-2 text-xs">
+                      {event.session_id ? (
+                        <button
+                          type="button"
+                          onClick={() => void loadLinkedTraces(event.session_id ?? '')}
+                          className="max-w-[180px] truncate font-mono underline-offset-2 hover:underline"
+                          style={{ color: 'var(--cp-accent)' }}
+                          title={t('aiCenter.home.viewTaskRouteTraces', 'View route traces for this task')}
+                        >
+                          {event.session_id}
+                        </button>
+                      ) : (
+                        <span style={{ color: 'var(--cp-muted)' }}>-</span>
+                      )}
+                    </td>
                     <td className="px-4 py-2 text-xs" style={{ color: 'var(--cp-text)' }}>{formatTokens(tokens)}</td>
                     <td className="px-4 py-2 text-xs" style={{ color: 'var(--cp-text)' }}>{formatUsd(usageFinanceAmount(event))}</td>
                     <td className="px-4 py-2 text-xs" style={{ color: event.status === 'success' ? 'var(--cp-success)' : 'var(--cp-danger)' }}>{event.status}</td>
@@ -598,8 +635,155 @@ export function UsageDashboard() {
           </div>
         )}
       </section>
+
+      {linkedTraceTaskId && (
+        <section ref={linkedTraceRef} className="rounded-xl p-4 scroll-mt-4" style={{ background: 'var(--cp-surface)', border: '1px solid var(--cp-border)' }}>
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <Route size={16} style={{ color: 'var(--cp-accent)' }} />
+              <h3 className="min-w-0 truncate text-sm font-medium" style={{ color: 'var(--cp-text)' }}>
+                {t('aiCenter.home.linkedRouteTraces', 'Route Traces for Task / Session')}
+              </h3>
+            </div>
+            <span className="text-xs font-mono" style={{ color: 'var(--cp-muted)' }}>{linkedTraceTaskId}</span>
+          </div>
+          <div className="grid grid-cols-1 gap-2">
+            {linkedTraces.map((trace) => (
+              <RecentTraceCard key={trace.request_id} trace={trace} />
+            ))}
+            {!linkedTraceLoading && linkedTraces.length === 0 && (
+              <div className="rounded-lg px-3 py-8 text-center text-xs" style={{ color: 'var(--cp-muted)', background: 'var(--cp-bg)' }}>
+                {t('aiCenter.home.noLinkedRouteTraces', 'No route traces were found for this task/session.')}
+              </div>
+            )}
+          </div>
+          {linkedTraceError && (
+            <div className="mt-3 rounded-lg px-3 py-2 text-xs" style={{ color: 'var(--cp-warning)', background: 'var(--cp-bg)' }}>
+              {linkedTraceError}
+            </div>
+          )}
+          {linkedTraceCursor && (
+            <button
+              type="button"
+              onClick={() => void loadLinkedTraces(linkedTraceTaskId, linkedTraceCursor)}
+              disabled={linkedTraceLoading}
+              className="mt-3 inline-flex min-h-9 w-full items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium disabled:opacity-60"
+              style={{ color: 'var(--cp-accent)', background: 'var(--cp-bg)', border: '1px solid var(--cp-border)' }}
+            >
+              <ChevronDown size={15} />
+              {linkedTraceLoading
+                ? t('aiCenter.home.traceLoading', 'Loading...')
+                : t('aiCenter.home.traceLoadMore', 'Load more')}
+            </button>
+          )}
+        </section>
+      )}
     </div>
   )
+}
+
+function RecentTraceCard({ trace }: { trace: RouteTrace }) {
+  const { t } = useI18n()
+  const [expanded, setExpanded] = useState(false)
+  const selectedCandidate = selectedTraceCandidate(trace)
+  const visibleCandidates = expanded
+    ? trace.ranked_candidates
+    : selectedCandidate ? [selectedCandidate] : []
+  const hiddenCandidateCount = Math.max(0, trace.ranked_candidates.length - visibleCandidates.length)
+
+  return (
+    <article className="rounded-lg p-3" style={{ background: 'var(--cp-bg)' }}>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(260px,1.2fr)]">
+        <div className="min-w-0">
+          <div className="truncate text-xs" style={{ color: 'var(--cp-muted)' }}>
+            {trace.requested_model}{' -> '}{trace.selected_exact_model ?? t('aiCenter.home.noExactResolved', 'unresolved')}
+          </div>
+          <div className="mt-1 text-sm" style={{ color: 'var(--cp-text)' }}>
+            {trace.user_summary?.reason_short}
+          </div>
+        </div>
+        <div className="min-w-0 rounded-md p-2" style={{ background: 'var(--cp-surface)' }}>
+          <div className="mb-1 text-xs font-medium" style={{ color: 'var(--cp-muted)' }}>
+            {t('aiCenter.home.traceFinalSelection', 'Final selection')}
+          </div>
+          {selectedCandidate ? (
+            <RecentTraceCandidate candidate={selectedCandidate} selected />
+          ) : (
+            <div className="truncate text-xs" style={{ color: trace.selected_exact_model ? 'var(--cp-text)' : 'var(--cp-warning)' }}>
+              {trace.selected_exact_model ?? t('aiCenter.home.noExactResolved', 'No exact model resolved')}
+            </div>
+          )}
+        </div>
+      </div>
+      {expanded && visibleCandidates.length > 0 && (
+        <div className="mt-3 flex flex-col gap-1">
+          {visibleCandidates.map((candidate) => (
+            <RecentTraceCandidate key={candidate.exact_model} candidate={candidate} selected={candidate.selected} />
+          ))}
+        </div>
+      )}
+      {expanded && trace.filtered_candidates.length > 0 && (
+        <div className="mt-3 flex flex-col gap-1">
+          {trace.filtered_candidates.map((candidate) => (
+            <div key={candidate.exact_model} className="flex flex-col gap-0.5 text-xs">
+              <span style={{ color: 'var(--cp-warning)' }}>{candidate.exact_model}</span>
+              <span style={{ color: 'var(--cp-muted)' }}>{candidate.reason}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {(trace.ranked_candidates.length > 1 || trace.filtered_candidates.length > 0) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="mt-3 inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium"
+          style={{ color: 'var(--cp-accent)', border: '1px solid var(--cp-border)' }}
+        >
+          {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+          {expanded
+            ? t('aiCenter.home.traceHideCandidates', 'Hide candidates')
+            : t('aiCenter.home.traceShowCandidates', 'Show candidates ({{count}})', { count: hiddenCandidateCount + trace.filtered_candidates.length })}
+        </button>
+      )}
+    </article>
+  )
+}
+
+function RecentTraceCandidate({
+  candidate,
+  selected,
+}: {
+  candidate: RouteTrace['ranked_candidates'][number]
+  selected: boolean
+}) {
+  return (
+    <div className="flex justify-between gap-3 text-xs">
+      <span className="min-w-0" style={{ color: selected ? 'var(--cp-accent)' : 'var(--cp-muted)' }}>
+        <span className="block truncate">{candidate.exact_model}</span>
+        <span className="block" style={{ color: 'var(--cp-muted)' }}>
+          {candidateWeightSummary(candidate)}
+        </span>
+      </span>
+      <span className="shrink-0" style={{ color: 'var(--cp-muted)' }}>{candidate.final_score?.toFixed(2)}</span>
+    </div>
+  )
+}
+
+function selectedTraceCandidate(trace: RouteTrace): RouteTrace['ranked_candidates'][number] | undefined {
+  return trace.ranked_candidates.find((candidate) => candidate.selected)
+    ?? trace.ranked_candidates.find((candidate) => candidate.exact_model === trace.selected_exact_model)
+}
+
+function mergeRouteTraces(current: RouteTrace[], next: RouteTrace[]): RouteTrace[] {
+  const seen = new Set(current.map((trace) => trace.request_id))
+  const merged = [...current]
+  for (const trace of next) {
+    if (!seen.has(trace.request_id)) {
+      seen.add(trace.request_id)
+      merged.push(trace)
+    }
+  }
+  return merged
 }
 
 function TimeRangeFilterControl({

--- a/src/kernel/buckyos-api/src/aicc_usage_log.rs
+++ b/src/kernel/buckyos-api/src/aicc_usage_log.rs
@@ -26,7 +26,7 @@ use crate::rdb_mgr::{RdbBackend, RdbInstanceConfig};
 pub const AICC_USAGE_LOG_RDB_INSTANCE_ID: &str = "aicc-usage-log";
 
 /// Version of the usage-log schema. Bump whenever the DDL changes.
-pub const AICC_USAGE_LOG_RDB_SCHEMA_VERSION: u64 = 1;
+pub const AICC_USAGE_LOG_RDB_SCHEMA_VERSION: u64 = 2;
 
 /// Sqlite DDL for the usage-log database. The only required table in v1 is
 /// `aicc_usage_event`; summary tables can be added later when SQL aggregation
@@ -62,6 +62,24 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_aicc_usage_event_tenant_task
 CREATE UNIQUE INDEX IF NOT EXISTS idx_aicc_usage_event_tenant_idem
     ON aicc_usage_event(tenant_id, idempotency_key)
     WHERE idempotency_key IS NOT NULL;
+CREATE TABLE IF NOT EXISTS aicc_route_trace (
+    trace_id                 TEXT PRIMARY KEY,
+    tenant_id                TEXT NOT NULL,
+    caller_app_id            TEXT,
+    task_id                  TEXT NOT NULL,
+    request_model            TEXT NOT NULL,
+    selected_exact_model     TEXT,
+    provider_instance_name   TEXT,
+    api_type                 TEXT NOT NULL,
+    route_trace_json         TEXT NOT NULL,
+    created_at_ms            INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_time
+    ON aicc_route_trace(created_at_ms);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_tenant_time
+    ON aicc_route_trace(tenant_id, created_at_ms);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_request_model_time
+    ON aicc_route_trace(request_model, created_at_ms);
 "#;
 
 /// Postgres DDL mirroring the sqlite schema above.
@@ -96,6 +114,24 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_aicc_usage_event_tenant_task
 CREATE UNIQUE INDEX IF NOT EXISTS idx_aicc_usage_event_tenant_idem
     ON aicc_usage_event(tenant_id, idempotency_key)
     WHERE idempotency_key IS NOT NULL;
+CREATE TABLE IF NOT EXISTS aicc_route_trace (
+    trace_id                 TEXT PRIMARY KEY,
+    tenant_id                TEXT NOT NULL,
+    caller_app_id            TEXT,
+    task_id                  TEXT NOT NULL,
+    request_model            TEXT NOT NULL,
+    selected_exact_model     TEXT,
+    provider_instance_name   TEXT,
+    api_type                 TEXT NOT NULL,
+    route_trace_json         TEXT NOT NULL,
+    created_at_ms            BIGINT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_time
+    ON aicc_route_trace(created_at_ms);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_tenant_time
+    ON aicc_route_trace(tenant_id, created_at_ms);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_request_model_time
+    ON aicc_route_trace(request_model, created_at_ms);
 "#;
 
 /// Default rdb-instance config for the aicc usage-log. The scheduler drops
@@ -150,6 +186,39 @@ pub struct AiccUsageEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finance_snapshot_json: Option<Value>,
     pub created_at_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiccRouteTraceEvent {
+    pub trace_id: String,
+    pub tenant_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_app_id: Option<String>,
+    pub task_id: String,
+    pub request_model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_exact_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_instance_name: Option<String>,
+    pub api_type: String,
+    pub route_trace_json: Value,
+    pub created_at_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryRouteTraceRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct QueryRouteTraceResponse {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub traces: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// Time-range selector for `query_usage`.

--- a/src/kernel/buckyos-api/src/aicc_usage_log.rs
+++ b/src/kernel/buckyos-api/src/aicc_usage_log.rs
@@ -26,7 +26,7 @@ use crate::rdb_mgr::{RdbBackend, RdbInstanceConfig};
 pub const AICC_USAGE_LOG_RDB_INSTANCE_ID: &str = "aicc-usage-log";
 
 /// Version of the usage-log schema. Bump whenever the DDL changes.
-pub const AICC_USAGE_LOG_RDB_SCHEMA_VERSION: u64 = 2;
+pub const AICC_USAGE_LOG_RDB_SCHEMA_VERSION: u64 = 3;
 
 /// Sqlite DDL for the usage-log database. The only required table in v1 is
 /// `aicc_usage_event`; summary tables can be added later when SQL aggregation
@@ -80,6 +80,8 @@ CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_tenant_time
     ON aicc_route_trace(tenant_id, created_at_ms);
 CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_request_model_time
     ON aicc_route_trace(request_model, created_at_ms);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_task_time
+    ON aicc_route_trace(task_id, created_at_ms);
 "#;
 
 /// Postgres DDL mirroring the sqlite schema above.
@@ -132,6 +134,8 @@ CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_tenant_time
     ON aicc_route_trace(tenant_id, created_at_ms);
 CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_request_model_time
     ON aicc_route_trace(request_model, created_at_ms);
+CREATE INDEX IF NOT EXISTS idx_aicc_route_trace_task_time
+    ON aicc_route_trace(task_id, created_at_ms);
 "#;
 
 /// Default rdb-instance config for the aicc usage-log. The scheduler drops
@@ -211,6 +215,10 @@ pub struct QueryRouteTraceRequest {
     pub limit: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub task_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub request_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/src/kernel/scheduler/src/scheduler.rs
+++ b/src/kernel/scheduler/src/scheduler.rs
@@ -147,6 +147,7 @@ pub enum ServiceSpecType {
     Kernel,  //kernel service 无owner_user_id
     Service, //系统服务
     App,     // 无状态的app服务，有owner_user_id
+    Agent,
 }
 
 impl From<String> for ServiceSpecType {
@@ -155,9 +156,16 @@ impl From<String> for ServiceSpecType {
             "kernel" => ServiceSpecType::Kernel,
             "service" => ServiceSpecType::Service,
             "frame" => ServiceSpecType::Service,
+            "agent" => ServiceSpecType::Agent,
             "app" => ServiceSpecType::App,
             _ => ServiceSpecType::App,
         }
+    }
+}
+
+impl ServiceSpecType {
+    pub fn is_app_like(&self) -> bool {
+        matches!(self, ServiceSpecType::App | ServiceSpecType::Agent)
     }
 }
 
@@ -882,7 +890,7 @@ impl NodeScheduler {
                     ));
                 }
                 ServiceSpecState::Disable => {
-                    if spec_snapshot.spec_type != ServiceSpecType::App {
+                    if !spec_snapshot.spec_type.is_app_like() {
                         continue;
                     }
 

--- a/src/kernel/scheduler/src/system_config_agent.rs
+++ b/src/kernel/scheduler/src/system_config_agent.rs
@@ -66,8 +66,9 @@ fn create_service_spec_by_app_config(
     app_config: &AppServiceSpec,
 ) -> ServiceSpec {
     let spec_state = ServiceSpecState::from(app_config.state.clone());
+    let is_agent = app_config.app_doc.get_app_type() == AppType::Agent;
 
-    let mut need_container = app_config.app_doc.get_app_type() == AppType::Agent;
+    let mut need_container = is_agent;
     if !need_container {
         need_container = true;
         if app_config
@@ -90,7 +91,11 @@ fn create_service_spec_by_app_config(
         app_index: app_config.app_index,
         app_id: app_config.app_id().to_string(),
         owner_id: owner_user_id.to_string(),
-        spec_type: ServiceSpecType::App,
+        spec_type: if is_agent {
+            ServiceSpecType::Agent
+        } else {
+            ServiceSpecType::App
+        },
         state: spec_state,
         need_container,
         best_instance_count: app_config.expected_instance_count,
@@ -316,7 +321,7 @@ pub(crate) fn schedule_action_to_tx_actions(
             }
             let service_spec = service_spec.unwrap();
             match service_spec.spec_type {
-                ServiceSpecType::App => {
+                ServiceSpecType::App | ServiceSpecType::Agent => {
                     let set_state_action =
                         set_app_service_state(spec_id.as_str(), spec_status, input_config)?;
                     info!(
@@ -345,7 +350,7 @@ pub(crate) fn schedule_action_to_tx_actions(
             let service_spec = service_spec.unwrap();
             need_update_gateway_node_list.insert(new_instance.node_id.clone());
             match service_spec.spec_type {
-                ServiceSpecType::App => {
+                ServiceSpecType::App | ServiceSpecType::Agent => {
                     let instance_action =
                         instance_app_service(new_instance, &device_list, &input_config)?;
                     info!("will instance app pod: {}", new_instance.spec_id);
@@ -400,7 +405,7 @@ pub(crate) fn schedule_action_to_tx_actions(
                     }
                 });
             match service_spec.spec_type {
-                ServiceSpecType::App => {
+                ServiceSpecType::App | ServiceSpecType::Agent => {
                     info!("will uninstance app service: {}", instance.spec_id);
                     let uninstance_action = uninstance_app_service(&instance)?;
                     result.extend(uninstance_action);
@@ -422,7 +427,7 @@ pub(crate) fn schedule_action_to_tx_actions(
             }
             let service_spec = service_spec_opt.unwrap();
             match service_spec.spec_type {
-                ServiceSpecType::App => {
+                ServiceSpecType::App | ServiceSpecType::Agent => {
                     let update_action = update_app_service_instance(instance)?;
                     info!("will update app service instance: {}", instance.spec_id);
                     result.extend(update_action);
@@ -1298,6 +1303,12 @@ async fn update_rbac(
             ServiceSpecType::App => {
                 push_policy_line(&mut rbac_policy, format!("g, {}, app", service_spec.app_id));
             }
+            ServiceSpecType::Agent => {
+                push_policy_line(
+                    &mut rbac_policy,
+                    format!("g, {}, agent", service_spec.app_id),
+                );
+            }
             ServiceSpecType::Service => {
                 push_policy_line(
                     &mut rbac_policy,
@@ -1941,6 +1952,48 @@ mod tests {
         assert!(!policy.lines().any(|line| line.trim() == "g, bob, user"));
     }
 
+    #[tokio::test]
+    async fn test_build_schedule_plan_generates_agent_rbac_group() {
+        let zone_config = create_test_zone_config();
+        let device_ood1 = create_test_device_info("ood1", None);
+        let mut input_system_config = HashMap::new();
+        input_system_config.insert(
+            "boot/config".to_string(),
+            serde_json::to_string(&zone_config).unwrap(),
+        );
+        input_system_config.insert(
+            "devices/ood1/info".to_string(),
+            serde_json::to_string(&device_ood1).unwrap(),
+        );
+        input_system_config.insert(
+            "users/alice/settings".to_string(),
+            serde_json::to_string(&json!({
+                "type": "admin",
+                "user_id": "alice",
+                "password": "hashed",
+                "state": "active",
+                "res_pool_id": "default",
+                "is_local": true
+            }))
+            .unwrap(),
+        );
+        input_system_config.insert(
+            "users/alice/agents/buckyos_jarvis/spec".to_string(),
+            serde_json::to_string(&create_test_agent_spec()).unwrap(),
+        );
+
+        let plan = build_schedule_plan(&input_system_config, true)
+            .await
+            .expect("boot plan should build");
+        let policy = match plan.tx_actions.get("system/rbac/policy").unwrap() {
+            KVAction::Update(value) => value,
+            other => panic!("unexpected rbac kv action: {:?}", other),
+        };
+
+        assert!(policy.contains("g, buckyos_jarvis, agent"));
+        assert!(!policy.contains("g, buckyos_jarvis, app"));
+    }
+
     #[test]
     fn test_create_scheduler_by_system_config_loads_agent_specs() {
         let zone_config = create_test_zone_config();
@@ -1980,7 +2033,7 @@ mod tests {
 
         assert_eq!(spec.app_id, "buckyos_jarvis");
         assert_eq!(spec.owner_id, "alice");
-        assert_eq!(spec.spec_type, ServiceSpecType::App);
+        assert_eq!(spec.spec_type, ServiceSpecType::Agent);
         assert!(spec.need_container);
     }
 


### PR DESCRIPTION
## 摘要
- 在 AICC 服务中持久化 route trace 记录，并通过 `buckyos-api` 和桌面端 AICC manager 暴露 route trace 查询能力。
- 为 AI Center 的路由追踪页面增加分页能力，并优化分页交互体验。
- 将 usage log 事件关联回 route trace，并在用量看板中展示相关路由追踪上下文。
- 修复 scheduler 中 agent RBAC role 的生成逻辑，确保 agent service 权限能被正确调度。

## 提交范围
- 07cc2049 Persist AICC route traces
- f56b7bb2 Add AICC route trace pagination
- d5f942bc Refine route trace pagination UX
- 668394cf Fix agent RBAC role scheduling
- af1c6c34 Link usage events to route traces

## 验证
- 本次仅更新 PR 文案，未运行测试。