### PR TITLE
fix(runtime): report expired session tokens clearly

### DIFF
--- a/src/kernel/buckyos-api/src/runtime.rs
+++ b/src/kernel/buckyos-api/src/runtime.rs
@@ -1721,12 +1721,30 @@ impl BuckyOSRuntime {
                         return new_session_token_str;
                     }
                 }
-                warn!("session-token expired!");
+                warn!("session token expired; re-authentication is required");
                 return "".to_string();
             }
         }
         warn!("use a session-token without expiration, it will be a BUG?");
         return session_token_str;
+    }
+
+    async fn get_required_session_token(&self) -> Result<String> {
+        let session_token = self.get_session_token().await;
+        if !session_token.trim().is_empty() {
+            return Ok(session_token);
+        }
+
+        let configured_session_token = self.session_token.read().await;
+        if configured_session_token.trim().is_empty() {
+            return Err(RPCErrors::InvalidToken(
+                "session token is missing; authentication is required".to_string(),
+            ));
+        }
+
+        Err(RPCErrors::TokenExpired(
+            "session token is expired; re-authentication is required".to_string(),
+        ))
     }
 
     pub fn get_data_folder(&self) -> Result<PathBuf> {
@@ -1985,7 +2003,7 @@ impl BuckyOSRuntime {
         let url = self.get_system_config_url();
 
         //let url = self.get_zone_service_url("system_config",self.force_https)?;
-        let session_token = self.get_session_token().await;
+        let session_token = self.get_required_session_token().await?;
         let client = self
             .system_config_client
             .get_or_try_init(|| async {
@@ -2261,10 +2279,10 @@ impl BuckyOSRuntime {
         let url = self
             .get_zone_service_url(service_name, self.force_https)
             .await?;
-        let session_token = self.session_token.read().await;
+        let session_token = self.get_required_session_token().await?;
         let timeout_secs = default_timeout_secs.unwrap_or(DEFAULT_KRPC_TIMEOUT_SECS);
 
-        let client = kRPC::new_with_timeout_secs(&url, Some(session_token.clone()), timeout_secs);
+        let client = kRPC::new_with_timeout_secs(&url, Some(session_token), timeout_secs);
         Ok(client)
     }
 
@@ -2395,6 +2413,43 @@ mod tests {
             client_b.get_session_token().await,
             Some("token-b".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn required_session_token_reports_missing_and_expired_states() {
+        let runtime = BuckyOSRuntime::new("session_test", None, BuckyOSRuntimeType::Kernel);
+
+        let missing_error = runtime
+            .get_required_session_token()
+            .await
+            .expect_err("missing session token must fail locally");
+        assert!(matches!(
+            missing_error,
+            RPCErrors::InvalidToken(message)
+                if message == "session token is missing; authentication is required"
+        ));
+
+        let expired_token = serde_json::json!({
+            "appid": "session_test",
+            "exp": buckyos_get_unix_timestamp().saturating_sub(1),
+            "iss": "ood1",
+            "sub": "alice"
+        })
+        .to_string();
+        {
+            let mut session_token = runtime.session_token.write().await;
+            *session_token = expired_token;
+        }
+
+        let expired_error = match runtime.get_system_config_client().await {
+            Ok(_) => panic!("expired session token must fail before an RPC request"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            expired_error,
+            RPCErrors::TokenExpired(message)
+                if message == "session token is expired; re-authentication is required"
+        ));
     }
 
     #[tokio::test]

--- a/src/kernel/buckyos-api/src/runtime.rs
+++ b/src/kernel/buckyos-api/src/runtime.rs
@@ -1747,6 +1747,15 @@ impl BuckyOSRuntime {
         ))
     }
 
+    async fn get_optional_session_token(&self) -> Option<String> {
+        let session_token = self.get_session_token().await;
+        if session_token.trim().is_empty() {
+            None
+        } else {
+            Some(session_token)
+        }
+    }
+
     pub fn get_data_folder(&self) -> Result<PathBuf> {
         match self.runtime_type {
             BuckyOSRuntimeType::AppClient => Err(self.unsupported_error("get_data_folder")),
@@ -2279,10 +2288,10 @@ impl BuckyOSRuntime {
         let url = self
             .get_zone_service_url(service_name, self.force_https)
             .await?;
-        let session_token = self.get_required_session_token().await?;
+        let session_token = self.get_optional_session_token().await;
         let timeout_secs = default_timeout_secs.unwrap_or(DEFAULT_KRPC_TIMEOUT_SECS);
 
-        let client = kRPC::new_with_timeout_secs(&url, Some(session_token), timeout_secs);
+        let client = kRPC::new_with_timeout_secs(&url, session_token, timeout_secs);
         Ok(client)
     }
 
@@ -2419,6 +2428,8 @@ mod tests {
     async fn required_session_token_reports_missing_and_expired_states() {
         let runtime = BuckyOSRuntime::new("session_test", None, BuckyOSRuntimeType::Kernel);
 
+        assert_eq!(runtime.get_optional_session_token().await, None);
+
         let missing_error = runtime
             .get_required_session_token()
             .await
@@ -2428,6 +2439,22 @@ mod tests {
             RPCErrors::InvalidToken(message)
                 if message == "session token is missing; authentication is required"
         ));
+
+        let valid_token = serde_json::json!({
+            "appid": "session_test",
+            "exp": buckyos_get_unix_timestamp().saturating_add(60),
+            "iss": "ood1",
+            "sub": "alice"
+        })
+        .to_string();
+        {
+            let mut session_token = runtime.session_token.write().await;
+            *session_token = valid_token.clone();
+        }
+        assert_eq!(
+            runtime.get_optional_session_token().await,
+            Some(valid_token)
+        );
 
         let expired_token = serde_json::json!({
             "appid": "session_test",
@@ -2440,6 +2467,8 @@ mod tests {
             let mut session_token = runtime.session_token.write().await;
             *session_token = expired_token;
         }
+
+        assert_eq!(runtime.get_optional_session_token().await, None);
 
         let expired_error = match runtime.get_system_config_client().await {
             Ok(_) => panic!("expired session token must fail before an RPC request"),


### PR DESCRIPTION
## Summary

- make the authentication-required SystemConfig client reject an expired session token with an explicit re-authentication message
- distinguish a missing token as `RPCErrors::InvalidToken` and an expired token as `RPCErrors::TokenExpired`
- let generic zone-service clients pass `None` when the token is missing or expired, so the target KAPI retains control over anonymous access

## Why

When a VerifyHub refresh session is lost, the runtime currently turns the expired token into an empty token. Authentication-required clients can then issue misleading downstream errors such as `JWT decode header error` or `service info not found` instead of reporting that re-authentication is required.

Generic zone-service transport remains usable without a token because login, refresh, bootstrap, and other anonymous KAPIs must be able to apply their own authentication policy.

This PR only improves local error classification and messaging. It does not change refresh-token persistence or recovery behavior.

## Tests

- `cargo fmt -p buckyos-api -- --check`
- `cargo test -p buckyos-api` (113 passed)
