### PR TITLE
新增 provider-driver 云更新详细设计文档

### DIFF
--- a/doc/aicc/README.md
+++ b/doc/aicc/README.md
@@ -18,6 +18,7 @@
 - `aicc-models-todo.md`：模型管理后续设计任务。
 - `aicc-upgrade-todo.md`：新 API 与模型体系升级设计任务。
 - `aicc改进.md`：AICC 改进方案记录。
+- `provider-driver-cloud-update-design.md`：provider-driver metadata 云更新详细设计。
 - `aicc_log1.html`：AICC 设计讨论和历史记录。
 
 ## 维护参考文档

--- a/doc/aicc/provider-driver-cloud-update-design.md
+++ b/doc/aicc/provider-driver-cloud-update-design.md
@@ -1,0 +1,952 @@
+# Provider Driver Metadata 云更新详细设计
+
+状态：Draft  
+适用版本：beta 2.2 breaking change，不做向前兼容  
+相关文档：
+
+- `doc/aicc/driver_metadata_schema.md`
+- `doc/aicc/aicc-models-mgr.md`
+- `doc/aicc/aicc_router.md`
+- `doc/aicc/aicc_provider修改.md`
+
+## 1. Overview
+
+服务名：
+
+- `provider-metadata-tech-service`：技术参数云服务，下文简称 A 服务。
+- `provider-metadata-ops-service`：运营参数云服务，下文简称 B 服务。
+
+本设计定义 provider-driver metadata 的云端维护、发布、客户端拉取和本地增量应用机制。A 服务负责相对稳定的技术事实与 key 字段，B 服务负责相对高频的运营参数，并可从 A 服务拉取技术参数后合并成客户端可直接消费的完整配置。客户端最终接收的发布格式保持为 `revision + providers[].models[]` 的 JSON 快照，供 AICC metadata resolver 生成 `ProviderInventory`、`ModelMetadata`、`logical_mounts`、`capabilities`、`pricing` 等运行时结构。
+
+## 2. Data Classification
+
+| 数据项 | 归属 | 分类 | 说明 |
+|---|---|---|---|
+| Provider 技术主数据 | A | Durable | `provider_driver`、`name`、`base_url`、provider key、协议族、默认 endpoint 等。 |
+| Model 技术主数据 | A | Durable | `model.id`、`original_provider`、`api_types`、`capabilities`、上下文长度、默认 logical mounts、技术 tags。 |
+| Pattern/defaults/variants/version_rules | A | Durable | driver metadata resolver 的规则输入。 |
+| Provider 模型选择规则 | A | Durable | 白名单、黑名单、按原厂/协议族/model id pattern 的选择规则、`model_nicks`。 |
+| 运营 overlay | B | Durable | provider/model 禁用、推荐权重、运营价格覆盖、展示优先级、灰度策略。 |
+| 发布 revision | A/B | Durable | 每次有效发布递增，客户端据此判断是否更新。 |
+| 编辑会话快照 | A/B | Durable | 进入编辑模式时保存，提交时用于 diff、影响范围分析和审计。 |
+| 变更日志 | A/B | Durable | 记录操作者、导入文档、diff、审批结果、发布 revision。 |
+| 导入更新计划 | A/B | Durable | 人或 AI 生成的可读文本，导入后成为待提交变更。 |
+| 聚合发布缓存 | A/B | Disposable | 从 RDB 物化出的 `revision + providers[]` JSON，可随时重建。 |
+| A 服务远端查询缓存 | B | Disposable | B 服务拉取 A 服务结果后的短期缓存，可在服务启动或发布后重建。 |
+| API HTTP cache metadata | A/B | Disposable | ETag、Last-Modified、压缩缓存。 |
+| WebUI 检索索引 | A/B | Disposable | 搜索加速索引，可由 durable data 重建。 |
+
+## 3. Storage Strategy
+
+结构化持久数据必须使用平台 RDB 实例，不绑定 sqlite、PostgreSQL 等具体后端。发布 JSON、预览结果和搜索索引是可丢弃缓存，由 RDB 中的实体和规则重建。
+
+对象型数据仅用于保存导入文本、diff 报告、测试用例草案等较大的审计附件；它们通过 object id 被 RDB 记录引用，不作为核心查询模型。
+
+## 4. Schema Definitions
+
+### Table: metadata_meta
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| key | TEXT PK | NO | | 元数据 key。 |
+| value | TEXT | NO | | 元数据 value。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+约束：
+
+- `schema_version` 必须存在。
+- `published_revision` 必须存在。
+
+### Table: providers
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| provider_key | TEXT PK | NO | | A 服务生成的稳定 provider key。 |
+| provider_driver | TEXT | NO | | AICC driver id，如 `openai`、`claude`、`google-gemini`、`fal`。 |
+| name | TEXT | YES | | 主流展示名，如 `OpenRouter`；不是用户创建的 provider instance 展示名。 |
+| base_url | TEXT | YES | | provider endpoint 匹配 key；为空时客户端按 `provider_driver` 取默认 endpoint。 |
+| provider_kind | TEXT | NO | `origin` | `origin` / `aggregator` / `compatible_proxy`。 |
+| protocol_family | TEXT | YES | | 协议族，如 `openai-compatible`。 |
+| enabled | INTEGER | NO | `1` | A 服务技术层是否发布。 |
+| owner_service | TEXT | NO | `A` | 字段主责服务，固定为 A。 |
+| extra | TEXT | YES | | JSON 扩展字段。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Indexes:
+
+- `idx_providers_driver` ON `providers(provider_driver)`。
+- `idx_providers_base_url` ON `providers(base_url)`。
+- `idx_providers_name` ON `providers(name)`。
+
+### Table: models
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| model_key | TEXT PK | NO | | 稳定主键，建议为 `<original_provider>:<model_id>` 的归一化 hash 或 slug。 |
+| model_id | TEXT | NO | | 原厂模型 id。 |
+| original_provider | TEXT | NO | | 原厂 provider key 或规范名；不同原厂允许相同 `model_id`。 |
+| provider_key | TEXT | YES | | 为空表示全局默认原厂 model meta；非空表示 provider 专属 model meta。 |
+| model_driver | TEXT | YES | | 可覆盖 `provider_driver`，用于聚合商上游归属。 |
+| api_types | TEXT | NO | `[]` | JSON array。 |
+| logical_mounts | TEXT | NO | `[]` | JSON array，支持当前 `model.logical_mounts` 通配符语法。 |
+| capabilities | TEXT | NO | `{}` | JSON object，对应 `ModelCapabilities` patch。 |
+| attributes | TEXT | YES | | JSON object，对应 `ModelAttributes`。 |
+| context_limits | TEXT | YES | | JSON object，如 `max_context_tokens`、`max_output_tokens`。 |
+| pricing | TEXT | YES | | JSON object，参考价格；动态 provider 价格优先。 |
+| exclude | INTEGER | NO | `0` | 技术层排除标记；黑名单模型仍发布但置 `exclude=true`。 |
+| extra | TEXT | YES | | JSON 扩展字段。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Indexes:
+
+- `idx_models_identity` ON `models(original_provider, model_id, provider_key)`。
+- `idx_models_provider` ON `models(provider_key)`。
+- `idx_models_original_provider` ON `models(original_provider)`。
+
+Constraints:
+
+- `original_provider + model_id + provider_key` 唯一。
+- `provider_key IS NULL` 的记录是全局默认 model meta。
+- provider 专属 model meta 只覆盖全局默认 meta，不自动成为白名单。
+
+### Table: model_patterns
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| pattern_key | TEXT PK | NO | | 稳定 pattern id。 |
+| scope_provider_key | TEXT | YES | | 为空表示全局 pattern；非空表示 provider 专属 pattern。 |
+| original_provider | TEXT | YES | | 限定原厂。 |
+| pattern | TEXT | NO | | `model.id` wildcard，`*` 为基础通配符。 |
+| priority | INTEGER | NO | | 数组顺序；越小越早匹配。 |
+| rule_patch | TEXT | NO | `{}` | 与 model meta 相同字段的 JSON patch。 |
+| enabled | INTEGER | NO | `1` | 是否启用。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Indexes:
+
+- `idx_patterns_scope_priority` ON `model_patterns(scope_provider_key, priority)`。
+
+### Table: provider_model_rules
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| rule_key | TEXT PK | NO | | 稳定 rule id。 |
+| provider_key | TEXT | NO | | 目标 provider。 |
+| rule_type | TEXT | NO | | `allow` / `deny` / `include_origin` / `exclude_origin` / `include_pattern` / `exclude_pattern`。 |
+| selector | TEXT | NO | | 原厂、协议族、model id 或 pattern。 |
+| priority | INTEGER | NO | | 同类规则顺序。 |
+| enabled | INTEGER | NO | `1` | 是否启用。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Indexes:
+
+- `idx_provider_model_rules_provider` ON `provider_model_rules(provider_key, priority)`。
+
+### Table: model_nicks
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| nick_key | TEXT PK | NO | | 稳定 nick id。 |
+| provider_key | TEXT | NO | | 目标 provider。 |
+| original_provider | TEXT | YES | | 原厂限制。 |
+| model_id | TEXT | NO | | 原始模型 id 或 pattern。 |
+| nick | TEXT | NO | | 下发给客户端的模型 id。 |
+| selector_type | TEXT | NO | `exact` | `exact` / `pattern`。 |
+| priority | INTEGER | NO | | 批量 nick 顺序。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Indexes:
+
+- `idx_model_nicks_provider` ON `model_nicks(provider_key, priority)`。
+
+Constraints:
+
+- `nick` 属于 key 性字段，由 A 服务管理。
+- 发布时 `models[].id` 使用 nick 后的 id；原 id 保存在 `source_model_id`。
+
+### Table: metadata_blocks
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| block_key | TEXT PK | NO | | 稳定 block id。 |
+| provider_key | TEXT | YES | | 为空表示全局 block。 |
+| block_type | TEXT | NO | | `defaults` / `variants` / `version_rules`。 |
+| content | TEXT | NO | | JSON content。 |
+| enabled | INTEGER | NO | `1` | 是否启用。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Indexes:
+
+- `idx_metadata_blocks_provider_type` ON `metadata_blocks(provider_key, block_type)`。
+
+### Table: ops_overlays
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| overlay_key | TEXT PK | NO | | 稳定 overlay id。 |
+| target_type | TEXT | NO | | `provider` / `model` / `pattern` / `defaults` / `variants` / `version_rules`。 |
+| target_key | TEXT | NO | | A 服务 key 或发布 key。 |
+| disabled | INTEGER | NO | `0` | B 服务是否禁用该对象。 |
+| ops_patch | TEXT | NO | `{}` | B 服务管理的运营字段 patch。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Indexes:
+
+- `idx_ops_overlays_target` ON `ops_overlays(target_type, target_key)`。
+
+Constraints:
+
+- `ops_patch` 不得包含 A 服务管理字段；发现污染字段时发布阶段丢弃该字段，不丢弃整条记录。
+
+### Table: edit_sessions
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| session_id | TEXT PK | NO | | 编辑会话 id。 |
+| service_role | TEXT | NO | | `A` / `B`。 |
+| operator_id | TEXT | NO | | 操作者账号。 |
+| base_revision | TEXT | NO | | 开始编辑时的发布 revision。 |
+| snapshot_object_id | TEXT | NO | | 快照对象 id。 |
+| status | TEXT | NO | `editing` | `editing` / `previewed` / `approved` / `published` / `discarded`。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+| updated_at | INTEGER | NO | | Unix timestamp ms。 |
+
+### Table: change_logs
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| change_id | TEXT PK | NO | | 变更 id。 |
+| service_role | TEXT | NO | | `A` / `B`。 |
+| operator_id | TEXT | NO | | 操作者账号。 |
+| from_revision | TEXT | NO | | 发布前 revision。 |
+| to_revision | TEXT | NO | | 发布后 revision。 |
+| summary | TEXT | NO | | 人类可读摘要。 |
+| diff_object_id | TEXT | NO | | diff 报告对象 id。 |
+| import_object_id | TEXT | YES | | 导入更新计划对象 id。 |
+| test_plan_object_id | TEXT | YES | | 生成的测试建议对象 id。 |
+| created_at | INTEGER | NO | | Unix timestamp ms。 |
+
+Object Type: `metadata_update_plan`
+
+- Description：人类或 AI 生成的更新计划文本。
+- Naming Convention：`metadata-update-plan/<change_id>/<file_name>`。
+- Content Format：UTF-8 YAML 或 Markdown 包裹 YAML。
+
+Object Type: `metadata_diff_report`
+
+- Description：提交前后差异、影响范围、被污染字段、生成测试建议。
+- Naming Convention：`metadata-diff-report/<change_id>.json`。
+- Content Format：JSON。
+
+## 5. Schema Version
+
+初始 `schema_version = 1`，存储在 `metadata_meta` 表：
+
+```text
+key = schema_version
+value = 1
+```
+
+任意 RDB 表结构、发布 JSON 语义或导入文本 schema 发生不兼容变化时递增 schema version。provider-driver metadata 自身的业务 revision 与 schema version 分离：schema version 表示存储格式，published revision 表示配置内容版本。
+
+## 6. Upgrade Compatibility Strategy
+
+当前版本处于 beta 2.2 breaking change 阶段，云服务可按 No-compat 处理首次落地数据；正式发布后采用以下策略：
+
+| 数据项 | 策略 | 说明 |
+|---|---|---|
+| `metadata_meta` | Additive-only | 新 key 可增加，已有 key 语义冻结。 |
+| `providers` | Migration | key 字段语义冻结，新增字段走 migration。 |
+| `models` | Migration | `model_id`、`original_provider`、`provider_key` 语义冻结。 |
+| `model_patterns` | Additive-only | 新 rule 字段放入 `rule_patch` 或新增列。 |
+| `provider_model_rules` | Additive-only | 新 rule type 可增加，旧 rule type 语义冻结。 |
+| `model_nicks` | Migration | nick 会影响客户端 key，修改语义必须显式迁移。 |
+| `metadata_blocks` | Migration | `defaults/variants/version_rules` schema 改动需要迁移。 |
+| `ops_overlays` | Additive-only | 新运营字段写入 `ops_patch`。 |
+| `edit_sessions` | Rebuild | 未完成编辑会话可在大版本升级时丢弃或重新打开。 |
+| `change_logs` | Additive-only | 审计日志只追加，不修改历史。 |
+
+Migration 在服务启动时执行。失败时服务进入只读模式，继续提供上一版已发布缓存；管理端写入暂停，避免生成不可审计的发布。
+
+## 7. Extensibility Rules
+
+冻结字段：
+
+- Provider key：`provider_key`、`provider_driver`、`base_url`、`name`。
+- Model key：`model_id`、`original_provider`、`provider_key`。
+- Nick key：`nick`、`model_id`、`provider_key`。
+- Revision：所有已发布 revision 不可复用。
+
+可扩展字段：
+
+- `extra`、`attributes`、`capabilities`、`pricing`、`ops_patch` 可增加子字段。
+- `metadata_blocks.content` 可按 block type 增加字段，但必须更新 block schema 文档。
+- `provider_model_rules.rule_type` 可新增枚举值，但旧值语义不可改变。
+
+清理规则：
+
+- provider 专属 model metadata 如果和对应全局默认原厂 metadata 等价，提交前应自动删除该专属记录，直接引用全局默认 metadata。
+- B 服务 overlay 里出现 A 服务字段时，发布阶段丢弃污染字段并记录 warning，不丢弃整个 provider/model。
+
+## 8. Query Patterns
+
+| 查询 | 频率 | 索引 |
+|---|---|---|
+| 按 revision 获取发布 JSON | 高 | `metadata_meta.published_revision` + 发布缓存。 |
+| 按 provider_driver 列 provider | 高 | `idx_providers_driver`。 |
+| 按 base_url/name 匹配 provider | 高 | `idx_providers_base_url`、`idx_providers_name`。 |
+| 按 provider 列 model | 高 | `idx_models_provider`。 |
+| 按原厂列全局 model | 高 | `idx_models_original_provider`。 |
+| 合成某 provider 的最终 models | 中 | `idx_provider_model_rules_provider`、`idx_models_identity`、`idx_model_nicks_provider`。 |
+| 按 pattern 顺序匹配 model | 中 | `idx_patterns_scope_priority`。 |
+| B 合并 A 发布快照 | 中 | `idx_ops_overlays_target`。 |
+| WebUI 搜索 provider/model | 高 | RDB 索引 + 可丢弃搜索索引。 |
+| 变更审计查询 | 低 | `change_logs.created_at` 可后续加索引。 |
+
+发布 JSON 构建允许全量扫描，因为配置更新频率低。客户端 GET 路径必须读发布缓存，不应实时 JOIN 生成。
+
+## 9. 架构与职责边界
+
+### 9.1 A 服务职责
+
+A 服务是技术事实源，负责：
+
+- 汇总各 provider-driver 的技术 metadata。
+- 管理 provider key、`provider_driver`、`base_url`、`name` 等 key 字段。
+- 管理全局默认原厂 model meta。
+- 管理 provider 专属 model meta。
+- 管理 patterns、defaults、variants、version_rules。
+- 管理白名单、黑名单、原厂/协议族/model pattern 选择规则。
+- 管理 model nick 规则。
+- 生成 A 服务自身的发布 JSON。
+
+A 服务只开放读取发布配置的公开 GET API。更新配置需要登录账号和 `metadata.update` 授权。
+
+### 9.2 B 服务职责
+
+B 服务是运营 overlay 源，负责：
+
+- 保存 A 服务查询 URL。
+- 定期或按需拉取 A 服务发布 JSON。
+- 在本地 overlay 中管理运营参数。
+- 禁用特定 provider/model/pattern/rule。
+- 合并 A 技术参数与 B 运营参数，生成客户端完整发布 JSON。
+- 生成 B 服务自身的发布 revision。
+
+B 服务可以浏览 A 管理的 key 字段，但不得修改。B 服务 overlay 只对自己负责的字段生效。
+
+### 9.3 客户端职责
+
+客户端负责：
+
+- 保存 B 服务 URL，支持默认占位 URL 和用户配置 URL。
+- 以本地当前 revision 调用云服务 GET API。
+- 校验发布 JSON schema、revision、可选签名和缓存头。
+- 用三方合并算法把远端更新应用到本地配置。
+- 不覆盖用户手工写入字段和本机运行统计字段。
+- 原子替换 `base` 与 `local` 配置。
+
+## 10. 字段所有权
+
+| 字段/对象 | A 服务 | B 服务 | 客户端 |
+|---|---|---|---|
+| `provider_key` | 写 | 读 | 读 |
+| `provider_driver` | 写 | 读 | 读 |
+| `provider.name` | 写 | 读 | 匹配与展示 |
+| `provider.base_url` | 写 | 读 | 以 endpoint 匹配 |
+| `model.id` | 写 | 读 | 读 |
+| `model.source_model_id` | 写 | 读 | 读 |
+| `original_provider` | 写 | 读 | 读 |
+| `nick` | 写 | 读 | 读 |
+| `api_types` | 写 | 读，可禁用 | 读 |
+| `logical_mounts` | 写 | 可 overlay 运营目录 | 本地可 overlay |
+| `capabilities` | 写 | 读 | 读 |
+| `context_limits` | 写 | 读 | 读 |
+| `pricing.reference` | 写 | 可覆盖运营价 | 可结合动态价和汇率 |
+| `routing_weight` | 读 | 写 | 本地可 overlay |
+| `disabled` | 写技术禁用 | 写运营禁用 | 本地可禁用 |
+| `latency/reliability` | 不写 | 不写 | 本机统计写 |
+| 用户自定义 provider/model 字段 | 不写 | 不写 | 写 |
+
+污染处理：
+
+- A 发布 JSON 中出现 B-only 字段，B 合并时丢弃这些字段并记录 warning。
+- B overlay 中出现 A-only 字段，B 发布时丢弃这些字段并记录 warning。
+- 客户端远端更新中出现 local-only 统计字段，客户端丢弃这些字段。
+
+## 11. 发布 JSON
+
+### 11.1 顶层格式
+
+客户端 API 返回格式：
+
+```json
+{
+  "schema_version": 1,
+  "revision": "20260708.000001",
+  "generated_at": 1783500000000,
+  "source": {
+    "service_role": "B",
+    "tech_revision": "20260708.000001",
+    "ops_revision": "20260708.000004"
+  },
+  "providers": []
+}
+```
+
+`revision` 必须单调递增，推荐格式：
+
+```text
+<utc_yyyymmddHHMMSS>.<sequence>
+```
+
+同一毫秒内多次发布时递增 sequence。服务端每次成功发布必须同步更新 revision 和 ETag。
+
+### 11.2 Provider 格式
+
+```json
+{
+  "provider_key": "openrouter",
+  "provider_driver": "openai-compatible",
+  "name": "OpenRouter",
+  "base_url": "https://openrouter.ai/api/v1",
+  "provider_kind": "aggregator",
+  "protocol_family": "openai-compatible",
+  "model_select_rules": [
+    {
+      "rule_type": "include_origin",
+      "selector": "openai"
+    }
+  ],
+  "model_nicks": [
+    {
+      "id": "gpt-5.2",
+      "nick": "openai/gpt-5.2"
+    }
+  ],
+  "defaults": {},
+  "patterns": [],
+  "variants": [],
+  "version_rules": [],
+  "models": []
+}
+```
+
+客户端创建 provider instance 时：
+
+- 如果用户配置了 endpoint，优先用 endpoint 匹配 `provider.base_url`。
+- 如果没有 endpoint，认为 endpoint 是 `provider_driver` 的原厂默认 endpoint。
+- 如果预置的是非原厂 endpoint，如 OpenRouter，客户端应以 `provider.name` 展示 provider Type，并以 `provider.name` 或 `base_url` 匹配参数。
+- `provider_driver` 只表示接口协议或 driver，不表示最终 UI 上的主流 provider Type。
+
+### 11.3 Model 格式
+
+```json
+{
+  "id": "openai/gpt-5.2",
+  "source_model_id": "gpt-5.2",
+  "original_provider": "openai",
+  "provider": "openrouter",
+  "model_driver": "openai",
+  "api_types": ["llm.chat"],
+  "logical_mounts": ["llm.gpt-standard", "llm.openai.gpt-5-2"],
+  "capabilities": {
+    "streaming": true,
+    "tool_call": true,
+    "json_schema": true,
+    "vision": true,
+    "max_context_tokens": 128000,
+    "max_output_tokens": 16384
+  },
+  "pricing": {
+    "input": { "price": 1.25, "currency": "USD", "unit": "1M_tokens" },
+    "output": { "price": 10.0, "currency": "USD", "unit": "1M_tokens" },
+    "source": "metadata_reference"
+  },
+  "routing": {
+    "weight": 1.0,
+    "cost_class": "mid",
+    "latency_class": "mid",
+    "quality_score": 0.9
+  },
+  "exclude": false
+}
+```
+
+规则：
+
+- `id` 是客户端看到的 provider model id；存在 nick 时使用 nick。
+- `source_model_id` 是原始模型 id。
+- `original_provider` 必填。
+- `provider` 为空时表示全局默认原厂 model meta；在最终 provider 发布列表里应填当前 provider key。
+- 黑名单模型仍出现在 `models` 中，但 `exclude=true`。
+- 价格是参考价或运营价；如果 provider 运行时可动态返回价格，以 provider 返回价格为准。
+- 汇率不在云服务处理，由客户端统一处理。
+
+## 12. 合成规则
+
+### 12.1 A 服务合成 provider
+
+对每个 provider：
+
+1. 读取 provider 技术主数据。
+2. 以所有全局默认原厂模型为全集。
+3. 应用白名单和黑名单规则。
+4. 选择命中的全局默认 model meta。
+5. 如存在 provider 专属 model meta，则覆盖全局默认 meta。
+6. 应用 model nick，重写 `models[].id`，保留 `source_model_id`。
+7. 对 patterns/defaults/variants/version_rules 执行同样的 provider 专属覆盖和 nick 重写。
+8. 黑名单命中的模型保留在列表里并设置 `exclude=true`。
+9. 删除与全局默认 meta 等价的 provider 专属 meta。
+
+未配置黑白名单的 provider 视为支持所有全局默认模型。provider 专属 model meta 不作为白名单。
+
+### 12.2 B 服务合并 A 发布
+
+B 服务合并流程：
+
+1. 读取本地 A 服务 URL。
+2. 拉取 A 发布 JSON；如果 A revision 未变化且本地 A 缓存可用，可直接使用缓存。
+3. 校验 A 发布 JSON schema 和 revision。
+4. 丢弃 A JSON 中不属于 A 的污染字段。
+5. 对 provider/model/pattern/block 应用本地 `ops_overlays`。
+6. 对 B 禁用的 provider，最终发布不包含该 provider。
+7. 对 B 禁用的 model，最终发布不包含该 model；如需要保留诊断，可在管理 API 中可见，不下发客户端。
+8. 对 B 禁用的 pattern/defaults/variants/version_rules，发布时移除对应项。
+9. 生成 B 发布 JSON、revision、ETag 和缓存。
+
+如果单个 provider 或 model 合并失败，只跳过该对象并记录 warning；不得因为一条污染参数丢弃整个发布文档。
+
+## 13. 云服务 API
+
+### 13.1 公开 GET API
+
+```http
+GET /v1/provider-driver-metadata?revision=<client_revision>&cursor=<cursor>&limit=<limit>
+Accept-Encoding: br, gzip
+If-None-Match: "<etag>"
+```
+
+响应：无需更新
+
+```json
+{
+  "status": "not_modified",
+  "revision": "20260708.000001"
+}
+```
+
+响应：完整或分批更新
+
+```json
+{
+  "status": "ok",
+  "revision": "20260708.000002",
+  "batch": {
+    "cursor": null,
+    "next_cursor": "provider:openai:200",
+    "done": false
+  },
+  "providers": []
+}
+```
+
+最后一批：
+
+```json
+{
+  "status": "ok",
+  "revision": "20260708.000002",
+  "batch": {
+    "cursor": "provider:openai:200",
+    "next_cursor": null,
+    "done": true
+  },
+  "providers": []
+}
+```
+
+要求：
+
+- 配置量小的时候应一次返回。
+- 支持 `gzip` 和 `br`。
+- 支持 `ETag`、`Cache-Control`、`Last-Modified`。
+- GET 权限全开放，但要有常规防攻击措施：限速、请求大小限制、分页上限、IP 风险控制。
+
+### 13.2 管理 API
+
+管理 API 需要账号登录和 `metadata.update` 授权。
+
+```http
+POST /v1/admin/edit-sessions
+POST /v1/admin/edit-sessions/{session_id}/import-plan
+POST /v1/admin/edit-sessions/{session_id}/preview
+POST /v1/admin/edit-sessions/{session_id}/approve
+POST /v1/admin/edit-sessions/{session_id}/publish
+POST /v1/admin/edit-sessions/{session_id}/discard
+GET  /v1/admin/change-logs
+GET  /v1/admin/providers
+GET  /v1/admin/models
+```
+
+B 服务额外提供：
+
+```http
+GET  /v1/admin/tech-source
+PUT  /v1/admin/tech-source
+POST /v1/admin/tech-source/refresh
+```
+
+`tech-source` 保存 A 服务查询 URL 和最近成功同步的 A revision。
+
+## 14. WebUI 设计
+
+### 14.1 通用模式
+
+A/B 服务后台 WebUI 默认是浏览模式。增删改是高风险操作，必须显式切换到编辑模式。
+
+进入编辑模式：
+
+1. 保存当前发布状态快照。
+2. 创建 `edit_session`。
+3. UI 顶部显示 base revision、操作者和编辑状态。
+
+退出编辑模式：
+
+1. 对编辑后状态和快照做 diff。
+2. 展示影响范围：provider 数、model 数、patterns/defaults/variants/version_rules 数、逻辑目录影响、API type/capability 影响。
+3. 导出 diff 文本，供人或 AI 分析核实。
+4. 生成测试用例建议。
+5. 二次确认后写 change log 并发布。
+
+### 14.2 A 服务 WebUI
+
+必须支持：
+
+- 添加原厂 provider。
+- 添加全局默认原厂 model meta。
+- 以已有 provider/model 为模板创建新对象。
+- 编辑 patterns/defaults/variants/version_rules。
+- 添加聚合模型中间商，如 OpenRouter。
+- 从原厂列表、原厂模型列表选择模型构造聚合 provider。
+- 批量 nick：加前缀、加后缀、替换片段、pattern rewrite。
+- 批量选择：按厂商、协议族、api_type、capability、model.id 模糊匹配。
+- 逻辑目录管理：目录树和面包屑浏览，批量添加模型到目录，支持一个模型多个目录。
+- api_type 管理。
+- capabilities 管理。
+- 删除/新增全局 model meta 前显示受影响 provider 列表。
+
+### 14.3 B 服务 WebUI
+
+必须支持：
+
+- 配置 A 服务 URL。
+- 查看 A revision 与 B revision。
+- 浏览 A 管理字段，但这些字段只读。
+- 为 provider/model/pattern/block 增加运营 overlay。
+- 禁用 provider/model。
+- 批量调整运营价格、routing weight、推荐级别。
+- 查看污染字段 warning。
+- 预览最终下发给客户端的发布 JSON。
+
+## 15. 导入文本格式
+
+导入文本使用人类可读 YAML。文件可以由人编辑，也可以由 AI 生成。WebUI 导入后，应把各条 action 分发到对应 UI 组件，进入待提交状态，而不是直接发布。
+
+```yaml
+schema_version: 1
+kind: provider_metadata_update_plan
+target_service: A
+title: add openrouter gpt models
+author: human-or-ai
+base_revision: "20260708.000001"
+
+actions:
+  - action: upsert_provider
+    provider_key: openrouter
+    provider_driver: openai-compatible
+    name: OpenRouter
+    base_url: https://openrouter.ai/api/v1
+    provider_kind: aggregator
+
+  - action: include_models
+    provider_key: openrouter
+    selector:
+      original_provider: openai
+      model_id_pattern: "gpt-*"
+
+  - action: set_model_nick
+    provider_key: openrouter
+    selector:
+      original_provider: openai
+      model_id_pattern: "gpt-*"
+    rewrite:
+      prefix: "openai/"
+
+  - action: override_model_meta
+    provider_key: openrouter
+    source:
+      original_provider: openai
+      model_id: gpt-5.2
+    patch:
+      pricing:
+        input:
+          price: 1.4
+          currency: USD
+          unit: 1M_tokens
+
+  - action: set_logical_mounts
+    selector:
+      original_provider: openai
+      model_id_pattern: "gpt-5*"
+    mode: add
+    logical_mounts:
+      - llm.gpt-standard
+
+  - action: disable_model
+    provider_key: openrouter
+    selector:
+      id: openai/gpt-4.1-preview
+    reason: preview model is not recommended
+```
+
+支持的 action：
+
+- `upsert_provider`
+- `disable_provider`
+- `upsert_model_meta`
+- `override_model_meta`
+- `delete_provider_model_meta`
+- `include_models`
+- `exclude_models`
+- `set_model_nick`
+- `upsert_pattern`
+- `upsert_defaults`
+- `upsert_variant`
+- `upsert_version_rule`
+- `set_logical_mounts`
+- `set_api_types`
+- `set_capabilities`
+- `set_pricing`
+- `set_ops_overlay`
+- `disable_model`
+
+导入校验：
+
+- `target_service=A` 的文档不得包含 B-only action。
+- `target_service=B` 的文档不得修改 A-only key 字段。
+- 所有 selector 必须可预览命中结果。
+- 任何批量 action 在提交前必须显示命中数量和样例。
+
+## 16. 客户端更新流程
+
+### 16.1 本地文件分层
+
+客户端维护两份基础状态：
+
+- `base`：上次成功应用云更新后的基础配置。
+- `local`：当前系统生效配置，包含用户修改和本机统计。
+
+下载得到：
+
+- `remote`：云端新 revision 对应的发布配置。
+
+### 16.2 三方合并
+
+流程：
+
+1. 对 `base` 和 `local` 取快照。
+2. 下载 `remote`。
+3. 校验 `remote`。
+4. 计算 `diff_local = diff(local, base)`。
+5. 计算 `diff_remote = diff(remote, base)`。
+6. 从 `local` 拷贝出 `merged`。
+7. 逐条应用 `diff_remote`：
+   - 如果同一路径出现在 `diff_local` 中，说明用户改过，跳过该字段。
+   - key 性字段永远不改。
+   - local-only 统计字段永远不改。
+   - remote 新增字段在 local 未改过时补充。
+   - remote 删除对象时，如果用户只改了统计字段，不阻止删除。
+8. 原子写入新的 `base = remote` 和 `local = merged`。
+9. 更新本地 revision。
+
+注意：概要中的“用 remote 替换 local”应理解为“以 remote diff 为输入生成 merged local 后，原子替换本地生效配置”，不能直接覆盖用户配置。
+
+### 16.3 数组 diff 规则
+
+数组必须有元素身份 key：
+
+| 数组 | identity |
+|---|---|
+| `providers[]` | `provider_key`，缺失时用 `provider_driver + base_url/name`。 |
+| `models[]` | `id`。 |
+| `patterns[]` | `pattern_key` 或 `pattern`。 |
+| `variants[]` | `name`。 |
+| `version_rules[]` | `rule_key` 或 `family + tier + model_pattern`。 |
+| `logical_mounts[]` | 字符串值。 |
+| `api_types[]` | 字符串值。 |
+| `capabilities` | object path。 |
+
+数组顺序变化本身是 diff。数组元素顺序变化不能阻止 remote 修改该元素属性；数组元素属性变化也不能阻止 remote 调整数组顺序。但如果用户修改了某个元素的非统计字段，remote 删除该元素时应保留该元素，除非 remote 明确是安全删除且用户只改了 local-only 统计字段。
+
+### 16.4 增删边界
+
+- 用户手工添加 provider/model：remote 不得删除；remote 可补充缺失字段或数组项。
+- 用户物理删除 provider/model：remote 不得再添加回来。
+- 用户只是设置删除标记：remote 可更新其属性，但保留删除标记。
+- 用户手工添加或删除某字段/数组项：remote 不更新对应字段/数组项，但可更新同数组其他项。
+- 本机统计字段变化不阻止 remote 删除对应 provider/model。
+
+### 16.5 Provider 信息页功能
+
+客户端 provider 信息页提供：
+
+- `恢复配置`：把该 provider instance 中用户编辑过的字段还原成 base。执行前展示将改变的字段和风险提示。
+- `导出配置`：把 provider instance 配置导出为可读文本，可作为新建自定义 provider 的模板。
+
+## 17. 自定义 Provider 流程
+
+用户在客户端添加自定义 provider：
+
+1. 输入 provider Type 和 endpoint。
+2. 如果 endpoint 匹配 `provider.base_url`，启用对应云配置。
+3. 如果没有 endpoint，则按 provider Type 的原厂默认 endpoint 匹配。
+4. 如果匹配不到：
+   - 提示风险。
+   - 提供高级配置向导。
+   - 可导入文本计划。
+   - 可调用 provider `/models` 获取模型列表，并把返回列表作为白名单候选。
+   - 提供 nick 编辑器，把返回模型 id 匹配到原厂模型 meta。
+
+OpenRouter 示例：
+
+- `provider.name = OpenRouter`
+- `provider.base_url = https://openrouter.ai/api/v1`
+- `provider.provider_driver = openai-compatible` 或当前实现确认后的 driver id
+- UI provider Type 展示 `OpenRouter`
+- 实际调用协议使用 OpenAI-compatible driver
+
+## 18. 缓存、压缩与可用性
+
+服务端：
+
+- 发布后生成不可变发布缓存。
+- GET API 优先返回缓存。
+- 支持 `ETag`、`If-None-Match`、`Cache-Control`。
+- 支持 gzip/br。
+- B 服务拉取 A 服务失败时，可继续使用最近一次成功 A 缓存，并在管理端提示 stale。
+- 如果当前 RDB 数据损坏，公开 GET API 可继续提供上一版发布缓存；管理写入暂停。
+
+客户端：
+
+- 网络失败时继续使用本地配置。
+- remote schema 校验失败时丢弃 remote，保留现有 base/local。
+- 分批下载未完成时不得应用。
+- 只有所有 batch 校验完成后才进入三方合并。
+
+## 19. 安全与权限
+
+公开 GET：
+
+- 无认证。
+- 限速、防爬、请求参数长度限制、分页上限。
+- 只返回公开 metadata，不返回账号、密钥、内部备注、编辑日志。
+
+管理端：
+
+- 需要账号系统认证。
+- 更新配置需要 `metadata.update` 权限。
+- 发布需要二次确认。
+- 所有发布写入 `change_logs`。
+- 可选增加签名：发布 JSON 中保留 `signature` envelope；客户端可按策略启用校验。
+
+## 20. 对接 AICC
+
+云端发布结果落到客户端后，应进入当前 AICC driver metadata 体系：
+
+```text
+remote publish JSON
+-> $BUCKYOS_ROOT/etc/aicc/driver_metadata/remote_cache/<driver>.json 或等价缓存
+-> metadata_resolver
+-> ProviderInventory
+-> ModelRegistry::apply_inventory()
+-> logical_mounts/default items/auto admission
+-> ModelRouter/ModelScheduler
+```
+
+需要保持的现有约束：
+
+- provider 自发现只负责模型 id。
+- driver metadata resolver 负责能力、挂载、variant、成本 fallback。
+- unknown model 走 conservative fallback。
+- `ModelCapabilities` 是能力真相源。
+- `logical_mounts` 受 `LogicalModelDefinition.min_line` admission 约束。
+
+## 21. 验证计划
+
+单元测试：
+
+- A 服务 provider/model/rule 合成。
+- provider 专属 model meta 覆盖全局 meta。
+- 专属 meta 等价时自动删除。
+- nick 后 `models[].id` 重写和 `source_model_id` 保留。
+- 黑名单模型发布为 `exclude=true`。
+- patterns 顺序匹配。
+- B 服务污染字段丢弃。
+- B 服务禁用 provider/model 后不下发。
+- revision 递增与 ETag 更新。
+
+客户端测试：
+
+- `not_modified` 不更新。
+- 单 batch 更新。
+- 多 batch 完整后再应用。
+- 三方合并不覆盖用户字段。
+- 本机统计字段不被 remote 覆盖。
+- 用户物理删除对象不被 remote 添加回来。
+- 数组顺序 diff 和元素属性 diff 互不误伤。
+- remote 删除对象时，本机统计字段变化不阻止删除。
+
+集成测试：
+
+- B 从 A 拉取并合并发布。
+- 客户端拉取 B 发布后 AICC `models.list` 可看到新 provider/model。
+- `logical_mounts`、`api_types`、`capabilities`、`pricing` 正确进入 `ProviderInventory`。
+- OpenRouter 以 `provider.name` 展示 provider Type，调用 driver 使用 OpenAI-compatible。
+- 损坏 A 缓存不影响 B 上一版发布 GET。
+
+## 22. 落地顺序
+
+1. 固化发布 JSON schema 和本地 remote cache 路径。
+2. 实现 A 服务 RDB schema、合成器和公开 GET API。
+3. 实现 B 服务 A URL 配置、A 拉取缓存、overlay 合并器和公开 GET API。
+4. 实现 A/B WebUI 浏览模式、搜索和详情页。
+5. 实现编辑模式、快照、diff、二次确认和 change log。
+6. 实现导入文本计划。
+7. 客户端实现 revision 拉取、分批下载和三方合并。
+8. 对接 AICC metadata resolver reload。
+9. 补齐验收测试和回滚策略。
+
+## 23. 风险与待确认
+
+待确认：
+
+- `provider_driver = openai-compatible` 是否作为正式 driver id，还是继续使用 `openai` 表示 OpenAI-compatible 协议。
+- 发布 JSON 是否按 provider_driver 拆分落入现有 `$BUCKYOS_ROOT/etc/aicc/driver_metadata/remote_cache/<driver>.json`，还是新增聚合缓存文件后由 resolver 拆分。
+- B 服务运营字段的首版最小集合：价格覆盖、routing weight、禁用、展示优先级是否足够。
+- `defaults` 和 `variants` 当前不支持数组式匹配规则的问题，需要在 schema 和 resolver 中补齐。
+
+主要风险：
+
+- provider/model key 设计不稳定会导致客户端三方合并误判。
+- nick 会改变客户端看到的 model id，必须在 diff 和 trace 中始终保留 `source_model_id`。
+- 聚合商 provider 的白名单可能来自 `/models` 动态返回，必须和原厂 meta 匹配失败场景一起设计 UI。
+- 客户端合并算法复杂，尤其是数组顺序和元素删除，需要独立测试覆盖。
+- A/B 字段所有权如果没有机器校验，长期会产生污染字段。


### PR DESCRIPTION
## 文档意图

添加provider-driver云更新服务设计文档，为动态添加更新模型/provider做准备

## 主要改动

- 新增 doc/aicc/provider-driver-cloud-update-design.md。
- 在 doc/aicc/README.md 中补充该文档入口。
- 明确 A 服务负责技术事实和 key 字段，B 服务负责运营 overlay 与最终客户端发布。
- 定义 provider/model/pattern/defaults/variants/version_rules 等持久数据管理方式。
- 定义公开 GET API、管理 API、发布 revision、缓存压缩、污染字段处理和客户端三方合并流程。
- 记录后续实现风险和待确认点，尤其是 defaults / ariants / ersion_rules 的细化 schema。

## 验证

- 本次只新增和索引设计文档，未修改运行时代码。
- 已检查文档标题层级和 git diff。
- 未运行 cargo test / uckyos-build。

## 提示词

<details>
<summary>展开查看</summary>

<pre>
下面是对`provider-driver云更新`的概要设计，你用中文生成一份详细设计文档

```
provider-driver云更新设计:

# 目标
	实现各模型厂商的`provider-dirver metadata`云更新
	
# 概要设计

1. 分两个云服务：A: 一个配置技术上的参数（相对固定，更新频率低），B: 一个配置运营上的参数（更新频率相对高）
	* 你汇总各个provider-driver的信息，还有下面提到的新增字段
	* B服务接受一个A服务的查询URL，并向A查询得到技术参数，再和自己本地的运营参数合并得到完整配置信息，可以向客户端提供完整的查询服务；A服务只提供自己保存参数的查询服务
2. 两个云服务在生产环境上分别部署和管理，需要账号系统管理`更新配置`授权，get配置权限全开放（只做常规的防攻击防御）
3. B服务地址在客户端可配置，并有默认值（先占位，后面再填写正式URL）
4. 客户端依据一个版本号（递增，可以用一个时间戳和一个递增序号）识别是否需要更新，服务端更新配置要同步更新版本号
5. `provider-dirver metadata`信息主要分两个维度（每个维度内部是否再细分视情况而定）：
	* model-meta信息：目前`provider-dirver metadata`中的models列表，增加一些属性：
		* original_provider: 该模型的原厂商，这个是必填项，不同原厂的模型可以有相同的model.id；通常原厂商会支持它自己提供的所有模型，但也可以通过黑名单禁用其中部分
		* provider: 它属于哪个provider；为空时全局默认model-meta，也就是原厂model-meta
		* 模型限长: 目前好像没有，如果没有配置用默认值
		* 模型单价：&lt;price, 币种&gt;，如果provider本身服务商能动态返回价格，以provider返回价格为准；客户端会通过不同渠道在不同场景处理币种，汇率问题由客户端统一处理
	* patterns: 是一组model.id的通配方式，属性和model-meta相同，patterns数组有先后顺序，表达匹配优先级
	* provider信息：目前`provider-dirver metadata`中除models列表以外的其他信息，增加一些属性：
		* base_url: 用来区分不同的provider，用来匹配厂商，缺省时由客户端按`provider_driver`字段取默认值
		* name: 跟base_url一样用处，可以为空，只是取个主流名，不是`provider instance`的展示名字；
			* 在客户端推荐provider时，用户没有选择接口协议，最后的Type就可以展示这个字段；如OpenRouter采用的provider_driver是openai，但最后展示的type如果是openai会让用户有点迷惑
		* model列表选取规则：黑名单，白名单，用来定义怎样构造该provider最终json格式的`providers[N].models`列表
			* 更可以以模型原厂商/协议族为单位批量增减（如：不支持OpenAI的全部模型；只支持OpenAI某系列模型），也可以model.id等模糊匹配
			* 如果支持的模型需要更新部分参数，应该增加provider专属的`model-meta`；UI上操作时，可以全局默认meta（如果有的话）为模板修正；
			* 如果在`model-meta信息`中有本provider专属的model-meta，优先用专属信息，否则用全局默认信息
			* 黑白名单以所有全局默认模型为全集，没有配置黑白名单的provider视为支持所有全局model，provider专属model-meta不应当作白名单使用，它只是覆盖全局model-meta
			* 在黑名单里的模型应该出现在models列表中，只是要置exclude字段为true
		* model_nick列表：[&lt;id, nick&gt;]某provider可能为部分模型重命名了，在设定时可以批量设置（比如：为OpenRouter模型列表取别名时，选中openai里一批模型，给它们加`openai/`前缀；再选中gemini同样加前缀，也可以添加其他简易操作）；客户端get到的models列表中，应该以它为id
		* patterns是以通配形式表达的特殊的model.id
	* defaults、variants、version_rules也应该有对应的管理
	* key性质的字段(provider.name, base_url, model.id, original_provider, nick等)都由A服务管理，B服务可以浏览，并为它们赋予自己管理的属性值，但可以禁用特定provider/model，禁用后下发的配置将不包括它们相关的内容
6. 两个云服务保存数据的格式可以按数据库形式，但对客户端提供的API应当按照当前客户端需求的json格式返回，更新频率应该不高，可以在服务启动和配置更新时从数据库加载并更新缓存
7. 客户端更新配置时，以客户端当前revision为参数调用服务端API，服务端对比服务端revision后，如果不需要更新，返回`无需更新`，否则，服务端把信息组织好了以后，可分批返回，最后一批应返回标识；量少尽量一次返回
	```
	{
		revision: N,
		providers: [{
			  ...provider属性
			  &quot;models&quot;: [
				...model属性
			  ]
		},
		...
		]
	}
	```
	两个服务各自从本地信息组织后的数据结构都应该是上述结构，B服务从A服务查到的参数添加进对应的位置进行合并，所以，返回给客户端的结构也应该是上述样子；要注意A和B管理的参数列表，如果参数被污染(如：B从本地服务读到A负责的参数，或者从A读到B负责的参数)，则丢弃该参数，不应丢弃全部数据
8. 云服务API通信支持压缩，也支持缓存
9. 两个云服务各自应该有个后台webui
	* 添加原厂provider和model（也就是全局默认的原厂`model meta`）,要逐个参数编辑，可以选择一个已有对象作为模板进行修改
		* 通常还要给它们编辑patterns/defaults/variants/version_rules这些参数
	* 添加类似OpenRouter的聚合模型中间商，它可能支持一个或多个原厂商的全部或部分模型；
		* 它的编辑可以通过从原厂列表和原厂模型列表中选择对象来构造；
		* 选择后，可以原厂参数为模板修改其中部分属性值，这就可能构造该provider专属的`model meta`；
		* 可以为选中的模型取别名，通常是统一给原模型id加前缀或者后缀
		* patterns/defaults/variants/version_rules这些参数通常也跟model一样也是引用原厂配置（可以修改参数成为专属配置）；
			* 它们的模型id被重命名nick，所以这些属性的model.id匹配规则也同样需要类似nick的方式重写；但目前defaults和variants两个属性还没有定义匹配规则的属性，特别是defaults不支持数组，这需要额外支持
			* 它们也应该跟models一样被管理，被重命名nick，只是它们各自的属性列表不同
	* 方便添加/更新配置，应支持批量（多选，按厂商，按协议族，按model.id模糊匹配等）操作
	* 注意删除和添加全局模型meta信息时可能会影响很多的provider；
	* provider列表和models列表，提供丰富的检索功能和编辑功能
	* 逻辑目录管理，以目录树和面包屑两种方式浏览和编辑；
		* 可以为一批模型添加到某个逻辑目录，也可以把一个模型添加到多个逻辑目录
		* 还可以改变目录结构，通常只为模型原厂添加特指的目录（比如: llm.openai）；模型中间商(如OpenRouter)的各模型分别放到其原厂目录下，不添加叫做openrouter的目录
		* 支持目前model.logical_mounts字段中的通配符语法
	* api_type管理，可以添加，删改比较少，可以标识一批模型支持某个api_type，也可以标识一个模型添加多个api_type
	* capabilities管理，可以添加，删改较少，可以标识一批模型支持某个capabilities，也可以标识一个模型添加多个capabilities
	***编辑(增删改)是一个高风险操作，默认是浏览模式，不可编辑，要提供一个按钮切换浏览和编辑模式，编辑模式开始时要保存当时状态的快照，编辑模式结束要对编辑后的状态和编辑器快照做对比，提示影响的范围（展示方案要能直观地看到最终的变更事实），可以导出一个文本用以让人或AI进行分析核实，并生成测试用例；并在二次确认后记录变更日志再生效***
	***provider专属`model metadata`如果和对应的全局默认原厂metadata一致，则删掉这个专属metadata，直接使用全局默认原厂metadata***
10. 定义一个文本格式（要求人类可读），逐条记录本次希望执行的更新行为，可以由人类编辑，也可能由AI生成；并在云服务的webui上提供导入按钮，把这个格式的文档导入进去作为本次希望更新的信息，内容分别呈现到对应的UI组件上
11. 对接上当前buckyos系统，让它们能够生效
12. 在客户端，用户配置自定义provider时选择的`provider Type`，只是接口协议，重点还是要以endpoint为key匹配provider.base_url；
	* 如果没有配置endpoint，认为它就是`provider Type`原厂endpoint
	* 如果是客户端预制的非`provider Type`原厂endpoint，应该为它取个名字(provider.name)，并以provider.name匹配对应的provider；在UI上也展示provider.name作为`provider Type`；比如OpenRouter：
		* 应该给它配置一个叫做OpenRouter的provider；provider.name = `OpenRouter`；最终创建`provider instance`时，就以`provider.name`为key匹配对应参数
		* 但它的接口协议是OpenAI兼容的；provider.provider_driver = `openai`；或者provider.provider_driver = `openai-compatible`，具体是什么应该看具体对应的设计文档或实现代码做最终决策
		* WebUI上展示`provider Type`展示`provider.name`的值，但OpenAI原厂的provider就展示`provider.provider_driver`的值
13. 客户端应用更新时，不应该更新用户自己写入的参数，也不应该更新客户端设备运行中的统计参数(比如: 延迟)；只做增量更新，为保证这个目标，应用更新应该是原子的；
	*具体方案可以考虑：
		* 保留上次更新的基础配置base，当前系统生效配置local
		* 对base和local取快照(可以用软链接，也可以用其他方案)
		* 下载更新配置remote
		* diff_local = diff(local, base); diff_remote = diff(remote, base)
		* 逐一应用diff_remote中的字段，如果同时出现在diff_local中，说明它被用户编辑过，跳过该字段
			* 要注意增加和删除
				* 如果用户手工添加了某provider/model，只对其中某些缺失的字段或数组项进行补充，不应全部更新，更不应被删除；
				* 如果用户手工物理删除了某provider/model，不应该再添加回来，如果只是做了删除标记，应该更新其属性；
				* 如果用户手工添加或删除了某字段/数组项，不应该更新对应字段/数组项，但可以更新同数组的其他项，同时对应的provider/model不应该被删除；
			* key性质的字段(base_url,provider.name,model.id等)不应被改动
		* 用remote替换local
		* 用新的base和local原子覆盖旧配置(可以用软链接，也可以用其他方案)
		
		***这个过程中有很多遍历，要特别注意遍历顺序***
		***数组元素顺序改变也是diff，数组元素的具体属性变更仅仅是数组元素变更，它不能阻止remote配置变更数组元素的顺序，但应该阻止这个元素被删除；反之，数组元素顺序变更不能阻止remote对元素属性变更***
		***系统自行统计的参数（延迟，可靠性等）极大概率被变更，它们同样不能被覆盖，但它们的更细不能阻止其对应的元素被删除；如一个模型的延迟和可靠性发生变化，这个模型被remote删除了，这个模型还是应该被删除***
	
	* 在provider信息页面
		* 提供`恢复配置`的菜单项，让用户有机会把该provider-instance编辑过的配置还原成base配置，在还原以前应该给用户展示其更新过的配置项，告诉用户哪些配置项将会被更新，在更新以前应该向用户警示风险
		* 提供`导出配置`的菜单项，让用户可以把这个provider-instance的配置信息导出成文本，可以以此为模板生成新的配置新建自定义的provider
14. 用户通过客户端添加自定义provider时
	* 如果匹配到配置的provider则启用
	* 如果没有匹配到配置的provider
		* 提示风险
		* 为用户提供高级功能添加provider配置，UI类似云服务上添加provider配置一样，不分技术参数和运营参数，可以用文本导入或者向导等方式让它更易用一些，尽量常态隐藏一些非常用参数，让UI更简洁，在用户需要的时候才展示；
		* base_url返回的model列表是这个provider的白名单，但这个model列表可能是原厂模型的别名（比如：OpenRouter返回的模型列表中gpt系列模型名可能是openai/gpt...），UI上也要注意提供好用的别名编辑器，让它们能匹配上原厂模型参数
```
</pre>

</details>