### PR TITLE
Stop stale AICC provider inventory refresh loops

### DIFF
--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -40,10 +40,10 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{watch, Mutex as AsyncMutex};
 
 const DEFAULT_FALLBACK_LIMIT: usize = 2;
 const DEFAULT_BASE64_MAX_BYTES: usize = 8 * 1024 * 1024;
@@ -55,6 +55,73 @@ const REDACTED_DATA_URL_BASE64_PREFIX: &str = "[redacted_data_url_base64";
 const REDACTED_LONG_BASE64_LIKE_PLACEHOLDER: &str = "[redacted_base64_like_string]";
 const LOG_BASE64_LIKE_MIN_CHARS: usize = 512;
 const SN_AI_PROVIDER_FREE_CREDIT_USD: f64 = 15.0;
+const REFRESH_IDLE: u8 = 0;
+const REFRESH_REQUEST_ACTIVE: u8 = 1;
+const REFRESH_STOPPED: u8 = 2;
+
+#[derive(Debug)]
+pub(crate) struct ProviderRefreshTask {
+    shutdown_tx: watch::Sender<bool>,
+    state: AtomicU8,
+    #[cfg(test)]
+    started_requests: AtomicU64,
+}
+
+impl ProviderRefreshTask {
+    pub(crate) fn new() -> (Arc<Self>, watch::Receiver<bool>) {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        (
+            Arc::new(Self {
+                shutdown_tx,
+                state: AtomicU8::new(REFRESH_IDLE),
+                #[cfg(test)]
+                started_requests: AtomicU64::new(0),
+            }),
+            shutdown_rx,
+        )
+    }
+
+    pub(crate) fn try_start_request(&self) -> bool {
+        let started = self
+            .state
+            .compare_exchange(
+                REFRESH_IDLE,
+                REFRESH_REQUEST_ACTIVE,
+                AtomicOrdering::AcqRel,
+                AtomicOrdering::Acquire,
+            )
+            .is_ok();
+        #[cfg(test)]
+        if started {
+            self.started_requests
+                .fetch_add(1, AtomicOrdering::Relaxed);
+        }
+        started
+    }
+
+    pub(crate) fn finish_request(&self) {
+        let _ = self.state.compare_exchange(
+            REFRESH_REQUEST_ACTIVE,
+            REFRESH_IDLE,
+            AtomicOrdering::AcqRel,
+            AtomicOrdering::Acquire,
+        );
+    }
+
+    pub(crate) fn shutdown(&self) {
+        self.state.store(REFRESH_STOPPED, AtomicOrdering::Release);
+        let _ = self.shutdown_tx.send(true);
+    }
+
+    pub(crate) fn is_stopped(&self) -> bool {
+        self.state.load(AtomicOrdering::Acquire) == REFRESH_STOPPED
+    }
+
+    #[cfg(test)]
+    pub(crate) fn started_requests(&self) -> u64 {
+        self.started_requests.load(AtomicOrdering::Relaxed)
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct InvokeCtx {
@@ -1286,39 +1353,49 @@ pub struct Registry {
 impl Registry {
     pub fn add_provider(&self, provider: Arc<dyn Provider>) -> ProviderInventory {
         let inventory = provider.inventory();
-        let mut entries = self
-            .entries
-            .write()
-            .expect("registry lock should be available");
-        entries.insert(
-            inventory.provider_instance_name.clone(),
-            ProviderEntry {
-                provider,
-                metrics: ProviderMetrics::default(),
-            },
-        );
+        let replaced = {
+            let mut entries = self
+                .entries
+                .write()
+                .expect("registry lock should be available");
+            entries.insert(
+                inventory.provider_instance_name.clone(),
+                ProviderEntry {
+                    provider,
+                    metrics: ProviderMetrics::default(),
+                },
+            )
+        };
+        if let Some(entry) = replaced {
+            entry.provider.shutdown();
+        }
         inventory
     }
 
     pub fn remove_instance(&self, provider_instance_name: &str) {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("registry lock should be available");
-        if let Some(entry) = entries.remove(provider_instance_name) {
+        let removed = {
+            let mut entries = self
+                .entries
+                .write()
+                .expect("registry lock should be available");
+            entries.remove(provider_instance_name)
+        };
+        if let Some(entry) = removed {
             entry.provider.shutdown();
         }
     }
 
     pub fn clear(&self) {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("registry lock should be available");
-        for entry in entries.values() {
+        let removed = {
+            let mut entries = self
+                .entries
+                .write()
+                .expect("registry lock should be available");
+            std::mem::take(&mut *entries)
+        };
+        for entry in removed.values() {
             entry.provider.shutdown();
         }
-        entries.clear();
     }
 
     pub fn snapshot(&self, capability: Capability) -> RegistrySnapshot {
@@ -5767,6 +5844,7 @@ mod tests {
         cost: CostEstimateOutput,
         start_results: Mutex<VecDeque<std::result::Result<ProviderStartResult, ProviderError>>>,
         start_call_count: std::sync::atomic::AtomicUsize,
+        shutdown_call_count: std::sync::atomic::AtomicUsize,
         canceled: Mutex<Vec<String>>,
     }
 
@@ -5783,12 +5861,17 @@ mod tests {
                 cost,
                 start_results: Mutex::new(start_results.into_iter().collect()),
                 start_call_count: std::sync::atomic::AtomicUsize::new(0),
+                shutdown_call_count: std::sync::atomic::AtomicUsize::new(0),
                 canceled: Mutex::new(vec![]),
             }
         }
 
         fn start_calls(&self) -> usize {
             self.start_call_count.load(AtomicOrdering::Relaxed)
+        }
+
+        fn shutdown_calls(&self) -> usize {
+            self.shutdown_call_count.load(AtomicOrdering::Relaxed)
         }
     }
 
@@ -5800,6 +5883,11 @@ mod tests {
 
         fn estimate_cost(&self, _input: &CostEstimateInput) -> CostEstimateOutput {
             self.cost.clone()
+        }
+
+        fn shutdown(&self) {
+            self.shutdown_call_count
+                .fetch_add(1, AtomicOrdering::Relaxed);
         }
 
         async fn start(
@@ -6138,6 +6226,51 @@ mod tests {
             confidence: 1.0,
             estimated_latency_ms: Some(estimated_latency_ms),
         }
+    }
+
+    #[test]
+    fn registry_stops_displaced_and_removed_providers() {
+        let registry = Registry::default();
+        let first = Arc::new(MockProvider::new(
+            mock_instance("provider-1", "provider-a"),
+            cost(0.001, 100),
+            vec![],
+        ));
+        let replacement = Arc::new(MockProvider::new(
+            mock_instance("provider-1", "provider-b"),
+            cost(0.002, 200),
+            vec![],
+        ));
+        let other = Arc::new(MockProvider::new(
+            mock_instance("provider-2", "provider-c"),
+            cost(0.003, 300),
+            vec![],
+        ));
+
+        registry.add_provider(first.clone());
+        registry.add_provider(replacement.clone());
+        assert_eq!(first.shutdown_calls(), 1);
+        assert_eq!(replacement.shutdown_calls(), 0);
+
+        registry.remove_instance("provider-1");
+        assert_eq!(replacement.shutdown_calls(), 1);
+
+        registry.add_provider(other.clone());
+        registry.clear();
+        assert_eq!(other.shutdown_calls(), 1);
+    }
+
+    #[test]
+    fn refresh_task_shutdown_wins_over_request_completion() {
+        let (task, _) = ProviderRefreshTask::new();
+        assert!(task.try_start_request());
+
+        task.shutdown();
+        task.finish_request();
+
+        assert!(task.is_stopped());
+        assert!(!task.try_start_request());
+        assert_eq!(task.started_requests(), 1);
     }
 
     fn center_with_taskmgr(registry: Registry, catalog: ModelCatalog) -> AIComputeCenter {

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -1238,6 +1238,7 @@ pub trait Provider: Send + Sync {
     fn legacy_instance(&self) -> Option<&ProviderInstance> {
         None
     }
+    fn shutdown(&self) {}
     fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput;
     async fn refresh_inventory(&self) -> std::result::Result<ProviderInventory, ProviderError> {
         Ok(self.inventory())
@@ -1304,7 +1305,9 @@ impl Registry {
             .entries
             .write()
             .expect("registry lock should be available");
-        entries.remove(provider_instance_name);
+        if let Some(entry) = entries.remove(provider_instance_name) {
+            entry.provider.shutdown();
+        }
     }
 
     pub fn clear(&self) {
@@ -1312,6 +1315,9 @@ impl Registry {
             .entries
             .write()
             .expect("registry lock should be available");
+        for entry in entries.values() {
+            entry.provider.shutdown();
+        }
         entries.clear();
     }
 

--- a/src/frame/aicc/src/claude.rs
+++ b/src/frame/aicc/src/claude.rs
@@ -1,6 +1,6 @@
 use crate::aicc::{
     provider_type_from_settings, redacted_json_log, AIComputeCenter, Provider, ProviderError,
-    ProviderInstance, ProviderStartResult, ResolvedRequest, TaskEventSink,
+    ProviderInstance, ProviderRefreshTask, ProviderStartResult, ResolvedRequest, TaskEventSink,
 };
 use crate::claude_protocol::convert_complete_request;
 use crate::metadata_resolver::{resolve_driver_inventory, DriverModelResolveRequest};
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::time;
@@ -47,7 +47,7 @@ pub struct ClaudeInstanceConfig {
     pub alias_map: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ClaudeProvider {
     instance: ProviderInstance,
     inventory: Arc<RwLock<ProviderInventory>>,
@@ -58,7 +58,7 @@ pub struct ClaudeProvider {
     provider_driver: String,
     provider_instance_name: String,
     features: Vec<Feature>,
-    refresh_shutdown: Arc<Mutex<Option<watch::Sender<bool>>>>,
+    refresh_task: Arc<Mutex<Option<Arc<ProviderRefreshTask>>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -123,7 +123,7 @@ impl ClaudeProvider {
             provider_driver,
             provider_instance_name,
             features: cfg.features,
-            refresh_shutdown: Arc::new(Mutex::new(None)),
+            refresh_task: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -153,39 +153,63 @@ impl ClaudeProvider {
             return;
         }
 
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        match self.refresh_shutdown.lock() {
-            Ok(mut current) => {
-                if let Some(existing) = current.take() {
-                    let _ = existing.send(true);
-                }
-                *current = Some(shutdown_tx);
-            }
+        let (refresh_task, shutdown_rx) = ProviderRefreshTask::new();
+        let existing = match self.refresh_task.lock() {
+            Ok(mut current) => current.replace(refresh_task.clone()),
             Err(_) => {
                 warn!(
-                    "aicc.claude.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                    "aicc.claude.inventory.refresh_task_lock_poisoned provider_instance_name={}",
                     self.provider_instance_name
                 );
                 return;
             }
+        };
+        if let Some(existing) = existing {
+            existing.shutdown();
         }
-        let provider = self.clone();
+        let provider = Arc::downgrade(&self);
+        let provider_instance_name = self.provider_instance_name.clone();
         tokio::spawn(async move {
-            provider.run_inventory_refresh(shutdown_rx).await;
+            Self::run_inventory_refresh(
+                provider,
+                provider_instance_name,
+                refresh_task,
+                shutdown_rx,
+            )
+            .await;
         });
     }
 
-    async fn run_inventory_refresh(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
-        if let Err(err) = self.refresh_inventory_once().await {
-            warn!(
-                "aicc.claude.inventory.initial_refresh_failed provider_instance_name={} err={}",
-                self.provider_instance_name, err
-            );
-        }
-        if *shutdown_rx.borrow() {
+    async fn run_inventory_refresh(
+        provider: Weak<Self>,
+        provider_instance_name: String,
+        refresh_task: Arc<ProviderRefreshTask>,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) {
+        if !refresh_task.try_start_request() {
             info!(
                 "aicc.claude.inventory.refresh_stopped provider_instance_name={}",
-                self.provider_instance_name
+                provider_instance_name
+            );
+            return;
+        }
+        let Some(current) = provider.upgrade() else {
+            refresh_task.shutdown();
+            return;
+        };
+        let initial_result = current.refresh_inventory_once().await;
+        refresh_task.finish_request();
+        drop(current);
+        if let Err(err) = initial_result {
+            warn!(
+                "aicc.claude.inventory.initial_refresh_failed provider_instance_name={} err={}",
+                provider_instance_name, err
+            );
+        }
+        if refresh_task.is_stopped() {
+            info!(
+                "aicc.claude.inventory.refresh_stopped provider_instance_name={}",
+                provider_instance_name
             );
             return;
         }
@@ -194,31 +218,60 @@ impl ClaudeProvider {
         interval.tick().await;
         loop {
             tokio::select! {
+                biased;
                 changed = shutdown_rx.changed() => {
                     if changed.is_err() || *shutdown_rx.borrow() {
                         info!(
                             "aicc.claude.inventory.refresh_stopped provider_instance_name={}",
-                            self.provider_instance_name
+                            provider_instance_name
                         );
                         return;
                     }
                 }
                 _ = interval.tick() => {
-                    if let Err(err) = self.refresh_inventory_once().await {
+                    if !refresh_task.try_start_request() {
+                        return;
+                    }
+                    let Some(current) = provider.upgrade() else {
+                        refresh_task.shutdown();
+                        return;
+                    };
+                    let result = current.refresh_inventory_once().await;
+                    refresh_task.finish_request();
+                    drop(current);
+                    if let Err(err) = result {
                         warn!(
                             "aicc.claude.inventory.refresh_failed provider_instance_name={} err={}",
-                            self.provider_instance_name, err
+                            provider_instance_name, err
                         );
                     }
-                    if *shutdown_rx.borrow() {
+                    if refresh_task.is_stopped() {
                         info!(
                             "aicc.claude.inventory.refresh_stopped provider_instance_name={}",
-                            self.provider_instance_name
+                            provider_instance_name
                         );
                         return;
                     }
                 }
             }
+        }
+    }
+
+    fn stop_inventory_refresh(&self) {
+        match self.refresh_task.lock() {
+            Ok(mut current) => {
+                if let Some(task) = current.take() {
+                    task.shutdown();
+                    info!(
+                        "aicc.claude.inventory.refresh_stop_requested provider_instance_name={}",
+                        self.provider_instance_name
+                    );
+                }
+            }
+            Err(_) => warn!(
+                "aicc.claude.inventory.refresh_task_lock_poisoned provider_instance_name={}",
+                self.provider_instance_name
+            ),
         }
     }
 
@@ -893,21 +946,7 @@ impl Provider for ClaudeProvider {
     }
 
     fn shutdown(&self) {
-        match self.refresh_shutdown.lock() {
-            Ok(mut current) => {
-                if let Some(sender) = current.take() {
-                    let _ = sender.send(true);
-                    info!(
-                        "aicc.claude.inventory.refresh_stop_requested provider_instance_name={}",
-                        self.provider_instance_name
-                    );
-                }
-            }
-            Err(_) => warn!(
-                "aicc.claude.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
-                self.provider_instance_name
-            ),
-        }
+        self.stop_inventory_refresh();
     }
 
     fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput {
@@ -972,6 +1011,12 @@ impl Provider for ClaudeProvider {
         _task_id: &str,
     ) -> std::result::Result<(), ProviderError> {
         Ok(())
+    }
+}
+
+impl Drop for ClaudeProvider {
+    fn drop(&mut self) {
+        self.stop_inventory_refresh();
     }
 }
 
@@ -1366,11 +1411,11 @@ pub fn register_claude_providers(center: &AIComputeCenter, settings: &Value) -> 
             config.clone(),
             config.api_token.clone(),
         )?);
-        provider.clone().start_inventory_refresh();
         prepared.push((config.clone(), provider));
     }
 
     for (config, provider) in prepared.into_iter() {
+        provider.clone().start_inventory_refresh();
         let inventory = center.registry().add_provider(provider);
         info!(
             "registered claude base_url={} inventory={:?}",
@@ -1553,6 +1598,78 @@ mod tests {
             instances[0].default_model.as_deref(),
             Some("claude-3-7-sonnet-20250219")
         );
+    }
+
+    #[tokio::test]
+    async fn stopped_refresh_does_not_send_initial_request() {
+        let config = build_claude_instances(&ClaudeSettings {
+            enabled: true,
+            api_token: "token".to_string(),
+            alias_map: HashMap::new(),
+            instances: vec![],
+        })
+        .expect("instances")
+        .remove(0);
+        let provider = Arc::new(
+            ClaudeProvider::new(config, "token".to_string()).expect("provider should build"),
+        );
+        let provider_instance_name = provider.provider_instance_name.clone();
+        let (refresh_task, shutdown_rx) = ProviderRefreshTask::new();
+        refresh_task.shutdown();
+
+        ClaudeProvider::run_inventory_refresh(
+            Arc::downgrade(&provider),
+            provider_instance_name,
+            refresh_task.clone(),
+            shutdown_rx,
+        )
+        .await;
+
+        assert_eq!(refresh_task.started_requests(), 0);
+    }
+
+    #[test]
+    fn dropping_provider_stops_refresh_task() {
+        let config = build_claude_instances(&ClaudeSettings {
+            enabled: true,
+            api_token: "token".to_string(),
+            alias_map: HashMap::new(),
+            instances: vec![],
+        })
+        .expect("instances")
+        .remove(0);
+        let provider = ClaudeProvider::new(config, "token".to_string()).expect("provider");
+        let (refresh_task, _) = ProviderRefreshTask::new();
+        *provider.refresh_task.lock().expect("refresh task lock") = Some(refresh_task.clone());
+
+        drop(provider);
+
+        assert!(refresh_task.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn registration_error_does_not_start_prepared_refresh() {
+        let center = AIComputeCenter::default();
+        let settings = json!({
+            "claude": {
+                "enabled": true,
+                "instances": [
+                    {
+                        "provider_instance_name": "claude-valid",
+                        "api_token": "token",
+                        "base_url": "http://127.0.0.1:1"
+                    },
+                    {
+                        "provider_instance_name": "claude-invalid"
+                    }
+                ]
+            }
+        });
+
+        let result = register_claude_providers(&center, &settings);
+
+        assert!(result.is_err());
+        assert!(center.registry().inventories().is_empty());
     }
 
     #[test]

--- a/src/frame/aicc/src/claude.rs
+++ b/src/frame/aicc/src/claude.rs
@@ -20,8 +20,9 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
+use tokio::sync::watch;
 use tokio::time;
 
 const DEFAULT_CLAUDE_BASE_URL: &str = "https://api.anthropic.com/v1";
@@ -57,6 +58,7 @@ pub struct ClaudeProvider {
     provider_driver: String,
     provider_instance_name: String,
     features: Vec<Feature>,
+    refresh_shutdown: Arc<Mutex<Option<watch::Sender<bool>>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -121,6 +123,7 @@ impl ClaudeProvider {
             provider_driver,
             provider_instance_name,
             features: cfg.features,
+            refresh_shutdown: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -150,26 +153,73 @@ impl ClaudeProvider {
             return;
         }
 
-        tokio::spawn(async move {
-            if let Err(err) = self.refresh_inventory_once().await {
-                warn!(
-                    "aicc.claude.inventory.initial_refresh_failed provider_instance_name={} err={}",
-                    self.provider_instance_name, err
-                );
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        match self.refresh_shutdown.lock() {
+            Ok(mut current) => {
+                if let Some(existing) = current.take() {
+                    let _ = existing.send(true);
+                }
+                *current = Some(shutdown_tx);
             }
+            Err(_) => {
+                warn!(
+                    "aicc.claude.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                    self.provider_instance_name
+                );
+                return;
+            }
+        }
+        let provider = self.clone();
+        tokio::spawn(async move {
+            provider.run_inventory_refresh(shutdown_rx).await;
+        });
+    }
 
-            let mut interval = time::interval(DEFAULT_CLAUDE_INVENTORY_REFRESH_INTERVAL);
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                if let Err(err) = self.refresh_inventory_once().await {
-                    warn!(
-                        "aicc.claude.inventory.refresh_failed provider_instance_name={} err={}",
-                        self.provider_instance_name, err
-                    );
+    async fn run_inventory_refresh(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
+        if let Err(err) = self.refresh_inventory_once().await {
+            warn!(
+                "aicc.claude.inventory.initial_refresh_failed provider_instance_name={} err={}",
+                self.provider_instance_name, err
+            );
+        }
+        if *shutdown_rx.borrow() {
+            info!(
+                "aicc.claude.inventory.refresh_stopped provider_instance_name={}",
+                self.provider_instance_name
+            );
+            return;
+        }
+
+        let mut interval = time::interval(DEFAULT_CLAUDE_INVENTORY_REFRESH_INTERVAL);
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        info!(
+                            "aicc.claude.inventory.refresh_stopped provider_instance_name={}",
+                            self.provider_instance_name
+                        );
+                        return;
+                    }
+                }
+                _ = interval.tick() => {
+                    if let Err(err) = self.refresh_inventory_once().await {
+                        warn!(
+                            "aicc.claude.inventory.refresh_failed provider_instance_name={} err={}",
+                            self.provider_instance_name, err
+                        );
+                    }
+                    if *shutdown_rx.borrow() {
+                        info!(
+                            "aicc.claude.inventory.refresh_stopped provider_instance_name={}",
+                            self.provider_instance_name
+                        );
+                        return;
+                    }
                 }
             }
-        });
+        }
     }
 
     async fn refresh_inventory_once(&self) -> Result<ProviderInventory> {
@@ -840,6 +890,24 @@ impl Provider for ClaudeProvider {
                     Some("inventory-lock-poisoned".to_string()),
                 )
             })
+    }
+
+    fn shutdown(&self) {
+        match self.refresh_shutdown.lock() {
+            Ok(mut current) => {
+                if let Some(sender) = current.take() {
+                    let _ = sender.send(true);
+                    info!(
+                        "aicc.claude.inventory.refresh_stop_requested provider_instance_name={}",
+                        self.provider_instance_name
+                    );
+                }
+            }
+            Err(_) => warn!(
+                "aicc.claude.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                self.provider_instance_name
+            ),
+        }
     }
 
     fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput {

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -1,6 +1,6 @@
 use crate::aicc::{
     provider_type_from_settings, redacted_json_log, AIComputeCenter, Provider, ProviderError,
-    ProviderInstance, ProviderStartResult, ResolvedRequest, TaskEventSink,
+    ProviderInstance, ProviderRefreshTask, ProviderStartResult, ResolvedRequest, TaskEventSink,
 };
 use crate::metadata_resolver::{resolve_driver_inventory, DriverModelResolveRequest};
 use crate::model_types::{
@@ -21,7 +21,7 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::time;
@@ -95,7 +95,7 @@ pub struct GoogleGeminiInstanceConfig {
     pub alias_map: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GoogleGeminiProvider {
     instance: ProviderInstance,
     inventory: Arc<RwLock<ProviderInventory>>,
@@ -106,7 +106,7 @@ pub struct GoogleGeminiProvider {
     provider_driver: String,
     provider_instance_name: String,
     features: Vec<Feature>,
-    refresh_shutdown: Arc<Mutex<Option<watch::Sender<bool>>>>,
+    refresh_task: Arc<Mutex<Option<Arc<ProviderRefreshTask>>>>,
 }
 
 #[derive(Debug, Default)]
@@ -240,7 +240,7 @@ impl GoogleGeminiProvider {
             provider_driver,
             provider_instance_name,
             features: cfg.features,
-            refresh_shutdown: Arc::new(Mutex::new(None)),
+            refresh_task: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -315,39 +315,63 @@ impl GoogleGeminiProvider {
             return;
         }
 
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        match self.refresh_shutdown.lock() {
-            Ok(mut current) => {
-                if let Some(existing) = current.take() {
-                    let _ = existing.send(true);
-                }
-                *current = Some(shutdown_tx);
-            }
+        let (refresh_task, shutdown_rx) = ProviderRefreshTask::new();
+        let existing = match self.refresh_task.lock() {
+            Ok(mut current) => current.replace(refresh_task.clone()),
             Err(_) => {
                 warn!(
-                    "aicc.gemini.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                    "aicc.gemini.inventory.refresh_task_lock_poisoned provider_instance_name={}",
                     self.provider_instance_name
                 );
                 return;
             }
+        };
+        if let Some(existing) = existing {
+            existing.shutdown();
         }
-        let provider = self.clone();
+        let provider = Arc::downgrade(&self);
+        let provider_instance_name = self.provider_instance_name.clone();
         tokio::spawn(async move {
-            provider.run_inventory_refresh(shutdown_rx).await;
+            Self::run_inventory_refresh(
+                provider,
+                provider_instance_name,
+                refresh_task,
+                shutdown_rx,
+            )
+            .await;
         });
     }
 
-    async fn run_inventory_refresh(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
-        if let Err(err) = self.refresh_inventory_once().await {
-            warn!(
-                "aicc.gemini.inventory.initial_refresh_failed provider_instance_name={} err={}",
-                self.provider_instance_name, err
-            );
-        }
-        if *shutdown_rx.borrow() {
+    async fn run_inventory_refresh(
+        provider: Weak<Self>,
+        provider_instance_name: String,
+        refresh_task: Arc<ProviderRefreshTask>,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) {
+        if !refresh_task.try_start_request() {
             info!(
                 "aicc.gemini.inventory.refresh_stopped provider_instance_name={}",
-                self.provider_instance_name
+                provider_instance_name
+            );
+            return;
+        }
+        let Some(current) = provider.upgrade() else {
+            refresh_task.shutdown();
+            return;
+        };
+        let initial_result = current.refresh_inventory_once().await;
+        refresh_task.finish_request();
+        drop(current);
+        if let Err(err) = initial_result {
+            warn!(
+                "aicc.gemini.inventory.initial_refresh_failed provider_instance_name={} err={}",
+                provider_instance_name, err
+            );
+        }
+        if refresh_task.is_stopped() {
+            info!(
+                "aicc.gemini.inventory.refresh_stopped provider_instance_name={}",
+                provider_instance_name
             );
             return;
         }
@@ -356,31 +380,60 @@ impl GoogleGeminiProvider {
         interval.tick().await;
         loop {
             tokio::select! {
+                biased;
                 changed = shutdown_rx.changed() => {
                     if changed.is_err() || *shutdown_rx.borrow() {
                         info!(
                             "aicc.gemini.inventory.refresh_stopped provider_instance_name={}",
-                            self.provider_instance_name
+                            provider_instance_name
                         );
                         return;
                     }
                 }
                 _ = interval.tick() => {
-                    if let Err(err) = self.refresh_inventory_once().await {
+                    if !refresh_task.try_start_request() {
+                        return;
+                    }
+                    let Some(current) = provider.upgrade() else {
+                        refresh_task.shutdown();
+                        return;
+                    };
+                    let result = current.refresh_inventory_once().await;
+                    refresh_task.finish_request();
+                    drop(current);
+                    if let Err(err) = result {
                         warn!(
                             "aicc.gemini.inventory.refresh_failed provider_instance_name={} err={}",
-                            self.provider_instance_name, err
+                            provider_instance_name, err
                         );
                     }
-                    if *shutdown_rx.borrow() {
+                    if refresh_task.is_stopped() {
                         info!(
                             "aicc.gemini.inventory.refresh_stopped provider_instance_name={}",
-                            self.provider_instance_name
+                            provider_instance_name
                         );
                         return;
                     }
                 }
             }
+        }
+    }
+
+    fn stop_inventory_refresh(&self) {
+        match self.refresh_task.lock() {
+            Ok(mut current) => {
+                if let Some(task) = current.take() {
+                    task.shutdown();
+                    info!(
+                        "aicc.gemini.inventory.refresh_stop_requested provider_instance_name={}",
+                        self.provider_instance_name
+                    );
+                }
+            }
+            Err(_) => warn!(
+                "aicc.gemini.inventory.refresh_task_lock_poisoned provider_instance_name={}",
+                self.provider_instance_name
+            ),
         }
     }
 
@@ -2349,21 +2402,7 @@ impl Provider for GoogleGeminiProvider {
     }
 
     fn shutdown(&self) {
-        match self.refresh_shutdown.lock() {
-            Ok(mut current) => {
-                if let Some(sender) = current.take() {
-                    let _ = sender.send(true);
-                    info!(
-                        "aicc.gemini.inventory.refresh_stop_requested provider_instance_name={}",
-                        self.provider_instance_name
-                    );
-                }
-            }
-            Err(_) => warn!(
-                "aicc.gemini.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
-                self.provider_instance_name
-            ),
-        }
+        self.stop_inventory_refresh();
     }
 
     fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput {
@@ -2483,6 +2522,12 @@ impl Provider for GoogleGeminiProvider {
         _task_id: &str,
     ) -> std::result::Result<(), ProviderError> {
         Ok(())
+    }
+}
+
+impl Drop for GoogleGeminiProvider {
+    fn drop(&mut self) {
+        self.stop_inventory_refresh();
     }
 }
 
@@ -2988,11 +3033,11 @@ pub fn register_google_gemini_providers(
             config.clone(),
             config.api_token.clone(),
         )?);
-        provider.clone().start_inventory_refresh();
         prepared.push((config.clone(), provider));
     }
 
     for (config, provider) in prepared.into_iter() {
+        provider.clone().start_inventory_refresh();
         let inventory = center.registry().add_provider(provider);
         info!(
             "registered google gemini base_url={} inventory={:?}",
@@ -3288,6 +3333,78 @@ mod tests {
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].provider_instance_name, "google-gemini-default");
         assert_eq!(instances[0].provider_driver, "google-gemini");
+    }
+
+    #[tokio::test]
+    async fn stopped_refresh_does_not_send_initial_request() {
+        let config = build_gemini_instances(&GeminiSettings {
+            enabled: true,
+            api_token: "token".to_string(),
+            alias_map: HashMap::new(),
+            instances: vec![],
+        })
+        .expect("instances")
+        .remove(0);
+        let provider = Arc::new(
+            GoogleGeminiProvider::new(config, "token".to_string()).expect("provider should build"),
+        );
+        let provider_instance_name = provider.provider_instance_name.clone();
+        let (refresh_task, shutdown_rx) = ProviderRefreshTask::new();
+        refresh_task.shutdown();
+
+        GoogleGeminiProvider::run_inventory_refresh(
+            Arc::downgrade(&provider),
+            provider_instance_name,
+            refresh_task.clone(),
+            shutdown_rx,
+        )
+        .await;
+
+        assert_eq!(refresh_task.started_requests(), 0);
+    }
+
+    #[test]
+    fn dropping_provider_stops_refresh_task() {
+        let config = build_gemini_instances(&GeminiSettings {
+            enabled: true,
+            api_token: "token".to_string(),
+            alias_map: HashMap::new(),
+            instances: vec![],
+        })
+        .expect("instances")
+        .remove(0);
+        let provider = GoogleGeminiProvider::new(config, "token".to_string()).expect("provider");
+        let (refresh_task, _) = ProviderRefreshTask::new();
+        *provider.refresh_task.lock().expect("refresh task lock") = Some(refresh_task.clone());
+
+        drop(provider);
+
+        assert!(refresh_task.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn registration_error_does_not_start_prepared_refresh() {
+        let center = AIComputeCenter::default();
+        let settings = json!({
+            "gemini": {
+                "enabled": true,
+                "instances": [
+                    {
+                        "provider_instance_name": "gemini-valid",
+                        "api_token": "token",
+                        "base_url": "http://127.0.0.1:1"
+                    },
+                    {
+                        "provider_instance_name": "gemini-invalid"
+                    }
+                ]
+            }
+        });
+
+        let result = register_google_gemini_providers(&center, &settings);
+
+        assert!(result.is_err());
+        assert!(center.registry().inventories().is_empty());
     }
 
     #[test]

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -21,8 +21,9 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
+use tokio::sync::watch;
 use tokio::time;
 
 const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -105,6 +106,7 @@ pub struct GoogleGeminiProvider {
     provider_driver: String,
     provider_instance_name: String,
     features: Vec<Feature>,
+    refresh_shutdown: Arc<Mutex<Option<watch::Sender<bool>>>>,
 }
 
 #[derive(Debug, Default)]
@@ -238,6 +240,7 @@ impl GoogleGeminiProvider {
             provider_driver,
             provider_instance_name,
             features: cfg.features,
+            refresh_shutdown: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -312,26 +315,73 @@ impl GoogleGeminiProvider {
             return;
         }
 
-        tokio::spawn(async move {
-            if let Err(err) = self.refresh_inventory_once().await {
-                warn!(
-                    "aicc.gemini.inventory.initial_refresh_failed provider_instance_name={} err={}",
-                    self.provider_instance_name, err
-                );
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        match self.refresh_shutdown.lock() {
+            Ok(mut current) => {
+                if let Some(existing) = current.take() {
+                    let _ = existing.send(true);
+                }
+                *current = Some(shutdown_tx);
             }
+            Err(_) => {
+                warn!(
+                    "aicc.gemini.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                    self.provider_instance_name
+                );
+                return;
+            }
+        }
+        let provider = self.clone();
+        tokio::spawn(async move {
+            provider.run_inventory_refresh(shutdown_rx).await;
+        });
+    }
 
-            let mut interval = time::interval(DEFAULT_GEMINI_INVENTORY_REFRESH_INTERVAL);
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                if let Err(err) = self.refresh_inventory_once().await {
-                    warn!(
-                        "aicc.gemini.inventory.refresh_failed provider_instance_name={} err={}",
-                        self.provider_instance_name, err
-                    );
+    async fn run_inventory_refresh(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
+        if let Err(err) = self.refresh_inventory_once().await {
+            warn!(
+                "aicc.gemini.inventory.initial_refresh_failed provider_instance_name={} err={}",
+                self.provider_instance_name, err
+            );
+        }
+        if *shutdown_rx.borrow() {
+            info!(
+                "aicc.gemini.inventory.refresh_stopped provider_instance_name={}",
+                self.provider_instance_name
+            );
+            return;
+        }
+
+        let mut interval = time::interval(DEFAULT_GEMINI_INVENTORY_REFRESH_INTERVAL);
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        info!(
+                            "aicc.gemini.inventory.refresh_stopped provider_instance_name={}",
+                            self.provider_instance_name
+                        );
+                        return;
+                    }
+                }
+                _ = interval.tick() => {
+                    if let Err(err) = self.refresh_inventory_once().await {
+                        warn!(
+                            "aicc.gemini.inventory.refresh_failed provider_instance_name={} err={}",
+                            self.provider_instance_name, err
+                        );
+                    }
+                    if *shutdown_rx.borrow() {
+                        info!(
+                            "aicc.gemini.inventory.refresh_stopped provider_instance_name={}",
+                            self.provider_instance_name
+                        );
+                        return;
+                    }
                 }
             }
-        });
+        }
     }
 
     async fn refresh_inventory_once(&self) -> Result<ProviderInventory> {
@@ -2296,6 +2346,24 @@ impl Provider for GoogleGeminiProvider {
                     Some("inventory-lock-poisoned".to_string()),
                 )
             })
+    }
+
+    fn shutdown(&self) {
+        match self.refresh_shutdown.lock() {
+            Ok(mut current) => {
+                if let Some(sender) = current.take() {
+                    let _ = sender.send(true);
+                    info!(
+                        "aicc.gemini.inventory.refresh_stop_requested provider_instance_name={}",
+                        self.provider_instance_name
+                    );
+                }
+            }
+            Err(_) => warn!(
+                "aicc.gemini.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                self.provider_instance_name
+            ),
+        }
     }
 
     fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput {

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -31,8 +31,9 @@ use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::error::Error as _;
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
+use tokio::sync::watch;
 use tokio::time;
 
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
@@ -103,6 +104,7 @@ pub struct OpenAIProvider {
     base_url: String,
     provider_type: crate::model_types::ProviderType,
     provider_driver: String,
+    refresh_shutdown: Arc<Mutex<Option<watch::Sender<bool>>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -179,6 +181,7 @@ impl OpenAIProvider {
             base_url: cfg.base_url.trim_end_matches('/').to_string(),
             provider_type,
             provider_driver,
+            refresh_shutdown: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -187,26 +190,73 @@ impl OpenAIProvider {
             return;
         }
 
-        tokio::spawn(async move {
-            if let Err(err) = self.refresh_inventory_once().await {
-                warn!(
-                    "aicc.openai.inventory.initial_refresh_failed provider_instance_name={} err={}",
-                    self.instance.provider_instance_name, err
-                );
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        match self.refresh_shutdown.lock() {
+            Ok(mut current) => {
+                if let Some(existing) = current.take() {
+                    let _ = existing.send(true);
+                }
+                *current = Some(shutdown_tx);
             }
+            Err(_) => {
+                warn!(
+                    "aicc.openai.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                    self.instance.provider_instance_name
+                );
+                return;
+            }
+        }
+        let provider = self.clone();
+        tokio::spawn(async move {
+            provider.run_inventory_refresh(shutdown_rx).await;
+        });
+    }
 
-            let mut interval = time::interval(DEFAULT_INVENTORY_REFRESH_INTERVAL);
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                if let Err(err) = self.refresh_inventory_once().await {
-                    warn!(
-                        "aicc.openai.inventory.refresh_failed provider_instance_name={} err={}",
-                        self.instance.provider_instance_name, err
-                    );
+    async fn run_inventory_refresh(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
+        if let Err(err) = self.refresh_inventory_once().await {
+            warn!(
+                "aicc.openai.inventory.initial_refresh_failed provider_instance_name={} err={}",
+                self.instance.provider_instance_name, err
+            );
+        }
+        if *shutdown_rx.borrow() {
+            info!(
+                "aicc.openai.inventory.refresh_stopped provider_instance_name={}",
+                self.instance.provider_instance_name
+            );
+            return;
+        }
+
+        let mut interval = time::interval(DEFAULT_INVENTORY_REFRESH_INTERVAL);
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        info!(
+                            "aicc.openai.inventory.refresh_stopped provider_instance_name={}",
+                            self.instance.provider_instance_name
+                        );
+                        return;
+                    }
+                }
+                _ = interval.tick() => {
+                    if let Err(err) = self.refresh_inventory_once().await {
+                        warn!(
+                            "aicc.openai.inventory.refresh_failed provider_instance_name={} err={}",
+                            self.instance.provider_instance_name, err
+                        );
+                    }
+                    if *shutdown_rx.borrow() {
+                        info!(
+                            "aicc.openai.inventory.refresh_stopped provider_instance_name={}",
+                            self.instance.provider_instance_name
+                        );
+                        return;
+                    }
                 }
             }
-        });
+        }
     }
 
     async fn refresh_inventory_once(&self) -> Result<ProviderInventory> {
@@ -3046,6 +3096,24 @@ impl Provider for OpenAIProvider {
                     self.provider_driver.as_str(),
                 )
             })
+    }
+
+    fn shutdown(&self) {
+        match self.refresh_shutdown.lock() {
+            Ok(mut current) => {
+                if let Some(sender) = current.take() {
+                    let _ = sender.send(true);
+                    info!(
+                        "aicc.openai.inventory.refresh_stop_requested provider_instance_name={}",
+                        self.instance.provider_instance_name
+                    );
+                }
+            }
+            Err(_) => warn!(
+                "aicc.openai.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                self.instance.provider_instance_name
+            ),
+        }
     }
 
     fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput {

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -1,6 +1,6 @@
 use crate::aicc::{
     provider_type_from_settings, redacted_json_log, AIComputeCenter, Provider, ProviderError,
-    ProviderInstance, ProviderStartResult, ResolvedRequest, TaskEventSink,
+    ProviderInstance, ProviderRefreshTask, ProviderStartResult, ResolvedRequest, TaskEventSink,
 };
 use crate::metadata_resolver::{resolve_driver_inventory, DriverModelResolveRequest};
 #[cfg(test)]
@@ -31,7 +31,7 @@ use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::error::Error as _;
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::time;
@@ -95,7 +95,7 @@ pub struct OpenAIInstanceConfig {
     pub timeout_ms: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct OpenAIProvider {
     instance: ProviderInstance,
     inventory: Arc<RwLock<ProviderInventory>>,
@@ -104,7 +104,7 @@ pub struct OpenAIProvider {
     base_url: String,
     provider_type: crate::model_types::ProviderType,
     provider_driver: String,
-    refresh_shutdown: Arc<Mutex<Option<watch::Sender<bool>>>>,
+    refresh_task: Arc<Mutex<Option<Arc<ProviderRefreshTask>>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -181,7 +181,7 @@ impl OpenAIProvider {
             base_url: cfg.base_url.trim_end_matches('/').to_string(),
             provider_type,
             provider_driver,
-            refresh_shutdown: Arc::new(Mutex::new(None)),
+            refresh_task: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -190,39 +190,63 @@ impl OpenAIProvider {
             return;
         }
 
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        match self.refresh_shutdown.lock() {
-            Ok(mut current) => {
-                if let Some(existing) = current.take() {
-                    let _ = existing.send(true);
-                }
-                *current = Some(shutdown_tx);
-            }
+        let (refresh_task, shutdown_rx) = ProviderRefreshTask::new();
+        let existing = match self.refresh_task.lock() {
+            Ok(mut current) => current.replace(refresh_task.clone()),
             Err(_) => {
                 warn!(
-                    "aicc.openai.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
+                    "aicc.openai.inventory.refresh_task_lock_poisoned provider_instance_name={}",
                     self.instance.provider_instance_name
                 );
                 return;
             }
+        };
+        if let Some(existing) = existing {
+            existing.shutdown();
         }
-        let provider = self.clone();
+        let provider = Arc::downgrade(&self);
+        let provider_instance_name = self.instance.provider_instance_name.clone();
         tokio::spawn(async move {
-            provider.run_inventory_refresh(shutdown_rx).await;
+            Self::run_inventory_refresh(
+                provider,
+                provider_instance_name,
+                refresh_task,
+                shutdown_rx,
+            )
+            .await;
         });
     }
 
-    async fn run_inventory_refresh(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
-        if let Err(err) = self.refresh_inventory_once().await {
-            warn!(
-                "aicc.openai.inventory.initial_refresh_failed provider_instance_name={} err={}",
-                self.instance.provider_instance_name, err
-            );
-        }
-        if *shutdown_rx.borrow() {
+    async fn run_inventory_refresh(
+        provider: Weak<Self>,
+        provider_instance_name: String,
+        refresh_task: Arc<ProviderRefreshTask>,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) {
+        if !refresh_task.try_start_request() {
             info!(
                 "aicc.openai.inventory.refresh_stopped provider_instance_name={}",
-                self.instance.provider_instance_name
+                provider_instance_name
+            );
+            return;
+        }
+        let Some(current) = provider.upgrade() else {
+            refresh_task.shutdown();
+            return;
+        };
+        let initial_result = current.refresh_inventory_once().await;
+        refresh_task.finish_request();
+        drop(current);
+        if let Err(err) = initial_result {
+            warn!(
+                "aicc.openai.inventory.initial_refresh_failed provider_instance_name={} err={}",
+                provider_instance_name, err
+            );
+        }
+        if refresh_task.is_stopped() {
+            info!(
+                "aicc.openai.inventory.refresh_stopped provider_instance_name={}",
+                provider_instance_name
             );
             return;
         }
@@ -231,31 +255,60 @@ impl OpenAIProvider {
         interval.tick().await;
         loop {
             tokio::select! {
+                biased;
                 changed = shutdown_rx.changed() => {
                     if changed.is_err() || *shutdown_rx.borrow() {
                         info!(
                             "aicc.openai.inventory.refresh_stopped provider_instance_name={}",
-                            self.instance.provider_instance_name
+                            provider_instance_name
                         );
                         return;
                     }
                 }
                 _ = interval.tick() => {
-                    if let Err(err) = self.refresh_inventory_once().await {
+                    if !refresh_task.try_start_request() {
+                        return;
+                    }
+                    let Some(current) = provider.upgrade() else {
+                        refresh_task.shutdown();
+                        return;
+                    };
+                    let result = current.refresh_inventory_once().await;
+                    refresh_task.finish_request();
+                    drop(current);
+                    if let Err(err) = result {
                         warn!(
                             "aicc.openai.inventory.refresh_failed provider_instance_name={} err={}",
-                            self.instance.provider_instance_name, err
+                            provider_instance_name, err
                         );
                     }
-                    if *shutdown_rx.borrow() {
+                    if refresh_task.is_stopped() {
                         info!(
                             "aicc.openai.inventory.refresh_stopped provider_instance_name={}",
-                            self.instance.provider_instance_name
+                            provider_instance_name
                         );
                         return;
                     }
                 }
             }
+        }
+    }
+
+    fn stop_inventory_refresh(&self) {
+        match self.refresh_task.lock() {
+            Ok(mut current) => {
+                if let Some(task) = current.take() {
+                    task.shutdown();
+                    info!(
+                        "aicc.openai.inventory.refresh_stop_requested provider_instance_name={}",
+                        self.instance.provider_instance_name
+                    );
+                }
+            }
+            Err(_) => warn!(
+                "aicc.openai.inventory.refresh_task_lock_poisoned provider_instance_name={}",
+                self.instance.provider_instance_name
+            ),
         }
     }
 
@@ -3099,21 +3152,7 @@ impl Provider for OpenAIProvider {
     }
 
     fn shutdown(&self) {
-        match self.refresh_shutdown.lock() {
-            Ok(mut current) => {
-                if let Some(sender) = current.take() {
-                    let _ = sender.send(true);
-                    info!(
-                        "aicc.openai.inventory.refresh_stop_requested provider_instance_name={}",
-                        self.instance.provider_instance_name
-                    );
-                }
-            }
-            Err(_) => warn!(
-                "aicc.openai.inventory.refresh_shutdown_lock_poisoned provider_instance_name={}",
-                self.instance.provider_instance_name
-            ),
-        }
+        self.stop_inventory_refresh();
     }
 
     fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput {
@@ -3212,6 +3251,12 @@ impl Provider for OpenAIProvider {
         _task_id: &str,
     ) -> std::result::Result<(), ProviderError> {
         Ok(())
+    }
+}
+
+impl Drop for OpenAIProvider {
+    fn drop(&mut self) {
+        self.stop_inventory_refresh();
     }
 }
 
@@ -3658,17 +3703,17 @@ pub fn register_openai_llm_providers(center: &AIComputeCenter, settings: &Value)
         return Ok(0);
     };
     let instances = build_openai_instances(&openai_settings)?;
-    let mut prepared = Vec::<(OpenAIInstanceConfig, Arc<dyn Provider>)>::new();
+    let mut prepared = Vec::<(OpenAIInstanceConfig, Arc<OpenAIProvider>)>::new();
     for config in instances.iter() {
         let provider = Arc::new(OpenAIProvider::new(
             config.clone(),
             config.api_token.as_str(),
         )?);
-        provider.clone().start_inventory_refresh();
         prepared.push((config.clone(), provider));
     }
 
     for (config, provider) in prepared.into_iter() {
+        provider.clone().start_inventory_refresh();
         let inventory = center.registry().add_provider(provider);
         info!(
             "registered openai base_url={} inventory={:?}",
@@ -4234,6 +4279,87 @@ data: [DONE]
         let instances = build_openai_instances(&settings).expect("instances should be built");
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].auth_mode, RUNTIME_SESSION_AUTH_MODE);
+    }
+
+    #[tokio::test]
+    async fn stopped_refresh_does_not_send_initial_request() {
+        let provider = Arc::new(
+            OpenAIProvider::new(
+                OpenAIInstanceConfig {
+                    provider_instance_name: "openai-stopped".to_string(),
+                    provider_type: "cloud_api".to_string(),
+                    api_token: "token".to_string(),
+                    base_url: "http://127.0.0.1:1".to_string(),
+                    auth_mode: "bearer".to_string(),
+                    timeout_ms: 100,
+                },
+                "token",
+            )
+            .expect("provider"),
+        );
+        let provider_instance_name = provider.instance.provider_instance_name.clone();
+        let (refresh_task, shutdown_rx) = ProviderRefreshTask::new();
+        refresh_task.shutdown();
+
+        OpenAIProvider::run_inventory_refresh(
+            Arc::downgrade(&provider),
+            provider_instance_name,
+            refresh_task.clone(),
+            shutdown_rx,
+        )
+        .await;
+
+        assert_eq!(refresh_task.started_requests(), 0);
+    }
+
+    #[test]
+    fn dropping_provider_stops_refresh_task() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openai-drop".to_string(),
+                provider_type: "cloud_api".to_string(),
+                api_token: "token".to_string(),
+                base_url: "http://127.0.0.1:1".to_string(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: 100,
+            },
+            "token",
+        )
+        .expect("provider");
+        let (refresh_task, _) = ProviderRefreshTask::new();
+        *provider.refresh_task.lock().expect("refresh task lock") = Some(refresh_task.clone());
+
+        drop(provider);
+
+        assert!(refresh_task.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn registration_error_does_not_start_prepared_refresh() {
+        let center = AIComputeCenter::default();
+        let settings = json!({
+            "openai": {
+                "enabled": true,
+                "instances": [
+                    {
+                        "provider_instance_name": "openai-valid",
+                        "api_token": "token",
+                        "base_url": "http://127.0.0.1:1",
+                        "auth_mode": "bearer",
+                        "timeout_ms": 100
+                    },
+                    {
+                        "provider_instance_name": "openai-invalid",
+                        "auth_mode": "bearer"
+                    }
+                ]
+            }
+        });
+
+        let result = register_openai_llm_providers(&center, &settings);
+
+        assert!(result.is_err());
+        assert!(center.registry().inventories().is_empty());
     }
 
     #[test]

--- a/src/frame/aicc/src/sn_ai_provider.rs
+++ b/src/frame/aicc/src/sn_ai_provider.rs
@@ -1,4 +1,4 @@
-use crate::aicc::{AIComputeCenter, Provider};
+use crate::aicc::AIComputeCenter;
 use crate::openai::{OpenAIInstanceConfig, OpenAIProvider};
 use anyhow::{anyhow, Result};
 use log::info;
@@ -119,17 +119,17 @@ pub fn register_sn_ai_provider(center: &AIComputeCenter, settings: &Value) -> Re
         return Ok(0);
     };
     let instances = build_sn_ai_provider_instances(&sn_settings)?;
-    let mut prepared = Vec::<(OpenAIInstanceConfig, Arc<dyn Provider>)>::new();
+    let mut prepared = Vec::<(OpenAIInstanceConfig, Arc<OpenAIProvider>)>::new();
     for config in instances.iter() {
         let provider = Arc::new(OpenAIProvider::new(
             config.clone(),
             config.api_token.as_str(),
         )?);
-        provider.clone().start_inventory_refresh();
         prepared.push((config.clone(), provider));
     }
 
     for (config, provider) in prepared.into_iter() {
+        provider.clone().start_inventory_refresh();
         let inventory = center.registry().add_provider(provider);
         info!(
             "registered sn-ai-provider base_url={} inventory={:?}",
@@ -192,5 +192,33 @@ mod tests {
             parsed.instances[0].provider_instance_name,
             "sn-ai-provider-alias"
         );
+    }
+
+    #[tokio::test]
+    async fn registration_error_does_not_start_prepared_refresh() {
+        let center = AIComputeCenter::default();
+        let settings = json!({
+            "sn-ai-provider": {
+                "enabled": true,
+                "instances": [
+                    {
+                        "provider_instance_name": "sn-valid",
+                        "api_token": "token",
+                        "base_url": "http://127.0.0.1:1",
+                        "auth_mode": "bearer",
+                        "timeout_ms": 100
+                    },
+                    {
+                        "provider_instance_name": "sn-invalid",
+                        "auth_mode": "bearer"
+                    }
+                ]
+            }
+        });
+
+        let result = register_sn_ai_provider(&center, &settings);
+
+        assert!(result.is_err());
+        assert!(center.registry().inventories().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Stop stale provider inventory refresh loops when AICC provider settings are reloaded.
- Add provider shutdown hook and cooperative refresh-loop shutdown for OpenAI/sn-ai-provider, Claude, and Gemini.
- Avoid aborting in-flight refresh requests; current refresh completes before the loop exits.

## Verification
- git diff --check -- src/frame/aicc/src/aicc.rs src/frame/aicc/src/openai.rs src/frame/aicc/src/claude.rs src/frame/aicc/src/gemini.rs
- cargo test --manifest-path src/frame/aicc/Cargo.toml (blocked by external name-client missing sha2 dependency)