### PR TITLE
Allow admin to update msg-center tunnel settings

### DIFF
--- a/src/kernel/buckyos-api/src/rbac_config.rs
+++ b/src/kernel/buckyos-api/src/rbac_config.rs
@@ -117,6 +117,7 @@ p, admin,obj://config/users/{admin}/profile,read|write,allow
 p, admin,obj://config/users/{admin}/apps/{app}/{key},read|write,allow
 p, admin,obj://config/users/{admin}/agents/{agent}/{key},read|write,allow
 p, admin,obj://config/services/aicc/settings,read|write,allow
+p, admin,obj://config/services/msg-center/settings,read|write,allow
 p, admin,obj://config/services/*,read,allow
 
 p, users,obj://config/boot/*, read,allow
@@ -502,7 +503,7 @@ g, bob, users
             .await
         );
         assert!(
-            !rbac::enforce(
+            rbac::enforce(
                 "alice",
                 "control-panel",
                 "obj://config/services/msg-center/settings",


### PR DESCRIPTION
## Summary
- Allow admin users to write `services/msg-center/settings`.
- Update the RBAC test expectation for msg-center settings writes.

## Intent
变更权限的意图是：利用 `buckycli` 动态更新 message tunnel 配置，以使 Jarvis 能正常工作。

## Validation
- `cargo test -p buckyos-api admin_can_write_aicc_settings`