### PR TITLE
修复 MessageCenter 入站恢复与幂等持久化

### DIFF
--- a/doc/message_hub/Message Center.md
+++ b/doc/message_hub/Message Center.md
@@ -410,6 +410,65 @@ MessageCenter 可以建立 `thread.topic → session_id` 的映射（同 topic �
 - 一次 `dispatch`/`post_send` 的全部 record + 索引写入放在**单个本地 RDB 事务**里：不存在"SENT 写了、DeliveryRecord 没写"的中间态。
 - 变更通知在事务提交**之后**发出，失败不回滚事务（通知是加速信号）。
 
+### 6.3.1 `msg_idempotency`
+
+`msg_idempotency` 是 `dispatch` / `post_send` 的持久幂等边界。主键是
+`(scope, idempotency_key)`，其中 `scope` 取 `dispatch` 或 `post_send`。
+每条记录包含：
+
+- `state`：`pending` 或 `completed`。
+- `msg_id`：已确定的内容寻址消息 id。
+- `result_json`：`completed` 记录保存对应 RPC result 的 JSON；`pending` 记录为空。
+- `retention_key`：清理分桶，按外部会话或本地发送者维度控制保留量。
+- `expires_at_ms`：清理候选时间。
+
+服务在同一个本地 RDB 事务内完成：占用幂等键为 `pending`，写入全部
+mailbox / delivery 副作用，再把同一行更新为 `completed` 并写入
+`result_json`。重复请求命中 `completed` 时直接返回 `result_json`，不重放
+副作用；命中未过期 `pending` 时必须稍后重试，不能再次执行。
+
+`expires_at_ms` 只作为物理清理依据，不作为幂等命中依据：只要 DB 中仍存在
+`completed` 记录，重复请求就必须返回已保存的 `result_json`，不能因为
+`expires_at_ms` 已过而重放副作用。DB 是唯一幂等命中源，不再维护内存
+幂等缓存。30 天是最短保留窗口，不是到点立即失效的逻辑 TTL。
+
+物理删除采用分桶和全局两层容量水位。单个 `retention_key` 超过 3,000 行时，
+按 `expires_at_ms` 从旧到新删除该 bucket 内已经过期的记录，并尽量降到 2,000
+行；未过期记录不得删除，其它 bucket 不受分桶清理影响。全表超过 100,000 行
+时启动全局清理，按相同顺序删除任意 bucket 的过期记录，逐轮降到 80,000 行。
+全局清理每批最多删除 10,000 行，避免服务启动或长期停机后在一个事务中清空
+大量记录。服务每小时枚举并清理一次超限 bucket，再启动一批全局清理；若该批
+删满 10,000 行且仍高于目标水位，后续消息写入会继续执行全局清理批次，直到
+降到目标水位或某批没有删满。30 天内的记录不受任一容量水位影响。
+
+`result_json` 使用 schema version 7 下 RPC result 的 serde JSON 表示，不再
+额外嵌套 envelope：
+
+- `scope=dispatch`：对象字段为 `ok: bool`、`msg_id: ObjId string`，以及可选的
+  `delivered_recipients: DID[]`、`dropped_recipients: DID[]`、
+  `delivered_group: DID`、`delivered_agents: DID[]`、`reason: string`；空数组和
+  `None` 字段序列化时省略。
+- `scope=post_send`：对象字段为 `ok: bool`、`msg_id: ObjId string`、可选的
+  `deliveries` 和 `reason`。每个 delivery 包含 `delivery_id`、`transport_did`、
+  `target_did`、`transport`；`transport` 为 `{"kind":"native"}`，或
+  `{"kind":"tunnel","platform":string,"tunnel_instance_id":string}`。
+
+`scope`、主键语义、`state` 状态机及上述结果字段在 version 7 内冻结；未来增加
+或改变结果字段必须提升 MessageCenter RDB schema version。当前共享 schema
+version 为 7，存放在 scheduler 下发的 msg-center RDB instance spec 中。
+beta2.2 尚处于 breaking-change 阶段，version 5/6 到 version 7 采用 no-compat
+策略：旧实例数据必须重建，不提供表内迁移。
+
+主要查询及索引：
+
+- `(scope, idempotency_key)` 精确命中由主键支持。
+- 超限 bucket 枚举和 bucket 行数统计由
+  `idx_msg_idempotency_retention_expire(retention_key, expires_at_ms)` 支持。
+- bucket 内按过期时间选择删除候选由同一索引支持；每小时的超限 bucket 枚举
+  会扫描该索引，是受 sweep 间隔控制的维护成本，不进入每次读取路径。
+- 全局清理的过期候选由 `idx_msg_idempotency_expire(expires_at_ms)` 支持，并受
+  全局水位和单批 10,000 行上限约束；连续批次由后续消息写入驱动。
+
 ### 6.4 崩溃恢复
 
 1. **DELIVERY_QUEUE 扫描**：启动时与定时 sweep 扫 `WAIT`（到期重试）与 `SENDING`（租约超时收回 → `WAIT`，标注 duplicate risk）。实时通知丢失不影响最终投递。

--- a/doc/message_hub/Message Tunnel Design.md
+++ b/doc/message_hub/Message Tunnel Design.md
@@ -257,6 +257,16 @@ delivery_id = hash(msg_id + target_did + executor_did)      # executor_did 即 t
 
 要求：同一平台事件重复上报得到同一 key；key 不含重试次数/批次/本地时间；持久化存储（带 TTL/容量控制），不能只放内存。
 
+`MessageCenter` 以 `msg_idempotency(scope, idempotency_key)` 保存入站和
+`post_send` 幂等结果。记录先在事务内占用为 `pending`，全部 mailbox /
+delivery 副作用写入成功后再更新为 `completed` 和结果 JSON。TTL 只作为物理
+清理候选依据，不作为命中依据；只要 DB 记录仍在，就必须命中。清理先按
+`retention_key` 分桶控制热点：同一个外部会话或本地发送者 bucket 超过 3,000
+行后，只删除该 bucket 内已过期记录并尽量降到 2,000 行。另有全表
+100,000 → 80,000 的容量水位，用于清理大量低基数 bucket 中的过期记录；全局
+清理单批最多删除 10,000 行，删满且仍高于目标水位时由后续消息写入
+继续触发批次。两层清理都不得删除 30 天内的记录。
+
 **平台层幂等**：平台支持 client message id 时带上 `delivery_id`；发送超时后状态未知时，回报 retryable failure 并标记 duplicate risk，重试前尽量用外部 id 查询确认。
 
 ### 6.3 四级投递语义
@@ -279,7 +289,7 @@ remote read           远端已读（平台 read receipt，若有）            
 ### 6.5 顺序与漏消息恢复
 
 - 顺序：只承诺同一外部会话内尽量按平台顺序提交；严格因果用 `thread.reply_to` / `correlation_id` / `ext_ids`。
-- 入站恢复：平台 offset/cursor 持久化，处理成功后推进；重启后按 cursor/时间窗补拉。
+- 入站恢复：平台 offset/cursor 持久化，处理成功后推进；重启后按 cursor/时间窗补拉。offset/cursor 读取失败或数据非法时必须暂停 polling 并重试，不能退回 0 开始拉取。
 - 出站恢复：`DELIVERY_QUEUE` 扫描（`WAIT` 到期 + `SENDING` 租约超时）。
 - webhook/stream/kevent 只能作为加速信号，不能作为唯一真相。
 

--- a/doc/message_hub/Message Tunnel Minimal Spec.md
+++ b/doc/message_hub/Message Tunnel Minimal Spec.md
@@ -140,8 +140,9 @@ WAIT → SENDING → SENT
 
 - 出站幂等键：`msg_id + target_did + executor_did`；重复提交/重放收敛到同一 `DeliveryRecord`。
 - 入站幂等键：`{platform}:{tunnel_account_id}:{chat_id}:{external_message_id}`；无稳定 id 时用 `{event_timestamp}:{payload_hash}` 组合；必须持久化（带 TTL），不能只放内存。
+- 持久幂等记录使用 `pending` / `completed` 状态；业务副作用和 completed 结果必须在同一个本地 RDB 事务内提交。TTL 只作为物理清理候选依据，不作为命中依据。清理采用两层容量水位：单个 `retention_key` bucket 超过 3,000 行后删除该 bucket 的过期记录并尽量降到 2,000 行；全表超过 100,000 行后分批删除所有 bucket 的过期记录并逐轮降到 80,000 行，单批最多删除 10,000 行，删满后由后续消息写入继续触发。30 天内的记录不得删除。
 - 投递语义四级：submission accepted → transport accepted（`SENT`）→ remote delivered → remote read；`SENT` 只承诺 transport accepted。
-- 恢复：入站靠平台 offset/cursor 持久化补拉；出站靠 `DELIVERY_QUEUE` 扫描（`WAIT` 到期 + `SENDING` 租约超时 sweep）；webhook/stream/kevent 只是加速信号。
+- 恢复：入站靠平台 offset/cursor 持久化补拉；offset/cursor 读取失败或数据非法时暂停 polling 并重试，不能退回 0；出站靠 `DELIVERY_QUEUE` 扫描（`WAIT` 到期 + `SENDING` 租约超时 sweep）；webhook/stream/kevent 只是加速信号。
 - 顺序：同一外部会话内尽量按平台顺序提交；严格因果用 `thread.reply_to`/`correlation_id`/`ext_ids`。
 
 ## 7. 流式 AI 消息

--- a/src/frame/msg_center/src/contact_mgr.rs
+++ b/src/frame/msg_center/src/contact_mgr.rs
@@ -2349,7 +2349,8 @@ mod tests {
     async fn new_test_mgr() -> (ContactMgr, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("contacts.sqlite3");
-        let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
+        let db_path = db_path.to_string_lossy().replace('\\', "/");
+        let conn = format!("sqlite:///{}?mode=rwc", db_path);
         let msg_box_db = MsgBoxDbMgr::open_default_sqlite(&conn).await.unwrap();
         let mgr = ContactMgr::new_with_msg_box(msg_box_db).await.unwrap();
         (mgr, temp_dir)

--- a/src/frame/msg_center/src/group_mgr.rs
+++ b/src/frame/msg_center/src/group_mgr.rs
@@ -2286,7 +2286,8 @@ mod tests {
     async fn new_test_mgr() -> (GroupMgr, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("groups.sqlite3");
-        let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
+        let db_path = db_path.to_string_lossy().replace('\\', "/");
+        let conn = format!("sqlite:///{}?mode=rwc", db_path);
         let msg_box_db = MsgBoxDbMgr::open_default_sqlite(&conn).await.unwrap();
         let mgr = GroupMgr::new_with_msg_box(msg_box_db);
         (mgr, temp_dir)

--- a/src/frame/msg_center/src/msg_box_db.rs
+++ b/src/frame/msg_center/src/msg_box_db.rs
@@ -30,7 +30,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
 use sqlx::any::{install_default_drivers, AnyPoolOptions, AnyRow};
-use sqlx::{AnyPool, Executor, Row};
+use sqlx::{Any, AnyPool, Executor, Row, Transaction};
 use std::sync::{Arc, Once};
 
 static INSTALL_DRIVERS: Once = Once::new();
@@ -45,6 +45,17 @@ pub struct SessionIndexEntry {
     pub session_id: String,
     pub updated_at_ms: u64,
     pub unread_count: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct IdempotencyStoredResult<T> {
+    pub result: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdempotencyCommitOutcome<T> {
+    Reused(T),
+    Committed,
 }
 
 #[derive(Clone, Debug)]
@@ -182,6 +193,288 @@ impl MsgBoxDbMgr {
         }
     }
 
+    async fn upsert_record_row_tx(
+        &self,
+        tx: &mut Transaction<'_, Any>,
+        record: &MailboxRecord,
+        msg: Option<&MsgObject>,
+    ) -> std::result::Result<(), RPCErrors> {
+        let tags_json = serde_json::to_string(&record.tags).map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "failed to encode tags of mailbox record {}: {}",
+                record.record_id, error
+            ))
+        })?;
+        let ingress_json =
+            encode_optional_json(record.ingress.as_ref(), &record.record_id, "ingress")?;
+        let msg_from = Some(
+            msg.map(|obj| obj.from.clone())
+                .unwrap_or_else(|| record.from.clone())
+                .to_string(),
+        );
+        let msg_to = Some(
+            msg.and_then(|obj| obj.to.first().cloned())
+                .unwrap_or_else(|| record.to.clone())
+                .to_string(),
+        );
+        let msg_kind = msg.map(|obj| obj.kind).unwrap_or(record.msg_kind);
+
+        let sql = self.render_sql(&format!(
+            r#"
+INSERT INTO mailbox_records ({MAILBOX_COLUMNS})
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(owner, record_id) DO UPDATE SET
+    msg_kind = COALESCE(excluded.msg_kind, mailbox_records.msg_kind),
+    session_id = COALESCE(mailbox_records.session_id, excluded.session_id)
+"#
+        ));
+
+        sqlx::query(&sql)
+            .bind(record.owner.to_string())
+            .bind(record.record_id.clone())
+            .bind(mailbox_kind_name(&record.box_kind).to_string())
+            .bind(record.msg_id.to_string())
+            .bind(Some(msg_obj_kind_name(&msg_kind).to_string()))
+            .bind(msg_from)
+            .bind(msg_to)
+            .bind(recipient_state_name(&record.state).to_string())
+            .bind(record.session_id.clone())
+            .bind(to_sql_i64(record.sort_key))
+            .bind(tags_json)
+            .bind(ingress_json)
+            .bind(to_sql_i64(record.created_at_ms))
+            .bind(to_sql_i64(record.updated_at_ms))
+            .execute(&mut **tx)
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to upsert mailbox record {}: {}",
+                    record.record_id, error
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn touch_message_tx(
+        &self,
+        tx: &mut Transaction<'_, Any>,
+        owner: &DID,
+        msg_id: &ObjId,
+        created_at_ms: u64,
+    ) -> std::result::Result<(), RPCErrors> {
+        let sql = self.render_sql(
+            "INSERT INTO msg_refs(owner, msg_id, created_at_ms) VALUES(?, ?, ?)
+             ON CONFLICT(owner, msg_id) DO NOTHING",
+        );
+        sqlx::query(&sql)
+            .bind(owner.to_string())
+            .bind(msg_id.to_string())
+            .bind(to_sql_i64(created_at_ms))
+            .execute(&mut **tx)
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to persist message ref {}: {}",
+                    msg_id.to_string(),
+                    error
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn upsert_record_with_msg_tx(
+        &self,
+        tx: &mut Transaction<'_, Any>,
+        record: &MailboxRecord,
+        msg: Option<&MsgObject>,
+    ) -> std::result::Result<(), RPCErrors> {
+        self.upsert_record_row_tx(tx, record, msg).await?;
+        self.touch_message_tx(tx, &record.owner, &record.msg_id, record.created_at_ms)
+            .await
+    }
+
+    async fn create_delivery_if_absent_tx(
+        &self,
+        tx: &mut Transaction<'_, Any>,
+        record: &DeliveryRecord,
+    ) -> std::result::Result<(), RPCErrors> {
+        let envelope_json = serde_json::to_string(&record.envelope).map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "failed to encode delivery envelope {}: {}",
+                record.delivery_id, error
+            ))
+        })?;
+        let last_error_json = encode_optional_json(
+            record.last_error.as_ref(),
+            &record.delivery_id,
+            "last_error",
+        )?;
+        let sql = self.render_sql(&format!(
+            r#"
+INSERT INTO delivery_records ({DELIVERY_COLUMNS})
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(delivery_id) DO NOTHING
+"#
+        ));
+        sqlx::query(&sql)
+            .bind(record.delivery_id.clone())
+            .bind(record.envelope.transport_did.to_string())
+            .bind(record.envelope.msg_id.to_string())
+            .bind(record.envelope.target_did.to_string())
+            .bind(envelope_json)
+            .bind(delivery_state_name(&record.state).to_string())
+            .bind(record.attempts as i64)
+            .bind(record.next_retry_at_ms.map(to_sql_i64))
+            .bind(record.external_msg_id.clone())
+            .bind(record.delivered_at_ms.map(to_sql_i64))
+            .bind(last_error_json)
+            .bind(to_sql_i64(record.created_at_ms))
+            .bind(to_sql_i64(record.updated_at_ms))
+            .execute(&mut **tx)
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to create delivery record {}: {}",
+                    record.delivery_id, error
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn prepare_idempotency_tx<T: DeserializeOwned>(
+        &self,
+        tx: &mut Transaction<'_, Any>,
+        scope: &str,
+        idempotency_key: &str,
+        retention_key: Option<&str>,
+        now_ms: u64,
+        expires_at_ms: Option<u64>,
+    ) -> std::result::Result<Option<T>, RPCErrors> {
+        let sql = self.render_sql(
+            "SELECT state, result_json, expires_at_ms FROM msg_idempotency
+             WHERE scope = ? AND idempotency_key = ?",
+        );
+        let row = sqlx::query(&sql)
+            .bind(scope.to_string())
+            .bind(idempotency_key.to_string())
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to query msg idempotency key {}:{}: {}",
+                    scope, idempotency_key, error
+                ))
+            })?;
+
+        if let Some(row) = row {
+            let state: String = row.try_get("state").map_err(|e| decode_err("state", &e))?;
+            let result_json: Option<String> = row
+                .try_get("result_json")
+                .map_err(|e| decode_err("result_json", &e))?;
+            if state == "completed" {
+                let Some(result_json) = result_json else {
+                    return Err(RPCErrors::ReasonError(format!(
+                        "completed msg idempotency key {}:{} has no result",
+                        scope, idempotency_key
+                    )));
+                };
+                let result = serde_json::from_str(&result_json).map_err(|error| {
+                    RPCErrors::ReasonError(format!(
+                        "failed to decode msg idempotency result {}:{}: {}",
+                        scope, idempotency_key, error
+                    ))
+                })?;
+                return Ok(Some(result));
+            } else {
+                return Err(RPCErrors::ReasonError(format!(
+                    "msg idempotency key {}:{} is pending",
+                    scope, idempotency_key
+                )));
+            }
+        }
+
+        let sql = self.render_sql(
+            "INSERT INTO msg_idempotency(
+                scope, idempotency_key, msg_id, retention_key, state, result_json,
+                created_at_ms, updated_at_ms, expires_at_ms
+             ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(scope, idempotency_key) DO NOTHING",
+        );
+        let result = sqlx::query(&sql)
+            .bind(scope.to_string())
+            .bind(idempotency_key.to_string())
+            .bind(Option::<String>::None)
+            .bind(retention_key.map(|value| value.to_string()))
+            .bind("pending")
+            .bind(Option::<String>::None)
+            .bind(to_sql_i64(now_ms))
+            .bind(to_sql_i64(now_ms))
+            .bind(expires_at_ms.map(to_sql_i64))
+            .execute(&mut **tx)
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to reserve msg idempotency key {}:{}: {}",
+                    scope, idempotency_key, error
+                ))
+            })?;
+        if result.rows_affected() == 0 {
+            return Err(RPCErrors::ReasonError(format!(
+                "msg idempotency key {}:{} is already reserved",
+                scope, idempotency_key
+            )));
+        }
+        Ok(None)
+    }
+
+    async fn complete_idempotency_tx<T: Serialize>(
+        &self,
+        tx: &mut Transaction<'_, Any>,
+        scope: &str,
+        idempotency_key: &str,
+        msg_id: Option<&ObjId>,
+        retention_key: Option<&str>,
+        result: &T,
+        now_ms: u64,
+        expires_at_ms: Option<u64>,
+    ) -> std::result::Result<(), RPCErrors> {
+        let result_json = serde_json::to_string(result).map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "failed to encode msg idempotency result {}:{}: {}",
+                scope, idempotency_key, error
+            ))
+        })?;
+        let sql = self.render_sql(
+            "UPDATE msg_idempotency
+             SET msg_id = ?, retention_key = ?, state = 'completed', result_json = ?,
+                 updated_at_ms = ?, expires_at_ms = ?
+             WHERE scope = ? AND idempotency_key = ? AND state = 'pending'",
+        );
+        let updated = sqlx::query(&sql)
+            .bind(msg_id.map(|id| id.to_string()))
+            .bind(retention_key.map(|value| value.to_string()))
+            .bind(result_json)
+            .bind(to_sql_i64(now_ms))
+            .bind(expires_at_ms.map(to_sql_i64))
+            .bind(scope.to_string())
+            .bind(idempotency_key.to_string())
+            .execute(&mut **tx)
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to complete msg idempotency key {}:{}: {}",
+                    scope, idempotency_key, error
+                ))
+            })?;
+        if updated.rows_affected() == 0 {
+            return Err(RPCErrors::ReasonError(format!(
+                "msg idempotency key {}:{} was not pending",
+                scope, idempotency_key
+            )));
+        }
+        Ok(())
+    }
+
     // ------------------------------------------------------------------
     // Mailbox records
     // ------------------------------------------------------------------
@@ -244,7 +537,7 @@ ON CONFLICT(owner, record_id) DO UPDATE SET
     sort_key = excluded.sort_key,
     tags_json = excluded.tags_json,
     ingress_json = COALESCE(excluded.ingress_json, mailbox_records.ingress_json),
-    created_at_ms = excluded.created_at_ms,
+    created_at_ms = mailbox_records.created_at_ms,
     updated_at_ms = excluded.updated_at_ms
 "#
         ));
@@ -523,6 +816,7 @@ ON CONFLICT(delivery_id) DO UPDATE SET
 
     /// Insert-if-absent for `post_send`: an existing delivery (idempotent
     /// resubmission) keeps its current state/attempts untouched.
+    #[allow(dead_code)]
     pub async fn create_delivery_if_absent(
         &self,
         record: &DeliveryRecord,
@@ -701,17 +995,17 @@ LIMIT 1
         &self,
         scope: &str,
         idempotency_key: &str,
-        now_ms: u64,
-    ) -> std::result::Result<Option<T>, RPCErrors> {
+        _now_ms: u64,
+    ) -> std::result::Result<Option<IdempotencyStoredResult<T>>, RPCErrors> {
         let sql = self.render_sql(
-            "SELECT result_json FROM msg_idempotency
+            "SELECT result_json, expires_at_ms FROM msg_idempotency
              WHERE scope = ? AND idempotency_key = ?
-               AND (expires_at_ms IS NULL OR expires_at_ms > ?)",
+               AND state = 'completed'
+               AND result_json IS NOT NULL",
         );
         let row = sqlx::query(&sql)
             .bind(scope.to_string())
             .bind(idempotency_key.to_string())
-            .bind(to_sql_i64(now_ms))
             .fetch_optional(self.pool())
             .await
             .map_err(|error| {
@@ -726,19 +1020,22 @@ LIMIT 1
         let result_json: String = row
             .try_get("result_json")
             .map_err(|e| decode_err("result_json", &e))?;
-        serde_json::from_str(&result_json).map(Some).map_err(|error| {
+        let result = serde_json::from_str(&result_json).map_err(|error| {
             RPCErrors::ReasonError(format!(
                 "failed to decode msg idempotency result {}:{}: {}",
                 scope, idempotency_key, error
             ))
-        })
+        })?;
+        Ok(Some(IdempotencyStoredResult { result }))
     }
 
+    #[allow(dead_code)]
     pub async fn upsert_idempotency_result<T: Serialize>(
         &self,
         scope: &str,
         idempotency_key: &str,
         msg_id: Option<&ObjId>,
+        retention_key: Option<&str>,
         result: &T,
         now_ms: u64,
         expires_at_ms: Option<u64>,
@@ -751,11 +1048,13 @@ LIMIT 1
         })?;
         let sql = self.render_sql(
             "INSERT INTO msg_idempotency(
-                scope, idempotency_key, msg_id, result_json,
+                scope, idempotency_key, msg_id, retention_key, state, result_json,
                 created_at_ms, updated_at_ms, expires_at_ms
-             ) VALUES(?, ?, ?, ?, ?, ?, ?)
+             ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(scope, idempotency_key) DO UPDATE SET
                 msg_id = excluded.msg_id,
+                retention_key = excluded.retention_key,
+                state = excluded.state,
                 result_json = excluded.result_json,
                 updated_at_ms = excluded.updated_at_ms,
                 expires_at_ms = excluded.expires_at_ms",
@@ -764,6 +1063,8 @@ LIMIT 1
             .bind(scope.to_string())
             .bind(idempotency_key.to_string())
             .bind(msg_id.map(|id| id.to_string()))
+            .bind(retention_key.map(|value| value.to_string()))
+            .bind("completed")
             .bind(result_json)
             .bind(to_sql_i64(now_ms))
             .bind(to_sql_i64(now_ms))
@@ -775,8 +1076,325 @@ LIMIT 1
                     "failed to upsert msg idempotency key {}:{}: {}",
                     scope, idempotency_key, error
                 ))
-            })?;
+        })?;
         Ok(())
+    }
+
+    pub async fn commit_dispatch_records<T>(
+        &self,
+        scope: &str,
+        idempotency_key: Option<&str>,
+        retention_key: Option<&str>,
+        msg_id: &ObjId,
+        msg: &MsgObject,
+        records: &[MailboxRecord],
+        result: &T,
+        now_ms: u64,
+        expires_at_ms: Option<u64>,
+    ) -> std::result::Result<IdempotencyCommitOutcome<T>, RPCErrors>
+    where
+        T: Serialize + DeserializeOwned + Clone,
+    {
+        let mut tx = self.pool().begin().await.map_err(|error| {
+            RPCErrors::ReasonError(format!("begin msg-center dispatch transaction failed: {}", error))
+        })?;
+        if let Some(key) = idempotency_key {
+            if let Some(cached) = self
+                .prepare_idempotency_tx::<T>(
+                    &mut tx,
+                    scope,
+                    key,
+                    retention_key,
+                    now_ms,
+                    expires_at_ms,
+                )
+                .await?
+            {
+                tx.commit().await.map_err(|error| {
+                    RPCErrors::ReasonError(format!(
+                        "commit reused msg idempotency transaction failed: {}",
+                        error
+                    ))
+                })?;
+                return Ok(IdempotencyCommitOutcome::Reused(cached));
+            }
+        }
+        for record in records {
+            self.upsert_record_with_msg_tx(&mut tx, record, Some(msg))
+                .await?;
+        }
+        if let Some(key) = idempotency_key {
+            self.complete_idempotency_tx(
+                &mut tx,
+                scope,
+                key,
+                Some(msg_id),
+                retention_key,
+                result,
+                now_ms,
+                expires_at_ms,
+            )
+            .await?;
+        }
+        tx.commit().await.map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "commit msg-center dispatch transaction failed: {}",
+                error
+            ))
+        })?;
+        Ok(IdempotencyCommitOutcome::Committed)
+    }
+
+    pub async fn commit_post_send_records<T>(
+        &self,
+        scope: &str,
+        idempotency_key: Option<&str>,
+        retention_key: Option<&str>,
+        msg_id: &ObjId,
+        msg: &MsgObject,
+        sent_record: Option<&MailboxRecord>,
+        deliveries: &[DeliveryRecord],
+        result: &T,
+        now_ms: u64,
+        expires_at_ms: Option<u64>,
+    ) -> std::result::Result<IdempotencyCommitOutcome<T>, RPCErrors>
+    where
+        T: Serialize + DeserializeOwned + Clone,
+    {
+        let mut tx = self.pool().begin().await.map_err(|error| {
+            RPCErrors::ReasonError(format!("begin msg-center post_send transaction failed: {}", error))
+        })?;
+        if let Some(key) = idempotency_key {
+            if let Some(cached) = self
+                .prepare_idempotency_tx::<T>(
+                    &mut tx,
+                    scope,
+                    key,
+                    retention_key,
+                    now_ms,
+                    expires_at_ms,
+                )
+                .await?
+            {
+                tx.commit().await.map_err(|error| {
+                    RPCErrors::ReasonError(format!(
+                        "commit reused msg idempotency transaction failed: {}",
+                        error
+                    ))
+                })?;
+                return Ok(IdempotencyCommitOutcome::Reused(cached));
+            }
+        }
+        if let Some(record) = sent_record {
+            self.upsert_record_with_msg_tx(&mut tx, record, Some(msg))
+                .await?;
+        }
+        for record in deliveries {
+            self.create_delivery_if_absent_tx(&mut tx, record).await?;
+        }
+        if let Some(key) = idempotency_key {
+            self.complete_idempotency_tx(
+                &mut tx,
+                scope,
+                key,
+                Some(msg_id),
+                retention_key,
+                result,
+                now_ms,
+                expires_at_ms,
+            )
+            .await?;
+        }
+        tx.commit().await.map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "commit msg-center post_send transaction failed: {}",
+                error
+            ))
+        })?;
+        Ok(IdempotencyCommitOutcome::Committed)
+    }
+
+    pub async fn sweep_expired_idempotency_bucket_by_capacity(
+        &self,
+        now_ms: u64,
+        retention_key: &str,
+        max_rows: u64,
+        target_rows: u64,
+    ) -> std::result::Result<u64, RPCErrors> {
+        if max_rows <= target_rows {
+            return Ok(0);
+        }
+        let count_sql = self
+            .render_sql("SELECT COUNT(*) AS row_count FROM msg_idempotency WHERE retention_key = ?");
+        let row = sqlx::query(&count_sql)
+            .bind(retention_key.to_string())
+            .fetch_one(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to count msg idempotency rows for bucket {}: {}",
+                    retention_key, error
+                ))
+            })?;
+        let row_count: i64 = row
+            .try_get("row_count")
+            .map_err(|e| decode_err("row_count", &e))?;
+        let row_count = row_count.max(0) as u64;
+        if row_count <= max_rows {
+            return Ok(0);
+        }
+        let delete_limit = row_count.saturating_sub(target_rows);
+        let sql = match self.backend() {
+            RdbBackend::Sqlite => self.render_sql(
+                "DELETE FROM msg_idempotency
+                 WHERE rowid IN (
+                     SELECT rowid FROM msg_idempotency
+                     WHERE retention_key = ?
+                       AND expires_at_ms IS NOT NULL AND expires_at_ms <= ?
+                     ORDER BY expires_at_ms ASC, updated_at_ms ASC
+                     LIMIT ?
+                 )",
+            ),
+            RdbBackend::Postgres => self.render_sql(
+                "DELETE FROM msg_idempotency
+                 WHERE ctid IN (
+                     SELECT ctid FROM msg_idempotency
+                     WHERE retention_key = ?
+                       AND expires_at_ms IS NOT NULL AND expires_at_ms <= ?
+                     ORDER BY expires_at_ms ASC, updated_at_ms ASC
+                     LIMIT ?
+                 )",
+            ),
+        };
+        let result = sqlx::query(&sql)
+            .bind(retention_key.to_string())
+            .bind(to_sql_i64(now_ms))
+            .bind(delete_limit.min(i64::MAX as u64) as i64)
+            .execute(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to delete expired msg idempotency rows: {}",
+                    error
+                ))
+            })?;
+        Ok(result.rows_affected())
+    }
+
+    pub async fn sweep_expired_idempotency_buckets_by_capacity(
+        &self,
+        now_ms: u64,
+        max_rows: u64,
+        target_rows: u64,
+    ) -> std::result::Result<u64, RPCErrors> {
+        if max_rows <= target_rows {
+            return Ok(0);
+        }
+        let sql = self.render_sql(
+            "SELECT retention_key, COUNT(*) AS row_count
+             FROM msg_idempotency
+             WHERE retention_key IS NOT NULL
+             GROUP BY retention_key
+             HAVING COUNT(*) > ?",
+        );
+        let rows = sqlx::query(&sql)
+            .bind(max_rows.min(i64::MAX as u64) as i64)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to list over-capacity msg idempotency buckets: {}",
+                    error
+                ))
+            })?;
+
+        let mut deleted = 0_u64;
+        for row in rows {
+            let retention_key: String = row
+                .try_get("retention_key")
+                .map_err(|e| decode_err("retention_key", &e))?;
+            deleted = deleted.saturating_add(
+                self.sweep_expired_idempotency_bucket_by_capacity(
+                    now_ms,
+                    &retention_key,
+                    max_rows,
+                    target_rows,
+                )
+                .await?,
+            );
+        }
+        Ok(deleted)
+    }
+
+    pub async fn sweep_expired_idempotency_global_by_capacity(
+        &self,
+        now_ms: u64,
+        max_rows: u64,
+        target_rows: u64,
+        batch_rows: u64,
+        continue_to_target: bool,
+    ) -> std::result::Result<(u64, u64), RPCErrors> {
+        if max_rows <= target_rows || batch_rows == 0 {
+            return Ok((0, 0));
+        }
+        let row = sqlx::query("SELECT COUNT(*) AS row_count FROM msg_idempotency")
+            .fetch_one(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to count global msg idempotency rows: {}",
+                    error
+                ))
+            })?;
+        let row_count: i64 = row
+            .try_get("row_count")
+            .map_err(|e| decode_err("row_count", &e))?;
+        let row_count = row_count.max(0) as u64;
+        let trigger_rows = if continue_to_target {
+            target_rows
+        } else {
+            max_rows
+        };
+        if row_count <= trigger_rows {
+            return Ok((0, row_count));
+        }
+        let delete_limit = row_count
+            .saturating_sub(target_rows)
+            .min(batch_rows)
+            .min(i64::MAX as u64) as i64;
+        let sql = match self.backend() {
+            RdbBackend::Sqlite => self.render_sql(
+                "DELETE FROM msg_idempotency
+                 WHERE rowid IN (
+                     SELECT rowid FROM msg_idempotency
+                     WHERE expires_at_ms IS NOT NULL AND expires_at_ms <= ?
+                     ORDER BY expires_at_ms ASC, updated_at_ms ASC
+                     LIMIT ?
+                 )",
+            ),
+            RdbBackend::Postgres => self.render_sql(
+                "DELETE FROM msg_idempotency
+                 WHERE ctid IN (
+                     SELECT ctid FROM msg_idempotency
+                     WHERE expires_at_ms IS NOT NULL AND expires_at_ms <= ?
+                     ORDER BY expires_at_ms ASC, updated_at_ms ASC
+                     LIMIT ?
+                 )",
+            ),
+        };
+        let result = sqlx::query(&sql)
+            .bind(to_sql_i64(now_ms))
+            .bind(delete_limit)
+            .execute(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to delete global expired msg idempotency rows: {}",
+                    error
+                ))
+            })?;
+        let deleted = result.rows_affected();
+        Ok((deleted, row_count.saturating_sub(deleted)))
     }
 
     pub async fn has_message(
@@ -1337,7 +1955,8 @@ mod tests {
     async fn setup_test_mgr() -> (MsgBoxDbMgr, tempfile::TempDir) {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().join("msg-box.db");
-        let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
+        let db_path = db_path.to_string_lossy().replace('\\', "/");
+        let conn = format!("sqlite:///{}?mode=rwc", db_path);
         let mgr = MsgBoxDbMgr::open_default_sqlite(&conn).await.unwrap();
         (mgr, temp_dir)
     }
@@ -1517,6 +2136,207 @@ mod tests {
             .unwrap();
         assert_eq!(again.attempts, 1);
         assert!(again.last_error.is_none() || again.last_error.unwrap().duplicate_risk);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idempotency_result_hits_until_capacity_sweep_deletes_expired_rows() {
+        let (mgr, _tmp) = setup_test_mgr().await;
+        let stored = serde_json::json!({
+            "ok": true,
+            "msg_id": "mobjchat:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        });
+        mgr.upsert_idempotency_result(
+            "dispatch",
+            "idem-expiring",
+            None,
+            Some("bucket-a"),
+            &stored,
+            100,
+            Some(200),
+        )
+        .await
+        .unwrap();
+
+        let hit: Option<IdempotencyStoredResult<Value>> = mgr
+            .get_idempotency_result("dispatch", "idem-expiring", 150)
+            .await
+            .unwrap();
+        assert!(hit.is_some());
+        let expired: Option<IdempotencyStoredResult<Value>> = mgr
+            .get_idempotency_result("dispatch", "idem-expiring", 201)
+            .await
+            .unwrap();
+        assert!(expired.is_some());
+
+        let below_capacity = mgr
+            .sweep_expired_idempotency_bucket_by_capacity(201, "bucket-a", 10, 5)
+            .await
+            .unwrap();
+        assert_eq!(below_capacity, 0);
+
+        mgr.upsert_idempotency_result(
+            "dispatch",
+            "idem-fresh",
+            None,
+            Some("bucket-a"),
+            &stored,
+            100,
+            Some(300),
+        )
+        .await
+        .unwrap();
+        mgr.upsert_idempotency_result(
+            "dispatch",
+            "idem-other-bucket-expiring",
+            None,
+            Some("bucket-b"),
+            &stored,
+            100,
+            Some(200),
+        )
+        .await
+        .unwrap();
+        let deleted = mgr
+            .sweep_expired_idempotency_bucket_by_capacity(201, "bucket-a", 1, 0)
+            .await
+            .unwrap();
+        assert_eq!(deleted, 1);
+        let fresh: Option<IdempotencyStoredResult<Value>> = mgr
+            .get_idempotency_result("dispatch", "idem-fresh", 201)
+            .await
+            .unwrap();
+        assert!(fresh.is_some());
+        let other_bucket: Option<IdempotencyStoredResult<Value>> = mgr
+            .get_idempotency_result("dispatch", "idem-other-bucket-expiring", 201)
+            .await
+            .unwrap();
+        assert!(other_bucket.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idempotency_global_sweep_cleans_every_over_capacity_bucket() {
+        let (mgr, _tmp) = setup_test_mgr().await;
+        let stored = serde_json::json!({"ok": true});
+        for bucket in ["bucket-a", "bucket-b"] {
+            for suffix in 0..2 {
+                mgr.upsert_idempotency_result(
+                    "dispatch",
+                    &format!("{bucket}-{suffix}"),
+                    None,
+                    Some(bucket),
+                    &stored,
+                    100,
+                    Some(200),
+                )
+                .await
+                .unwrap();
+            }
+        }
+        mgr.upsert_idempotency_result(
+            "dispatch",
+            "bucket-c-0",
+            None,
+            Some("bucket-c"),
+            &stored,
+            100,
+            Some(200),
+        )
+        .await
+        .unwrap();
+
+        let deleted = mgr
+            .sweep_expired_idempotency_buckets_by_capacity(201, 1, 0)
+            .await
+            .unwrap();
+        assert_eq!(deleted, 4);
+
+        for bucket in ["bucket-a", "bucket-b"] {
+            for suffix in 0..2 {
+                let result: Option<IdempotencyStoredResult<Value>> = mgr
+                    .get_idempotency_result(
+                        "dispatch",
+                        &format!("{bucket}-{suffix}"),
+                        201,
+                    )
+                    .await
+                    .unwrap();
+                assert!(result.is_none());
+            }
+        }
+        let under_capacity: Option<IdempotencyStoredResult<Value>> = mgr
+            .get_idempotency_result("dispatch", "bucket-c-0", 201)
+            .await
+            .unwrap();
+        assert!(under_capacity.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idempotency_global_capacity_sweep_handles_high_cardinality_buckets_in_batches() {
+        let (mgr, _tmp) = setup_test_mgr().await;
+        let stored = serde_json::json!({"ok": true});
+        for suffix in 0..4 {
+            mgr.upsert_idempotency_result(
+                "dispatch",
+                &format!("expired-{suffix}"),
+                None,
+                Some(&format!("bucket-{suffix}")),
+                &stored,
+                100,
+                Some(200),
+            )
+            .await
+            .unwrap();
+        }
+        for suffix in 0..2 {
+            mgr.upsert_idempotency_result(
+                "dispatch",
+                &format!("fresh-{suffix}"),
+                None,
+                Some(&format!("fresh-bucket-{suffix}")),
+                &stored,
+                100,
+                Some(300),
+            )
+            .await
+            .unwrap();
+        }
+
+        let mut continue_to_target = false;
+        for expected_remaining in [5, 4, 3, 2] {
+            let (deleted, remaining) = mgr
+                .sweep_expired_idempotency_global_by_capacity(
+                    201,
+                    4,
+                    2,
+                    1,
+                    continue_to_target,
+                )
+                .await
+                .unwrap();
+            assert_eq!(deleted, 1);
+            assert_eq!(remaining, expected_remaining);
+            continue_to_target = remaining > 2;
+        }
+
+        let (deleted, remaining) = mgr
+            .sweep_expired_idempotency_global_by_capacity(201, 4, 2, 1, continue_to_target)
+            .await
+            .unwrap();
+        assert_eq!((deleted, remaining), (0, 2));
+        for suffix in 0..4 {
+            let result: Option<IdempotencyStoredResult<Value>> = mgr
+                .get_idempotency_result("dispatch", &format!("expired-{suffix}"), 201)
+                .await
+                .unwrap();
+            assert!(result.is_none());
+        }
+        for suffix in 0..2 {
+            let result: Option<IdempotencyStoredResult<Value>> = mgr
+                .get_idempotency_result("dispatch", &format!("fresh-{suffix}"), 201)
+                .await
+                .unwrap();
+            assert!(result.is_some());
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/frame/msg_center/src/msg_box_db.rs
+++ b/src/frame/msg_center/src/msg_box_db.rs
@@ -27,6 +27,7 @@ use log::info;
 use name_lib::DID;
 use ndn_lib::{MsgObject, ObjId};
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use serde_json::Value;
 use sqlx::any::{install_default_drivers, AnyPoolOptions, AnyRow};
 use sqlx::{AnyPool, Executor, Row};
@@ -691,6 +692,88 @@ LIMIT 1
                     "failed to persist message ref {}: {}",
                     msg_id.to_string(),
                     error
+                ))
+            })?;
+        Ok(())
+    }
+
+    pub async fn get_idempotency_result<T: DeserializeOwned>(
+        &self,
+        scope: &str,
+        idempotency_key: &str,
+        now_ms: u64,
+    ) -> std::result::Result<Option<T>, RPCErrors> {
+        let sql = self.render_sql(
+            "SELECT result_json FROM msg_idempotency
+             WHERE scope = ? AND idempotency_key = ?
+               AND (expires_at_ms IS NULL OR expires_at_ms > ?)",
+        );
+        let row = sqlx::query(&sql)
+            .bind(scope.to_string())
+            .bind(idempotency_key.to_string())
+            .bind(to_sql_i64(now_ms))
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to query msg idempotency key {}:{}: {}",
+                    scope, idempotency_key, error
+                ))
+            })?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let result_json: String = row
+            .try_get("result_json")
+            .map_err(|e| decode_err("result_json", &e))?;
+        serde_json::from_str(&result_json).map(Some).map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "failed to decode msg idempotency result {}:{}: {}",
+                scope, idempotency_key, error
+            ))
+        })
+    }
+
+    pub async fn upsert_idempotency_result<T: Serialize>(
+        &self,
+        scope: &str,
+        idempotency_key: &str,
+        msg_id: Option<&ObjId>,
+        result: &T,
+        now_ms: u64,
+        expires_at_ms: Option<u64>,
+    ) -> std::result::Result<(), RPCErrors> {
+        let result_json = serde_json::to_string(result).map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "failed to encode msg idempotency result {}:{}: {}",
+                scope, idempotency_key, error
+            ))
+        })?;
+        let sql = self.render_sql(
+            "INSERT INTO msg_idempotency(
+                scope, idempotency_key, msg_id, result_json,
+                created_at_ms, updated_at_ms, expires_at_ms
+             ) VALUES(?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(scope, idempotency_key) DO UPDATE SET
+                msg_id = excluded.msg_id,
+                result_json = excluded.result_json,
+                updated_at_ms = excluded.updated_at_ms,
+                expires_at_ms = excluded.expires_at_ms",
+        );
+        sqlx::query(&sql)
+            .bind(scope.to_string())
+            .bind(idempotency_key.to_string())
+            .bind(msg_id.map(|id| id.to_string()))
+            .bind(result_json)
+            .bind(to_sql_i64(now_ms))
+            .bind(to_sql_i64(now_ms))
+            .bind(expires_at_ms.map(to_sql_i64))
+            .execute(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to upsert msg idempotency key {}:{}: {}",
+                    scope, idempotency_key, error
                 ))
             })?;
         Ok(())

--- a/src/frame/msg_center/src/msg_center.rs
+++ b/src/frame/msg_center/src/msg_center.rs
@@ -1,6 +1,6 @@
 use crate::contact_mgr::{ContactMgr, ZoneUserContactSeed};
 use crate::group_mgr::GroupMgr;
-use crate::msg_box_db::MsgBoxDbMgr;
+use crate::msg_box_db::{IdempotencyCommitOutcome, IdempotencyStoredResult, MsgBoxDbMgr};
 use async_trait::async_trait;
 use buckyos_api::{
     get_buckyos_api_runtime, AccessDecision, AccessGroupLevel, AccountBinding, Contact,
@@ -46,13 +46,19 @@ const MSG_CENTER_BOX_CHANGED_EVENT_NAME: &str = "changed";
 const IDEMPOTENCY_SCOPE_DISPATCH: &str = "dispatch";
 const IDEMPOTENCY_SCOPE_POST_SEND: &str = "post_send";
 const IDEMPOTENCY_TTL_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+const IDEMPOTENCY_SWEEP_INTERVAL_MS: u64 = 60 * 60 * 1000;
+const IDEMPOTENCY_BUCKET_MAX_ROWS: u64 = 3_000;
+const IDEMPOTENCY_BUCKET_TARGET_ROWS: u64 = 2_000;
+const IDEMPOTENCY_GLOBAL_MAX_ROWS: u64 = 100_000;
+const IDEMPOTENCY_GLOBAL_TARGET_ROWS: u64 = 80_000;
+const IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS: u64 = 10_000;
 
 #[derive(Debug, Default)]
 struct MessageCenterState {
     messages: HashMap<String, MsgObject>,
     receipts: HashMap<String, MsgReceiptObj>,
-    dispatch_idempotency: HashMap<String, DispatchResult>,
-    post_send_idempotency: HashMap<String, PostSendResult>,
+    last_idempotency_sweep_ms: u64,
+    idempotency_global_sweep_active: bool,
 }
 
 /// Registry entry for a registered message tunnel: maps the stable
@@ -250,104 +256,98 @@ impl MessageCenter {
         &self,
         key: &str,
     ) -> std::result::Result<Option<DispatchResult>, RPCErrors> {
-        if let Some(cached) =
-            self.with_state_read(|state| Ok(state.dispatch_idempotency.get(key).cloned()))?
-        {
-            return Ok(Some(cached));
-        }
-        let result: Option<DispatchResult> = self
-            .msg_box_db
-            .get_idempotency_result(IDEMPOTENCY_SCOPE_DISPATCH, key, Self::now_ms())
-            .await?;
-        if let Some(result) = result.as_ref() {
-            self.with_state_write(|state| {
-                state
-                    .dispatch_idempotency
-                    .insert(key.to_string(), result.clone());
-                Ok(())
-            })?;
-        }
-        Ok(result)
-    }
-
-    async fn remember_dispatch_idempotency(
-        &self,
-        key: Option<&String>,
-        msg_id: &ObjId,
-        result: &DispatchResult,
-    ) -> std::result::Result<(), RPCErrors> {
-        let Some(key) = key else {
-            return Ok(());
-        };
         let now_ms = Self::now_ms();
-        self.msg_box_db
-            .upsert_idempotency_result(
-                IDEMPOTENCY_SCOPE_DISPATCH,
-                key,
-                Some(msg_id),
-                result,
-                now_ms,
-                Self::idempotency_expires_at(now_ms),
-            )
+        let stored: Option<IdempotencyStoredResult<DispatchResult>> = self
+            .msg_box_db
+            .get_idempotency_result(IDEMPOTENCY_SCOPE_DISPATCH, key, now_ms)
             .await?;
-        self.with_state_write(|state| {
-            state
-                .dispatch_idempotency
-                .insert(key.clone(), result.clone());
-            Ok(())
-        })
+        Ok(stored.map(|stored| stored.result))
     }
 
     async fn load_post_send_idempotency(
         &self,
         key: &str,
     ) -> std::result::Result<Option<PostSendResult>, RPCErrors> {
-        if let Some(cached) =
-            self.with_state_read(|state| Ok(state.post_send_idempotency.get(key).cloned()))?
-        {
-            return Ok(Some(cached));
-        }
-        let result: Option<PostSendResult> = self
+        let now_ms = Self::now_ms();
+        let stored: Option<IdempotencyStoredResult<PostSendResult>> = self
             .msg_box_db
-            .get_idempotency_result(IDEMPOTENCY_SCOPE_POST_SEND, key, Self::now_ms())
+            .get_idempotency_result(IDEMPOTENCY_SCOPE_POST_SEND, key, now_ms)
             .await?;
-        if let Some(result) = result.as_ref() {
-            self.with_state_write(|state| {
-                state
-                    .post_send_idempotency
-                    .insert(key.to_string(), result.clone());
-                Ok(())
-            })?;
-        }
-        Ok(result)
+        Ok(stored.map(|stored| stored.result))
     }
 
-    async fn remember_post_send_idempotency(
-        &self,
-        key: Option<&String>,
-        msg_id: &ObjId,
-        result: &PostSendResult,
-    ) -> std::result::Result<(), RPCErrors> {
-        let Some(key) = key else {
-            return Ok(());
-        };
+    async fn maybe_sweep_expired_idempotency(&self) {
         let now_ms = Self::now_ms();
-        self.msg_box_db
-            .upsert_idempotency_result(
-                IDEMPOTENCY_SCOPE_POST_SEND,
-                key,
-                Some(msg_id),
-                result,
+        let sweep_plan = self
+            .with_state_write(|state| {
+                let periodic_sweep_due = now_ms.saturating_sub(state.last_idempotency_sweep_ms)
+                    >= IDEMPOTENCY_SWEEP_INTERVAL_MS;
+                if !periodic_sweep_due && !state.idempotency_global_sweep_active {
+                    return Ok(None);
+                }
+                if periodic_sweep_due {
+                    state.last_idempotency_sweep_ms = now_ms;
+                }
+                Ok(Some((
+                    periodic_sweep_due,
+                    state.idempotency_global_sweep_active,
+                )))
+            })
+            .unwrap_or(None);
+        let Some((periodic_sweep_due, global_sweep_active)) = sweep_plan else {
+            return;
+        };
+        let bucket_deleted = if periodic_sweep_due {
+            match self
+                .msg_box_db
+                .sweep_expired_idempotency_buckets_by_capacity(
+                    now_ms,
+                    IDEMPOTENCY_BUCKET_MAX_ROWS,
+                    IDEMPOTENCY_BUCKET_TARGET_ROWS,
+                )
+                .await
+            {
+                Ok(deleted) => deleted,
+                Err(error) => {
+                    warn!("msg_center idempotency bucket sweep failed: {}", error);
+                    0
+                }
+            }
+        } else {
+            0
+        };
+        let global_deleted = match self
+            .msg_box_db
+            .sweep_expired_idempotency_global_by_capacity(
                 now_ms,
-                Self::idempotency_expires_at(now_ms),
+                IDEMPOTENCY_GLOBAL_MAX_ROWS,
+                IDEMPOTENCY_GLOBAL_TARGET_ROWS,
+                IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS,
+                global_sweep_active,
             )
-            .await?;
-        self.with_state_write(|state| {
-            state
-                .post_send_idempotency
-                .insert(key.clone(), result.clone());
-            Ok(())
-        })
+            .await
+        {
+            Ok((deleted, remaining_rows)) => {
+                let continue_sweep = remaining_rows > IDEMPOTENCY_GLOBAL_TARGET_ROWS
+                    && deleted >= IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS;
+                let _ = self.with_state_write(|state| {
+                    state.idempotency_global_sweep_active = continue_sweep;
+                    Ok(())
+                });
+                deleted
+            }
+            Err(error) => {
+                warn!("msg_center idempotency global sweep failed: {}", error);
+                0
+            }
+        };
+        let deleted = bucket_deleted.saturating_add(global_deleted);
+        if deleted > 0 {
+            info!(
+                "msg_center idempotency sweep deleted {} expired rows",
+                deleted
+            );
+        }
     }
 
     fn sanitize_token(raw: &str) -> String {
@@ -538,6 +538,47 @@ impl MessageCenter {
             .map(|value| value.to_string())
     }
 
+    fn dispatch_idempotency_retention_key(
+        msg: &MsgObject,
+        ingress: Option<&IngressContext>,
+    ) -> String {
+        if let Some(ctx) = ingress {
+            let platform = Self::normalize_non_empty(ctx.platform.as_deref())
+                .unwrap_or_else(|| "unknown".to_string());
+            let source_account = Self::normalize_non_empty(ctx.source_account_id.as_deref())
+                .unwrap_or_else(|| {
+                    ctx.transport_did
+                        .as_ref()
+                        .map(|did| did.to_string())
+                        .unwrap_or_else(|| "unknown".to_string())
+                });
+            let session = Self::normalize_non_empty(ctx.chat_id.as_deref())
+                .or_else(|| Self::normalize_non_empty(msg.thread.topic.as_deref()))
+                .or_else(|| Self::normalize_non_empty(ctx.context_id.as_deref()))
+                .unwrap_or_else(|| "unknown".to_string());
+            return format!("dispatch:{}:{}:{}", platform, source_account, session);
+        }
+
+        if let Some(topic) = Self::normalize_non_empty(msg.thread.topic.as_deref()) {
+            return format!("dispatch:thread:{}", topic);
+        }
+        if Self::is_group_message(msg) {
+            return msg
+                .to
+                .first()
+                .map(|group| format!("dispatch:group:{}", group.to_string()))
+                .unwrap_or_else(|| format!("dispatch:sender:{}", msg.from.to_string()));
+        }
+        format!("dispatch:sender:{}", msg.from.to_string())
+    }
+
+    fn post_send_idempotency_retention_key(msg: &MsgObject) -> String {
+        if let Some(topic) = Self::normalize_non_empty(msg.thread.topic.as_deref()) {
+            return format!("post_send:{}:{}", msg.from.to_string(), topic);
+        }
+        format!("post_send:{}", msg.from.to_string())
+    }
+
     fn normalize_ui_session_arg(
         label: &str,
         value: &str,
@@ -713,8 +754,7 @@ impl MessageCenter {
         format!("dlv-{}", hex::encode(&hasher.finalize()[..16]))
     }
 
-    async fn create_or_get_record(
-        &self,
+    fn build_mailbox_record(
         owner: DID,
         box_kind: MailboxKind,
         msg: &MsgObject,
@@ -722,35 +762,20 @@ impl MessageCenter {
         ingress: Option<IngressContext>,
         tags: Vec<String>,
         variant: &str,
-    ) -> std::result::Result<MailboxRecord, RPCErrors> {
+    ) -> MailboxRecord {
         let msg_id = Self::message_obj_id(msg);
         let record_id = Self::build_record_id(&owner, &box_kind, &msg_id, variant);
         let session_id = Self::derive_session_id(&box_kind, msg);
-        if let Some(existing) = self.msg_box_db.get_record(&owner, &record_id).await? {
-            let mut record_for_update = existing.clone();
-            if record_for_update.msg_kind != msg.kind {
-                record_for_update.msg_kind = msg.kind;
-            }
-            if record_for_update.session_id.is_none() {
-                record_for_update.session_id = session_id;
-            }
-            self.msg_box_db
-                .upsert_record_with_msg(&record_for_update, Some(msg))
-                .await?;
-            Self::publish_box_changed_event(&record_for_update, "upsert");
-            return Ok(record_for_update);
-        }
-
         let now_ms = Self::now_ms();
         let record_to = match box_kind {
             MailboxKind::Inbox | MailboxKind::GroupInbox | MailboxKind::RequestBox => owner.clone(),
             MailboxKind::Sent => msg.to.first().cloned().unwrap_or_else(|| owner.clone()),
         };
-        let record = MailboxRecord {
-            record_id: record_id.clone(),
-            owner: owner.clone(),
+        MailboxRecord {
+            record_id,
+            owner,
             box_kind,
-            msg_id: msg_id.clone(),
+            msg_id,
             msg_kind: msg.kind,
             state: initial_state,
             from: msg.from.clone(),
@@ -766,13 +791,7 @@ impl MessageCenter {
             ingress,
             created_at_ms: now_ms,
             updated_at_ms: now_ms,
-        };
-
-        self.msg_box_db
-            .upsert_record_with_msg(&record, Some(msg))
-            .await?;
-        Self::publish_box_changed_event(&record, "upsert");
-        Ok(record)
+        }
     }
 
     async fn load_box_records(
@@ -1004,7 +1023,6 @@ impl MessageCenter {
             .and_then(|ctx| ctx.contact_mgr_owner.clone());
 
         enum DispatchPrepare {
-            Done(DispatchResult),
             Ready {
                 stored_msg: MsgObject,
                 stored_msg_id: ObjId,
@@ -1016,12 +1034,6 @@ impl MessageCenter {
         }
 
         let prepared = self.with_state_write(|state| {
-            if let Some(key) = idempotency_key.as_ref() {
-                if let Some(cached) = state.dispatch_idempotency.get(key) {
-                    return Ok(DispatchPrepare::Done(cached.clone()));
-                }
-            }
-
             let stored_msg = Self::ensure_message(state, msg);
             let (stored_msg_id, stored_msg_json) = stored_msg.gen_obj_id();
 
@@ -1040,7 +1052,6 @@ impl MessageCenter {
 
         let (stored_msg, stored_msg_id, stored_msg_json, sender, context_id, ingress) =
             match prepared {
-                DispatchPrepare::Done(result) => return Ok(result),
                 DispatchPrepare::Ready {
                     stored_msg,
                     stored_msg_id,
@@ -1057,6 +1068,8 @@ impl MessageCenter {
                     ingress,
                 ),
             };
+        let retention_key =
+            Self::dispatch_idempotency_retention_key(&stored_msg, ingress.as_ref());
 
         Self::store_message(&stored_msg_id, &stored_msg_json).await?;
 
@@ -1077,6 +1090,7 @@ impl MessageCenter {
             delivered_agents: Vec::new(),
             reason: None,
         };
+        let mut mailbox_records = Vec::<MailboxRecord>::new();
 
         if Self::is_group_message(&stored_msg) {
             if self
@@ -1102,12 +1116,27 @@ impl MessageCenter {
                     delivered_agents: Vec::new(),
                     reason: Some("blocked".to_string()),
                 };
-                self.remember_dispatch_idempotency(
-                    idempotency_key.as_ref(),
-                    &stored_msg_id,
-                    &blocked,
-                )
-                .await?;
+                let now_ms = Self::now_ms();
+                let expires_at_ms = Self::idempotency_expires_at(now_ms);
+                self.maybe_sweep_expired_idempotency().await;
+                match self
+                    .msg_box_db
+                    .commit_dispatch_records(
+                        IDEMPOTENCY_SCOPE_DISPATCH,
+                        idempotency_key.as_deref(),
+                        Some(retention_key.as_str()),
+                        &stored_msg_id,
+                        &stored_msg,
+                        &[],
+                        &blocked,
+                        now_ms,
+                        expires_at_ms,
+                    )
+                    .await?
+                {
+                    IdempotencyCommitOutcome::Reused(cached) => return Ok(cached),
+                    IdempotencyCommitOutcome::Committed => {}
+                }
                 return Ok(blocked);
             }
 
@@ -1119,7 +1148,7 @@ impl MessageCenter {
                 group_id.to_string(),
                 context_id.as_deref().unwrap_or("-"),
             );
-            self.create_or_get_record(
+            mailbox_records.push(Self::build_mailbox_record(
                 group_id.clone(),
                 MailboxKind::GroupInbox,
                 &stored_msg,
@@ -1127,8 +1156,7 @@ impl MessageCenter {
                 ingress.clone(),
                 Vec::new(),
                 "group-inbox",
-            )
-            .await?;
+            ));
 
             // Prefer the authoritative member list from GroupMgr when this
             // group is hosted locally; fall back to the ContactMgr
@@ -1158,7 +1186,7 @@ impl MessageCenter {
             let readers = Self::dedupe_dids(readers);
             for agent_did in readers.iter() {
                 let tag = format!("group:{}", group_id.to_string());
-                self.create_or_get_record(
+                mailbox_records.push(Self::build_mailbox_record(
                     agent_did.clone(),
                     MailboxKind::Inbox,
                     &stored_msg,
@@ -1166,8 +1194,7 @@ impl MessageCenter {
                     ingress.clone(),
                     vec![tag],
                     &format!("group-agent-{}", group_id.to_string()),
-                )
-                .await?;
+                ));
             }
 
             result.delivered_group = Some(group_id);
@@ -1226,7 +1253,7 @@ impl MessageCenter {
                                 context_id.as_deref().unwrap_or("-"),
                             );
                         }
-                        self.create_or_get_record(
+                        mailbox_records.push(Self::build_mailbox_record(
                             recipient.clone(),
                             box_kind,
                             &stored_msg,
@@ -1234,8 +1261,7 @@ impl MessageCenter {
                             ingress.clone(),
                             Vec::new(),
                             "inbox",
-                        )
-                        .await?;
+                        ));
                         result.delivered_recipients.push(recipient);
                     }
                     None => {
@@ -1252,8 +1278,31 @@ impl MessageCenter {
             }
         }
 
-        self.remember_dispatch_idempotency(idempotency_key.as_ref(), &stored_msg_id, &result)
-            .await?;
+        let now_ms = Self::now_ms();
+        let expires_at_ms = Self::idempotency_expires_at(now_ms);
+        self.maybe_sweep_expired_idempotency().await;
+        match self
+            .msg_box_db
+            .commit_dispatch_records(
+                IDEMPOTENCY_SCOPE_DISPATCH,
+                idempotency_key.as_deref(),
+                Some(retention_key.as_str()),
+                &stored_msg_id,
+                &stored_msg,
+                &mailbox_records,
+                &result,
+                now_ms,
+                expires_at_ms,
+            )
+            .await?
+        {
+            IdempotencyCommitOutcome::Reused(cached) => return Ok(cached),
+            IdempotencyCommitOutcome::Committed => {
+                for record in mailbox_records.iter() {
+                    Self::publish_box_changed_event(record, "upsert");
+                }
+            }
+        }
         Ok(result)
     }
 
@@ -1275,7 +1324,6 @@ impl MessageCenter {
         }
 
         enum PostSendPrepare {
-            Done(PostSendResult),
             Ready {
                 stored_msg: MsgObject,
                 stored_msg_id: ObjId,
@@ -1286,12 +1334,6 @@ impl MessageCenter {
         }
 
         let prepared = self.with_state_write(|state| {
-            if let Some(key) = idempotency_key.as_ref() {
-                if let Some(cached) = state.post_send_idempotency.get(key) {
-                    return Ok(PostSendPrepare::Done(cached.clone()));
-                }
-            }
-
             let stored_msg = Self::ensure_message(state, msg);
             let (stored_msg_id, stored_msg_json) = stored_msg.gen_obj_id();
             let author = stored_msg.from.clone();
@@ -1309,7 +1351,6 @@ impl MessageCenter {
 
         let (stored_msg, stored_msg_id, stored_msg_json, author, contact_mgr_owner) = match prepared
         {
-            PostSendPrepare::Done(result) => return Ok(result),
             PostSendPrepare::Ready {
                 stored_msg,
                 stored_msg_id,
@@ -1324,6 +1365,7 @@ impl MessageCenter {
                 contact_mgr_owner,
             ),
         };
+        let retention_key = Self::post_send_idempotency_retention_key(&stored_msg);
 
         if self
             .is_contact_blocked(&author, contact_mgr_owner.clone())
@@ -1335,12 +1377,28 @@ impl MessageCenter {
                 deliveries: Vec::new(),
                 reason: Some("blocked_author".to_string()),
             };
-            self.remember_post_send_idempotency(
-                idempotency_key.as_ref(),
-                &stored_msg_id,
-                &result,
-            )
-            .await?;
+            let now_ms = Self::now_ms();
+            let expires_at_ms = Self::idempotency_expires_at(now_ms);
+            self.maybe_sweep_expired_idempotency().await;
+            match self
+                .msg_box_db
+                .commit_post_send_records(
+                    IDEMPOTENCY_SCOPE_POST_SEND,
+                    idempotency_key.as_deref(),
+                    Some(retention_key.as_str()),
+                    &stored_msg_id,
+                    &stored_msg,
+                    None,
+                    &[],
+                    &result,
+                    now_ms,
+                    expires_at_ms,
+                )
+                .await?
+            {
+                IdempotencyCommitOutcome::Reused(cached) => return Ok(cached),
+                IdempotencyCommitOutcome::Committed => {}
+            }
             return Ok(result);
         }
 
@@ -1359,12 +1417,28 @@ impl MessageCenter {
                         deliveries: Vec::new(),
                         reason: Some(reason),
                     };
-                    self.remember_post_send_idempotency(
-                        idempotency_key.as_ref(),
-                        &stored_msg_id,
-                        &result,
-                    )
-                    .await?;
+                    let now_ms = Self::now_ms();
+                    let expires_at_ms = Self::idempotency_expires_at(now_ms);
+                    self.maybe_sweep_expired_idempotency().await;
+                    match self
+                        .msg_box_db
+                        .commit_post_send_records(
+                            IDEMPOTENCY_SCOPE_POST_SEND,
+                            idempotency_key.as_deref(),
+                            Some(retention_key.as_str()),
+                            &stored_msg_id,
+                            &stored_msg,
+                            None,
+                            &[],
+                            &result,
+                            now_ms,
+                            expires_at_ms,
+                        )
+                        .await?
+                    {
+                        IdempotencyCommitOutcome::Reused(cached) => return Ok(cached),
+                        IdempotencyCommitOutcome::Committed => {}
+                    }
                     return Ok(result);
                 }
             }
@@ -1381,18 +1455,18 @@ impl MessageCenter {
             }
         }
 
-        self.create_or_get_record(
-            author,
+        let sent_record = Self::build_mailbox_record(
+            author.clone(),
             MailboxKind::Sent,
             &stored_msg,
             RecipientState::Read,
             None,
             Vec::new(),
             "owner-sent",
-        )
-        .await?;
+        );
 
         let now_ms = Self::now_ms();
+        let mut delivery_records = Vec::with_capacity(envelopes.len());
         let mut deliveries = Vec::with_capacity(envelopes.len());
         for envelope in envelopes {
             let delivery_id = Self::build_delivery_id(
@@ -1412,15 +1486,13 @@ impl MessageCenter {
                 created_at_ms: now_ms,
                 updated_at_ms: now_ms,
             };
-            self.msg_box_db.create_delivery_if_absent(&record).await?;
-            Self::publish_delivery_changed_event(&record, "enqueue");
-
             deliveries.push(PostSendDelivery {
-                delivery_id,
+                delivery_id: delivery_id.clone(),
                 transport_did: envelope.transport_did,
                 target_did: envelope.target_did,
                 transport: envelope.transport,
             });
+            delivery_records.push(record);
         }
 
         let result = PostSendResult {
@@ -1429,8 +1501,32 @@ impl MessageCenter {
             deliveries,
             reason: None,
         };
-        self.remember_post_send_idempotency(idempotency_key.as_ref(), &stored_msg_id, &result)
-            .await?;
+        let expires_at_ms = Self::idempotency_expires_at(now_ms);
+        self.maybe_sweep_expired_idempotency().await;
+        match self
+            .msg_box_db
+            .commit_post_send_records(
+                IDEMPOTENCY_SCOPE_POST_SEND,
+                idempotency_key.as_deref(),
+                Some(retention_key.as_str()),
+                &stored_msg_id,
+                &stored_msg,
+                Some(&sent_record),
+                &delivery_records,
+                &result,
+                now_ms,
+                expires_at_ms,
+            )
+            .await?
+        {
+            IdempotencyCommitOutcome::Reused(cached) => return Ok(cached),
+            IdempotencyCommitOutcome::Committed => {
+                Self::publish_box_changed_event(&sent_record, "upsert");
+                for record in delivery_records.iter() {
+                    Self::publish_delivery_changed_event(record, "enqueue");
+                }
+            }
+        }
         Ok(result)
     }
 

--- a/src/frame/msg_center/src/msg_center.rs
+++ b/src/frame/msg_center/src/msg_center.rs
@@ -43,6 +43,9 @@ const DELIVERY_SENDING_LEASE_MS: u64 = 60_000;
 const DELIVERY_RETRY_BASE_MS: u64 = 2_000;
 const DELIVERY_RETRY_MAX_MS: u64 = 300_000;
 const MSG_CENTER_BOX_CHANGED_EVENT_NAME: &str = "changed";
+const IDEMPOTENCY_SCOPE_DISPATCH: &str = "dispatch";
+const IDEMPOTENCY_SCOPE_POST_SEND: &str = "post_send";
+const IDEMPOTENCY_TTL_MS: u64 = 30 * 24 * 60 * 60 * 1000;
 
 #[derive(Debug, Default)]
 struct MessageCenterState {
@@ -218,6 +221,10 @@ impl MessageCenter {
             .as_millis() as u64
     }
 
+    fn idempotency_expires_at(now_ms: u64) -> Option<u64> {
+        Some(now_ms.saturating_add(IDEMPOTENCY_TTL_MS))
+    }
+
     fn with_state_read<T, F>(&self, f: F) -> std::result::Result<T, RPCErrors>
     where
         F: FnOnce(&MessageCenterState) -> std::result::Result<T, RPCErrors>,
@@ -237,6 +244,110 @@ impl MessageCenter {
             RPCErrors::ReasonError("message center write lock poisoned".to_string())
         })?;
         f(&mut guard)
+    }
+
+    async fn load_dispatch_idempotency(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<DispatchResult>, RPCErrors> {
+        if let Some(cached) =
+            self.with_state_read(|state| Ok(state.dispatch_idempotency.get(key).cloned()))?
+        {
+            return Ok(Some(cached));
+        }
+        let result: Option<DispatchResult> = self
+            .msg_box_db
+            .get_idempotency_result(IDEMPOTENCY_SCOPE_DISPATCH, key, Self::now_ms())
+            .await?;
+        if let Some(result) = result.as_ref() {
+            self.with_state_write(|state| {
+                state
+                    .dispatch_idempotency
+                    .insert(key.to_string(), result.clone());
+                Ok(())
+            })?;
+        }
+        Ok(result)
+    }
+
+    async fn remember_dispatch_idempotency(
+        &self,
+        key: Option<&String>,
+        msg_id: &ObjId,
+        result: &DispatchResult,
+    ) -> std::result::Result<(), RPCErrors> {
+        let Some(key) = key else {
+            return Ok(());
+        };
+        let now_ms = Self::now_ms();
+        self.msg_box_db
+            .upsert_idempotency_result(
+                IDEMPOTENCY_SCOPE_DISPATCH,
+                key,
+                Some(msg_id),
+                result,
+                now_ms,
+                Self::idempotency_expires_at(now_ms),
+            )
+            .await?;
+        self.with_state_write(|state| {
+            state
+                .dispatch_idempotency
+                .insert(key.clone(), result.clone());
+            Ok(())
+        })
+    }
+
+    async fn load_post_send_idempotency(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<PostSendResult>, RPCErrors> {
+        if let Some(cached) =
+            self.with_state_read(|state| Ok(state.post_send_idempotency.get(key).cloned()))?
+        {
+            return Ok(Some(cached));
+        }
+        let result: Option<PostSendResult> = self
+            .msg_box_db
+            .get_idempotency_result(IDEMPOTENCY_SCOPE_POST_SEND, key, Self::now_ms())
+            .await?;
+        if let Some(result) = result.as_ref() {
+            self.with_state_write(|state| {
+                state
+                    .post_send_idempotency
+                    .insert(key.to_string(), result.clone());
+                Ok(())
+            })?;
+        }
+        Ok(result)
+    }
+
+    async fn remember_post_send_idempotency(
+        &self,
+        key: Option<&String>,
+        msg_id: &ObjId,
+        result: &PostSendResult,
+    ) -> std::result::Result<(), RPCErrors> {
+        let Some(key) = key else {
+            return Ok(());
+        };
+        let now_ms = Self::now_ms();
+        self.msg_box_db
+            .upsert_idempotency_result(
+                IDEMPOTENCY_SCOPE_POST_SEND,
+                key,
+                Some(msg_id),
+                result,
+                now_ms,
+                Self::idempotency_expires_at(now_ms),
+            )
+            .await?;
+        self.with_state_write(|state| {
+            state
+                .post_send_idempotency
+                .insert(key.clone(), result.clone());
+            Ok(())
+        })
     }
 
     fn sanitize_token(raw: &str) -> String {
@@ -882,6 +993,12 @@ impl MessageCenter {
         ingress_ctx: Option<IngressContext>,
         idempotency_key: Option<String>,
     ) -> std::result::Result<DispatchResult, RPCErrors> {
+        if let Some(key) = idempotency_key.as_ref() {
+            if let Some(cached) = self.load_dispatch_idempotency(key).await? {
+                return Ok(cached);
+            }
+        }
+
         let ingress_contact_mgr_owner = ingress_ctx
             .as_ref()
             .and_then(|ctx| ctx.contact_mgr_owner.clone());
@@ -946,9 +1063,7 @@ impl MessageCenter {
         // Re-check idempotency before doing any work; a concurrent caller may
         // have completed the same dispatch while we were awaiting store_message.
         if let Some(key) = idempotency_key.as_ref() {
-            if let Some(cached) =
-                self.with_state_read(|state| Ok(state.dispatch_idempotency.get(key).cloned()))?
-            {
+            if let Some(cached) = self.load_dispatch_idempotency(key).await? {
                 return Ok(cached);
             }
         }
@@ -987,14 +1102,12 @@ impl MessageCenter {
                     delivered_agents: Vec::new(),
                     reason: Some("blocked".to_string()),
                 };
-                if let Some(key) = idempotency_key.as_ref() {
-                    self.with_state_write(|state| {
-                        state
-                            .dispatch_idempotency
-                            .insert(key.clone(), blocked.clone());
-                        Ok(())
-                    })?;
-                }
+                self.remember_dispatch_idempotency(
+                    idempotency_key.as_ref(),
+                    &stored_msg_id,
+                    &blocked,
+                )
+                .await?;
                 return Ok(blocked);
             }
 
@@ -1139,14 +1252,8 @@ impl MessageCenter {
             }
         }
 
-        if let Some(key) = idempotency_key.as_ref() {
-            self.with_state_write(|state| {
-                state
-                    .dispatch_idempotency
-                    .insert(key.clone(), result.clone());
-                Ok(())
-            })?;
-        }
+        self.remember_dispatch_idempotency(idempotency_key.as_ref(), &stored_msg_id, &result)
+            .await?;
         Ok(result)
     }
 
@@ -1159,6 +1266,12 @@ impl MessageCenter {
             return Err(RPCErrors::ParseRequestError(
                 "post_send requires at least one target in msg.to".to_string(),
             ));
+        }
+
+        if let Some(key) = idempotency_key.as_ref() {
+            if let Some(cached) = self.load_post_send_idempotency(key).await? {
+                return Ok(cached);
+            }
         }
 
         enum PostSendPrepare {
@@ -1212,29 +1325,23 @@ impl MessageCenter {
             ),
         };
 
-        let cache_result =
-            |result: PostSendResult| -> std::result::Result<PostSendResult, RPCErrors> {
-                if let Some(key) = idempotency_key.as_ref() {
-                    self.with_state_write(|state| {
-                        state
-                            .post_send_idempotency
-                            .insert(key.clone(), result.clone());
-                        Ok(())
-                    })?;
-                }
-                Ok(result)
-            };
-
         if self
             .is_contact_blocked(&author, contact_mgr_owner.clone())
             .await?
         {
-            return cache_result(PostSendResult {
+            let result = PostSendResult {
                 ok: false,
                 msg_id: stored_msg_id.clone(),
                 deliveries: Vec::new(),
                 reason: Some("blocked_author".to_string()),
-            });
+            };
+            self.remember_post_send_idempotency(
+                idempotency_key.as_ref(),
+                &stored_msg_id,
+                &result,
+            )
+            .await?;
+            return Ok(result);
         }
 
         // Phase 1: resolve every target up front (pure, no writes). One
@@ -1246,12 +1353,19 @@ impl MessageCenter {
             match self.build_delivery_envelope(&stored_msg_id, target) {
                 Ok(envelope) => envelopes.push(envelope),
                 Err(reason) => {
-                    return cache_result(PostSendResult {
+                    let result = PostSendResult {
                         ok: false,
                         msg_id: stored_msg_id.clone(),
                         deliveries: Vec::new(),
                         reason: Some(reason),
-                    });
+                    };
+                    self.remember_post_send_idempotency(
+                        idempotency_key.as_ref(),
+                        &stored_msg_id,
+                        &result,
+                    )
+                    .await?;
+                    return Ok(result);
                 }
             }
         }
@@ -1262,9 +1376,7 @@ impl MessageCenter {
         Self::store_message(&stored_msg_id, &stored_msg_json).await?;
 
         if let Some(key) = idempotency_key.as_ref() {
-            if let Some(cached) =
-                self.with_state_read(|state| Ok(state.post_send_idempotency.get(key).cloned()))?
-            {
+            if let Some(cached) = self.load_post_send_idempotency(key).await? {
                 return Ok(cached);
             }
         }
@@ -1311,12 +1423,15 @@ impl MessageCenter {
             });
         }
 
-        cache_result(PostSendResult {
+        let result = PostSendResult {
             ok: true,
             msg_id: stored_msg_id.clone(),
             deliveries,
             reason: None,
-        })
+        };
+        self.remember_post_send_idempotency(idempotency_key.as_ref(), &stored_msg_id, &result)
+            .await?;
+        Ok(result)
     }
 
     async fn get_next_internal(

--- a/src/frame/msg_center/src/test_msg_center.rs
+++ b/src/frame/msg_center/src/test_msg_center.rs
@@ -21,7 +21,8 @@ fn next_created_at_ms() -> u64 {
 async fn new_center(_tag: &str) -> (MessageCenter, TempDir) {
     let tmp = tempdir().unwrap();
     let db_path = tmp.path().join("msg-center.db");
-    let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
+    let db_path = db_path.to_string_lossy().replace('\\', "/");
+    let conn = format!("sqlite:///{}?mode=rwc", db_path);
     let center = open_center_at(&conn).await;
     (center, tmp)
 }
@@ -543,6 +544,113 @@ async fn update_record_state_checks_transition_rules() {
 }
 
 #[tokio::test]
+async fn dispatch_replay_preserves_existing_recipient_state() {
+    let (center, _tmp) = new_center("replay_state").await;
+    let sender = DID::new("bns", "sender-replay-state");
+    let recipient = DID::new("bns", "recipient-replay-state");
+    let context_id = "ctx-replay-state".to_string();
+
+    center
+        .handle_grant_temporary_access(
+            vec![sender.clone()],
+            context_id.clone(),
+            60,
+            Some(recipient.clone()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    let msg = make_msg(sender, vec![recipient.clone()], MsgObjKind::Chat);
+    let ingress = IngressContext {
+        context_id: Some(context_id),
+        ..Default::default()
+    };
+    center
+        .handle_dispatch(
+            msg.clone(),
+            Some(ingress.clone()),
+            Some("replay-state-a".to_string()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+    let inbox = center
+        .handle_peek_box(
+            recipient.clone(),
+            MailboxKind::Inbox,
+            None,
+            None,
+            None,
+            ctx(),
+        )
+        .await
+        .unwrap();
+    let record_id = inbox[0].record.record_id.clone();
+
+    center
+        .handle_update_record_state(record_id.clone(), RecipientState::Read, ctx())
+        .await
+        .unwrap();
+    center
+        .handle_dispatch(
+            msg.clone(),
+            Some(ingress.clone()),
+            Some("replay-state-b".to_string()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+    let record = center
+        .handle_peek_box(
+            recipient.clone(),
+            MailboxKind::Inbox,
+            None,
+            None,
+            None,
+            ctx(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(record[0].record.state, RecipientState::Read);
+
+    center
+        .handle_update_record_state(record_id.clone(), RecipientState::Archived, ctx())
+        .await
+        .unwrap();
+    center
+        .handle_dispatch(msg.clone(), Some(ingress.clone()), None, ctx())
+        .await
+        .unwrap();
+    let record = center
+        .handle_peek_box(
+            recipient.clone(),
+            MailboxKind::Inbox,
+            None,
+            None,
+            None,
+            ctx(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(record[0].record.state, RecipientState::Archived);
+
+    center
+        .handle_update_record_state(record_id, RecipientState::Deleted, ctx())
+        .await
+        .unwrap();
+    center
+        .handle_dispatch(msg, Some(ingress), None, ctx())
+        .await
+        .unwrap();
+    let record = center
+        .handle_peek_box(recipient, MailboxKind::Inbox, None, None, None, ctx())
+        .await
+        .unwrap();
+    assert_eq!(record[0].record.state, RecipientState::Deleted);
+}
+
+#[tokio::test]
 async fn update_record_session_sets_session_id() {
     let (center, _tmp) = new_center("update_record_session").await;
     let sender = DID::new("bns", "sender-ui-session");
@@ -993,7 +1101,8 @@ async fn idempotency_key_prevents_duplicate_records() {
 async fn idempotency_key_survives_message_center_restart() {
     let tmp = tempdir().unwrap();
     let db_path = tmp.path().join("msg-center.db");
-    let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
+    let db_path = db_path.to_string_lossy().replace('\\', "/");
+    let conn = format!("sqlite:///{}?mode=rwc", db_path);
     let first_center = open_center_at(&conn).await;
     let sender = DID::new("bns", "sender-g");
     let recipient = DID::new("bns", "recipient-g");

--- a/src/frame/msg_center/src/test_msg_center.rs
+++ b/src/frame/msg_center/src/test_msg_center.rs
@@ -22,9 +22,13 @@ async fn new_center(_tag: &str) -> (MessageCenter, TempDir) {
     let tmp = tempdir().unwrap();
     let db_path = tmp.path().join("msg-center.db");
     let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
-    let msg_box_db = MsgBoxDbMgr::open_default_sqlite(&conn).await.unwrap();
-    let center = MessageCenter::open_with_db(msg_box_db).await.unwrap();
+    let center = open_center_at(&conn).await;
     (center, tmp)
+}
+
+async fn open_center_at(conn: &str) -> MessageCenter {
+    let msg_box_db = MsgBoxDbMgr::open_default_sqlite(&conn).await.unwrap();
+    MessageCenter::open_with_db(msg_box_db).await.unwrap()
 }
 
 fn make_msg(from: DID, to: Vec<DID>, kind: MsgObjKind) -> MsgObject {
@@ -983,4 +987,62 @@ async fn idempotency_key_prevents_duplicate_records() {
         .await
         .unwrap();
     assert!(empty.is_none());
+}
+
+#[tokio::test]
+async fn idempotency_key_survives_message_center_restart() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("msg-center.db");
+    let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
+    let first_center = open_center_at(&conn).await;
+    let sender = DID::new("bns", "sender-g");
+    let recipient = DID::new("bns", "recipient-g");
+
+    first_center
+        .handle_grant_temporary_access(
+            vec![sender.clone()],
+            "ctx-persist-idem".to_string(),
+            60,
+            Some(recipient.clone()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    let msg = make_msg(sender, vec![recipient.clone()], MsgObjKind::Chat);
+    let first_dispatch = first_center
+        .handle_dispatch(
+            msg.clone(),
+            Some(IngressContext {
+                context_id: Some("ctx-persist-idem".to_string()),
+                ..Default::default()
+            }),
+            Some("dispatch-persisted-key".to_string()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+    assert!(first_dispatch.ok);
+    drop(first_center);
+
+    let second_center = open_center_at(&conn).await;
+    let second_dispatch = second_center
+        .handle_dispatch(
+            msg,
+            Some(IngressContext {
+                context_id: Some("ctx-persist-idem".to_string()),
+                ..Default::default()
+            }),
+            Some("dispatch-persisted-key".to_string()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first_dispatch, second_dispatch);
+
+    let inbox = second_center
+        .handle_peek_box(recipient, MailboxKind::Inbox, None, None, None, ctx())
+        .await
+        .unwrap();
+    assert_eq!(inbox.len(), 1);
 }

--- a/src/frame/msg_center/src/tg_tunnel.rs
+++ b/src/frame/msg_center/src/tg_tunnel.rs
@@ -35,7 +35,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use tokio::io::AsyncReadExt;
-use tokio::sync::{mpsc::UnboundedReceiver, Mutex};
+use tokio::sync::{mpsc::UnboundedReceiver, oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
@@ -47,6 +47,7 @@ const TG_BINDING_EXTRA_BOT_TOKEN: &str = "bot_token";
 const TG_BOT_API_ENDPOINT: &str = "https://api.telegram.org";
 const TG_UI_SESSION_IDLE_TIMEOUT_MS: u64 = 10 * 60 * 1000;
 const TG_UI_SESSION_REFRESH_INTERVAL_MS: u64 = 5 * 1000;
+const TG_TASK_SHUTDOWN_TIMEOUT_MS: u64 = 5_000;
 const TG_BOT_API_OFFSET_STATE_KEY: &str = "bot_api_offset";
 const TG_BUILTIN_COMMANDS: &[(&str, &str)] = &[
     ("new", "Create a new session"),
@@ -58,6 +59,49 @@ const TG_BUILTIN_COMMANDS: &[(&str, &str)] = &[
     ("switch", "Bind this chat to another session"),
     ("help", "Show supported commands"),
 ];
+
+struct ManagedTask {
+    stop_tx: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<()>,
+}
+
+impl ManagedTask {
+    fn new(stop_tx: oneshot::Sender<()>, handle: JoinHandle<()>) -> Self {
+        Self {
+            stop_tx: Some(stop_tx),
+            handle,
+        }
+    }
+
+    async fn stop(mut self, label: &str) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        let timeout = tokio::time::sleep(Duration::from_millis(TG_TASK_SHUTDOWN_TIMEOUT_MS));
+        tokio::pin!(timeout);
+        tokio::select! {
+            result = &mut self.handle => {
+                match result {
+                    Ok(()) => {}
+                    Err(error) if error.is_cancelled() => {}
+                    Err(error) => {
+                        warn!("telegram task join failed ({}): {}", label, error);
+                    }
+                }
+            }
+            _ = &mut timeout => {
+                warn!("telegram task graceful stop timed out ({}), aborting", label);
+                self.handle.abort();
+                if let Err(error) = self.handle.await {
+                    if !error.is_cancelled() {
+                        warn!("telegram task abort join failed ({}): {}", label, error);
+                    }
+                }
+            }
+        }
+    }
+
+}
 
 #[derive(Debug, Clone)]
 pub struct TgTunnelConfig {
@@ -1216,7 +1260,7 @@ pub struct GrammersTgGateway {
     runtimes: Mutex<HashMap<String, GrammersTgRuntime>>,
     dispatcher: Arc<Mutex<Option<Arc<dyn MsgCenterHandler>>>>,
     ui_session_tracker: Arc<Mutex<Option<Arc<TgUiSessionTracker>>>>,
-    ingress_tasks: Mutex<HashMap<String, JoinHandle<()>>>,
+    ingress_tasks: Mutex<HashMap<String, ManagedTask>>,
 }
 
 impl GrammersTgGateway {
@@ -1560,12 +1604,13 @@ impl GrammersTgGateway {
         bot_account_id: String,
         client: Client,
         updates_rx: UnboundedReceiver<UpdatesLike>,
-    ) -> JoinHandle<()> {
+    ) -> ManagedTask {
         let dispatcher = self.dispatcher.clone();
         let ui_session_tracker = self.ui_session_tracker.clone();
         let transport_did = self.cfg.transport_did.clone();
         let tunnel_instance_id = self.cfg.tunnel_instance_id.clone();
-        tokio::spawn(async move {
+        let (stop_tx, mut stop_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
             let mut updates = client.stream_updates(
                 updates_rx,
                 UpdatesConfiguration {
@@ -1574,7 +1619,11 @@ impl GrammersTgGateway {
                 },
             );
             loop {
-                match updates.next().await {
+                let update = tokio::select! {
+                    _ = &mut stop_rx => break,
+                    update = updates.next() => update,
+                };
+                match update {
                     Ok(Update::NewMessage(message)) => {
                         info!("tg_tunnel get tg msg:{}", message.text());
                         let dispatcher = {
@@ -1629,7 +1678,8 @@ impl GrammersTgGateway {
                     }
                 }
             }
-        })
+        });
+        ManagedTask::new(stop_tx, handle)
     }
 
     fn peer_ref_from_dialog_id(dialog_id: i64) -> AnyResult<PeerRef> {
@@ -1779,15 +1829,34 @@ impl TgGateway for GrammersTgGateway {
         }
 
         let mut started = HashMap::new();
-        let mut started_tasks: HashMap<String, JoinHandle<()>> = HashMap::new();
+        let mut started_tasks: HashMap<String, ManagedTask> = HashMap::new();
         for binding in bindings {
-            binding.validate()?;
-            let token = resolve_binding_bot_token(binding)?;
+            if let Err(error) = binding.validate() {
+                for (_, task) in started_tasks.drain() {
+                    task.stop("grammers-start-rollback").await;
+                }
+                for (_, runtime) in started.drain() {
+                    let _ = Self::stop_runtime(runtime).await;
+                }
+                return Err(error);
+            }
+            let token = match resolve_binding_bot_token(binding) {
+                Ok(token) => token,
+                Err(error) => {
+                    for (_, task) in started_tasks.drain() {
+                        task.stop("grammers-start-rollback").await;
+                    }
+                    for (_, runtime) in started.drain() {
+                        let _ = Self::stop_runtime(runtime).await;
+                    }
+                    return Err(error);
+                }
+            };
             let (runtime, updates_rx) = match self.start_binding(binding, &token).await {
                 Ok(runtime) => runtime,
                 Err(error) => {
                     for (_, task) in started_tasks.drain() {
-                        task.abort();
+                        task.stop("grammers-start-rollback").await;
                     }
                     for (_, runtime) in started.drain() {
                         let _ = Self::stop_runtime(runtime).await;
@@ -1809,7 +1878,7 @@ impl TgGateway for GrammersTgGateway {
         let mut guard = self.runtimes.lock().await;
         if !guard.is_empty() {
             for (_, task) in started_tasks.drain() {
-                task.abort();
+                task.stop("grammers-start-race").await;
             }
             for (_, runtime) in started.drain() {
                 let _ = Self::stop_runtime(runtime).await;
@@ -1833,7 +1902,7 @@ impl TgGateway for GrammersTgGateway {
         {
             let mut tasks_guard = self.ingress_tasks.lock().await;
             for (_, task) in tasks_guard.drain() {
-                task.abort();
+                task.stop("grammers-ingress").await;
             }
         }
 
@@ -2250,7 +2319,7 @@ pub struct BotApiTgGateway {
     runtimes: Mutex<HashMap<String, BotApiTgRuntime>>,
     dispatcher: Arc<Mutex<Option<Arc<dyn MsgCenterHandler>>>>,
     ui_session_tracker: Arc<Mutex<Option<Arc<TgUiSessionTracker>>>>,
-    ingress_tasks: Mutex<HashMap<String, JoinHandle<()>>>,
+    ingress_tasks: Mutex<HashMap<String, ManagedTask>>,
     transport_did: Option<DID>,
     tunnel_instance_id: Option<String>,
     poll_timeout_secs: u64,
@@ -2974,7 +3043,7 @@ impl BotApiTgGateway {
         owner_did: &DID,
         bot_account_id: &str,
         tunnel_instance_id: &str,
-    ) -> i64 {
+    ) -> AnyResult<i64> {
         let session_id =
             Self::bot_api_offset_session_id(owner_did, bot_account_id, tunnel_instance_id);
         match dispatcher
@@ -2985,27 +3054,29 @@ impl BotApiTgGateway {
             )
             .await
         {
-            Ok(Some(entry)) => entry
-                .value
-                .as_i64()
-                .or_else(|| {
+            Ok(Some(entry)) => {
+                let offset = entry.value.as_i64().or_else(|| {
                     entry
                         .value
                         .as_u64()
                         .and_then(|value| i64::try_from(value).ok())
+                });
+                offset.filter(|value| *value >= 0).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "invalid telegram bot api offset state for owner={}, bot={}, value={}",
+                        owner_did.to_string(),
+                        bot_account_id,
+                        entry.value
+                    )
                 })
-                .unwrap_or(0)
-                .max(0),
-            Ok(None) => 0,
-            Err(error) => {
-                warn!(
-                    "telegram bot api offset load failed, owner={}, bot={}, error={}",
-                    owner_did.to_string(),
-                    bot_account_id,
-                    error
-                );
-                0
             }
+            Ok(None) => Ok(0),
+            Err(error) => Err(anyhow::anyhow!(
+                "telegram bot api offset load failed, owner={}, bot={}, error={}",
+                owner_did.to_string(),
+                bot_account_id,
+                error
+            )),
         }
     }
 
@@ -3030,7 +3101,7 @@ impl BotApiTgGateway {
             .map_err(|error| anyhow::anyhow!("persist telegram bot api offset failed: {}", error))
     }
 
-    fn spawn_ingress_task(&self, runtime: BotApiTgRuntime) -> JoinHandle<()> {
+    fn spawn_ingress_task(&self, runtime: BotApiTgRuntime) -> ManagedTask {
         let http = self.http.clone();
         let dispatcher = self.dispatcher.clone();
         let ui_session_tracker = self.ui_session_tracker.clone();
@@ -3042,10 +3113,11 @@ impl BotApiTgGateway {
             .unwrap_or("default")
             .to_string();
         let poll_timeout_secs = self.poll_timeout_secs;
-        tokio::spawn(async move {
+        let (stop_tx, mut stop_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
             let mut offset = 0_i64;
             let mut offset_loaded = false;
-            loop {
+            'poll_loop: loop {
                 let dispatcher = {
                     let guard = dispatcher.lock().await;
                     guard.clone()
@@ -3056,31 +3128,52 @@ impl BotApiTgGateway {
                         runtime.owner_did.to_string(),
                         runtime.bot_account_id,
                     );
-                    tokio::time::sleep(Duration::from_millis(1000)).await;
+                    tokio::select! {
+                        _ = &mut stop_rx => break 'poll_loop,
+                        _ = tokio::time::sleep(Duration::from_millis(1000)) => {}
+                    }
                     continue;
                 };
                 if !offset_loaded {
-                    offset = Self::load_bot_api_offset(
+                    offset = match Self::load_bot_api_offset(
                         &dispatcher,
                         &runtime.owner_did,
                         &runtime.bot_account_id,
                         &offset_tunnel_instance_id,
                     )
-                    .await;
+                    .await
+                    {
+                        Ok(offset) => offset,
+                        Err(error) => {
+                            warn!(
+                                "telegram bot api offset load failed, pause polling: owner={}, bot={}, error={}",
+                                runtime.owner_did.to_string(),
+                                runtime.bot_account_id,
+                                error
+                            );
+                            tokio::select! {
+                                _ = &mut stop_rx => break 'poll_loop,
+                                _ = tokio::time::sleep(Duration::from_millis(1000)) => {}
+                            }
+                            continue;
+                        }
+                    };
                     offset_loaded = true;
                 }
 
-                let updates = Self::call_api_with_client::<Vec<TgBotApiUpdate>>(
-                    &http,
-                    &runtime.token,
-                    "getUpdates",
-                    Some(json!({
-                        "offset": offset,
-                        "timeout": poll_timeout_secs,
-                        "allowed_updates": ["message"]
-                    })),
-                )
-                .await;
+                let updates = tokio::select! {
+                    _ = &mut stop_rx => break 'poll_loop,
+                    updates = Self::call_api_with_client::<Vec<TgBotApiUpdate>>(
+                        &http,
+                        &runtime.token,
+                        "getUpdates",
+                        Some(json!({
+                            "offset": offset,
+                            "timeout": poll_timeout_secs,
+                            "allowed_updates": ["message"]
+                        })),
+                    ) => updates,
+                };
 
                 let updates = match updates {
                     Ok(updates) => updates,
@@ -3091,7 +3184,10 @@ impl BotApiTgGateway {
                             runtime.bot_account_id,
                             error
                         );
-                        tokio::time::sleep(Duration::from_millis(1000)).await;
+                        tokio::select! {
+                            _ = &mut stop_rx => break 'poll_loop,
+                            _ = tokio::time::sleep(Duration::from_millis(1000)) => {}
+                        }
                         continue;
                     }
                 };
@@ -3115,7 +3211,10 @@ impl BotApiTgGateway {
                                 update.update_id,
                                 error
                             );
-                            tokio::time::sleep(Duration::from_millis(1000)).await;
+                            tokio::select! {
+                                _ = &mut stop_rx => break 'poll_loop,
+                                _ = tokio::time::sleep(Duration::from_millis(1000)) => {}
+                            }
                             break;
                         }
                         offset = offset.max(next_offset);
@@ -3145,7 +3244,10 @@ impl BotApiTgGateway {
                             runtime.bot_account_id,
                             error
                         );
-                        tokio::time::sleep(Duration::from_millis(1000)).await;
+                        tokio::select! {
+                            _ = &mut stop_rx => break 'poll_loop,
+                            _ = tokio::time::sleep(Duration::from_millis(1000)) => {}
+                        }
                         break;
                     }
                     if let Err(error) = Self::persist_bot_api_offset(
@@ -3164,13 +3266,17 @@ impl BotApiTgGateway {
                             message_id,
                             error
                         );
-                        tokio::time::sleep(Duration::from_millis(1000)).await;
+                        tokio::select! {
+                            _ = &mut stop_rx => break 'poll_loop,
+                            _ = tokio::time::sleep(Duration::from_millis(1000)) => {}
+                        }
                         break;
                     }
                     offset = offset.max(next_offset);
                 }
             }
-        })
+        });
+        ManagedTask::new(stop_tx, handle)
     }
 }
 
@@ -3189,11 +3295,24 @@ impl TgGateway for BotApiTgGateway {
         }
 
         let mut started = HashMap::<String, BotApiTgRuntime>::new();
-        let mut started_tasks = HashMap::<String, JoinHandle<()>>::new();
+        let mut started_tasks = HashMap::<String, ManagedTask>::new();
         for binding in bindings {
-            binding.validate()?;
-            let token = resolve_binding_bot_token(binding)?;
-            let me = Self::call_api_with_client::<TgBotApiMe>(&self.http, &token, "getMe", None)
+            if let Err(error) = binding.validate() {
+                for (_, task) in started_tasks.drain() {
+                    task.stop("bot-api-start-rollback").await;
+                }
+                return Err(error);
+            }
+            let token = match resolve_binding_bot_token(binding) {
+                Ok(token) => token,
+                Err(error) => {
+                    for (_, task) in started_tasks.drain() {
+                        task.stop("bot-api-start-rollback").await;
+                    }
+                    return Err(error);
+                }
+            };
+            let me = match Self::call_api_with_client::<TgBotApiMe>(&self.http, &token, "getMe", None)
                 .await
                 .with_context(|| {
                     format!(
@@ -3201,7 +3320,15 @@ impl TgGateway for BotApiTgGateway {
                         binding.owner_did.to_string(),
                         binding.bot_account_id
                     )
-                })?;
+                }) {
+                Ok(me) => me,
+                Err(error) => {
+                    for (_, task) in started_tasks.drain() {
+                        task.stop("bot-api-start-rollback").await;
+                    }
+                    return Err(error);
+                }
+            };
             info!(
                 "telegram bot api ready: owner={}, bot_id={}, username={:?}",
                 binding.owner_did.to_string(),
@@ -3231,7 +3358,7 @@ impl TgGateway for BotApiTgGateway {
         let mut guard = self.runtimes.lock().await;
         if !guard.is_empty() {
             for (_, task) in started_tasks.drain() {
-                task.abort();
+                task.stop("bot-api-start-race").await;
             }
             return Ok(());
         }
@@ -3251,7 +3378,7 @@ impl TgGateway for BotApiTgGateway {
         {
             let mut tasks_guard = self.ingress_tasks.lock().await;
             for (_, task) in tasks_guard.drain() {
-                task.abort();
+                task.stop("bot-api-ingress").await;
             }
         }
         let mut guard = self.runtimes.lock().await;
@@ -3544,7 +3671,7 @@ pub struct TgTunnel {
     dispatcher: Arc<RwLock<Option<Arc<dyn MsgCenterHandler>>>>,
     gateway: Arc<dyn TgGateway>,
     ui_session_tracker: Arc<TgUiSessionTracker>,
-    ui_session_worker: Mutex<Option<JoinHandle<()>>>,
+    ui_session_worker: Mutex<Option<ManagedTask>>,
 }
 
 impl TgTunnel {
@@ -3857,20 +3984,25 @@ impl TgTunnel {
 
         let tracker = self.ui_session_tracker.clone();
         let gateway = self.gateway.clone();
-        *worker_guard = Some(tokio::spawn(async move {
+        let (stop_tx, mut stop_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
             let mut ticker =
                 tokio::time::interval(Duration::from_millis(TG_UI_SESSION_REFRESH_INTERVAL_MS));
             ticker.tick().await;
             loop {
-                ticker.tick().await;
+                tokio::select! {
+                    _ = &mut stop_rx => break,
+                    _ = ticker.tick() => {}
+                }
                 Self::refresh_ui_sessions(tracker.as_ref(), gateway.as_ref()).await;
             }
-        }));
+        });
+        *worker_guard = Some(ManagedTask::new(stop_tx, handle));
     }
 
     async fn stop_ui_session_worker(&self) {
         if let Some(worker) = self.ui_session_worker.lock().await.take() {
-            worker.abort();
+            worker.stop("telegram-ui-session-worker").await;
         }
         let sessions = {
             let mut guard = self.ui_session_tracker.sessions.lock().await;
@@ -4401,7 +4533,8 @@ mod tests {
     async fn new_msg_center() -> (MessageCenter, tempfile::TempDir) {
         let tmp = tempdir().unwrap();
         let db_path = tmp.path().join("msg-center.db");
-        let conn = format!("sqlite://{}?mode=rwc", db_path.to_str().unwrap());
+        let db_path = db_path.to_string_lossy().replace('\\', "/");
+        let conn = format!("sqlite:///{}?mode=rwc", db_path);
         let cfg = buckyos_api::msg_center_default_rdb_instance_config();
         let schema = cfg.schema.get(&RdbBackend::Sqlite).cloned();
         let db = MsgBoxDbMgr::open(&conn, RdbBackend::Sqlite, schema.as_deref())
@@ -4415,6 +4548,57 @@ mod tests {
         let mut cfg = TgTunnelConfig::new(DID::new("bns", "tg-test"));
         cfg.supports_ingress = false;
         TgTunnel::new(cfg)
+    }
+
+    #[tokio::test]
+    async fn bot_api_offset_invalid_state_returns_error() {
+        let (center, _tmp) = new_msg_center().await;
+        let owner = DID::new("bns", "alice");
+        let bot_account_id = "@alice_bot";
+        let tunnel_instance_id = "default";
+        let session_id =
+            BotApiTgGateway::bot_api_offset_session_id(&owner, bot_account_id, tunnel_instance_id);
+        center
+            .handle_update_ui_session_state(
+                session_id,
+                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+                json!("not-an-offset"),
+                RPCContext::default(),
+            )
+            .await
+            .unwrap();
+
+        let handler: Arc<dyn MsgCenterHandler> = Arc::new(center);
+        let error = BotApiTgGateway::load_bot_api_offset(
+            &handler,
+            &owner,
+            bot_account_id,
+            tunnel_instance_id,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("invalid telegram bot api offset"));
+
+        let session_id =
+            BotApiTgGateway::bot_api_offset_session_id(&owner, bot_account_id, tunnel_instance_id);
+        handler
+            .handle_update_ui_session_state(
+                session_id,
+                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+                json!(-1),
+                RPCContext::default(),
+            )
+            .await
+            .unwrap();
+        let error = BotApiTgGateway::load_bot_api_offset(
+            &handler,
+            &owner,
+            bot_account_id,
+            tunnel_instance_id,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("invalid telegram bot api offset"));
     }
 
     fn build_record(
@@ -5041,6 +5225,22 @@ mod tests {
             .to_string()
             .contains("missing tg bot binding for did:bns:no-binding"));
         tunnel.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn managed_task_stop_signals_and_awaits_task_exit() {
+        let (stop_observed_tx, stop_observed_rx) = oneshot::channel();
+        let (stop_tx, mut stop_rx) = oneshot::channel();
+        let task = ManagedTask::new(
+            stop_tx,
+            tokio::spawn(async move {
+                let _ = (&mut stop_rx).await;
+                let _ = stop_observed_tx.send(());
+            }),
+        );
+
+        task.stop("test-managed-task").await;
+        stop_observed_rx.await.unwrap();
     }
 
     // 测试方式：

--- a/src/frame/msg_center/src/tg_tunnel.rs
+++ b/src/frame/msg_center/src/tg_tunnel.rs
@@ -47,6 +47,7 @@ const TG_BINDING_EXTRA_BOT_TOKEN: &str = "bot_token";
 const TG_BOT_API_ENDPOINT: &str = "https://api.telegram.org";
 const TG_UI_SESSION_IDLE_TIMEOUT_MS: u64 = 10 * 60 * 1000;
 const TG_UI_SESSION_REFRESH_INTERVAL_MS: u64 = 5 * 1000;
+const TG_BOT_API_OFFSET_STATE_KEY: &str = "bot_api_offset";
 const TG_BUILTIN_COMMANDS: &[(&str, &str)] = &[
     ("new", "Create a new session"),
     ("clean", "Delete current session and create a new one"),
@@ -2955,16 +2956,120 @@ impl BotApiTgGateway {
         trimmed.to_string()
     }
 
+    fn bot_api_offset_session_id(
+        owner_did: &DID,
+        bot_account_id: &str,
+        tunnel_instance_id: &str,
+    ) -> String {
+        format!(
+            "tg:bot-api-offset:{}:{}:{}",
+            owner_did.to_string(),
+            bot_account_id,
+            tunnel_instance_id
+        )
+    }
+
+    async fn load_bot_api_offset(
+        dispatcher: &Arc<dyn MsgCenterHandler>,
+        owner_did: &DID,
+        bot_account_id: &str,
+        tunnel_instance_id: &str,
+    ) -> i64 {
+        let session_id =
+            Self::bot_api_offset_session_id(owner_did, bot_account_id, tunnel_instance_id);
+        match dispatcher
+            .handle_get_ui_session_state(
+                session_id,
+                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+                RPCContext::default(),
+            )
+            .await
+        {
+            Ok(Some(entry)) => entry
+                .value
+                .as_i64()
+                .or_else(|| {
+                    entry
+                        .value
+                        .as_u64()
+                        .and_then(|value| i64::try_from(value).ok())
+                })
+                .unwrap_or(0)
+                .max(0),
+            Ok(None) => 0,
+            Err(error) => {
+                warn!(
+                    "telegram bot api offset load failed, owner={}, bot={}, error={}",
+                    owner_did.to_string(),
+                    bot_account_id,
+                    error
+                );
+                0
+            }
+        }
+    }
+
+    async fn persist_bot_api_offset(
+        dispatcher: &Arc<dyn MsgCenterHandler>,
+        owner_did: &DID,
+        bot_account_id: &str,
+        tunnel_instance_id: &str,
+        offset: i64,
+    ) -> AnyResult<()> {
+        let session_id =
+            Self::bot_api_offset_session_id(owner_did, bot_account_id, tunnel_instance_id);
+        dispatcher
+            .handle_update_ui_session_state(
+                session_id,
+                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+                json!(offset.max(0)),
+                RPCContext::default(),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| anyhow::anyhow!("persist telegram bot api offset failed: {}", error))
+    }
+
     fn spawn_ingress_task(&self, runtime: BotApiTgRuntime) -> JoinHandle<()> {
         let http = self.http.clone();
         let dispatcher = self.dispatcher.clone();
         let ui_session_tracker = self.ui_session_tracker.clone();
         let transport_did = self.transport_did.clone();
         let tunnel_instance_id = self.tunnel_instance_id.clone();
+        let offset_tunnel_instance_id = tunnel_instance_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("default")
+            .to_string();
         let poll_timeout_secs = self.poll_timeout_secs;
         tokio::spawn(async move {
             let mut offset = 0_i64;
+            let mut offset_loaded = false;
             loop {
+                let dispatcher = {
+                    let guard = dispatcher.lock().await;
+                    guard.clone()
+                };
+                let Some(dispatcher) = dispatcher else {
+                    warn!(
+                        "telegram ingress dispatcher missing, pause polling (gateway=bot_api): owner={}, bot={}",
+                        runtime.owner_did.to_string(),
+                        runtime.bot_account_id,
+                    );
+                    tokio::time::sleep(Duration::from_millis(1000)).await;
+                    continue;
+                };
+                if !offset_loaded {
+                    offset = Self::load_bot_api_offset(
+                        &dispatcher,
+                        &runtime.owner_did,
+                        &runtime.bot_account_id,
+                        &offset_tunnel_instance_id,
+                    )
+                    .await;
+                    offset_loaded = true;
+                }
+
                 let updates = Self::call_api_with_client::<Vec<TgBotApiUpdate>>(
                     &http,
                     &runtime.token,
@@ -2992,31 +3097,39 @@ impl BotApiTgGateway {
                 };
 
                 for update in updates {
-                    offset = offset.max(update.update_id.saturating_add(1));
+                    let next_offset = update.update_id.saturating_add(1);
                     let Some(message) = update.message else {
-                        continue;
-                    };
-                    let dispatcher = {
-                        let guard = dispatcher.lock().await;
-                        guard.clone()
-                    };
-                    let Some(dispatcher) = dispatcher else {
-                        warn!(
-                            "telegram ingress dispatcher missing, dropping message (gateway=bot_api): owner={}, bot={}, message_id={}",
-                            runtime.owner_did.to_string(),
-                            runtime.bot_account_id,
-                            message.message_id,
-                        );
+                        if let Err(error) = Self::persist_bot_api_offset(
+                            &dispatcher,
+                            &runtime.owner_did,
+                            &runtime.bot_account_id,
+                            &offset_tunnel_instance_id,
+                            next_offset,
+                        )
+                        .await
+                        {
+                            warn!(
+                                "telegram bot api offset persist failed after skipped update, owner={}, bot={}, update_id={}, error={}",
+                                runtime.owner_did.to_string(),
+                                runtime.bot_account_id,
+                                update.update_id,
+                                error
+                            );
+                            tokio::time::sleep(Duration::from_millis(1000)).await;
+                            break;
+                        }
+                        offset = offset.max(next_offset);
                         continue;
                     };
                     let ui_session_tracker = {
                         let guard = ui_session_tracker.lock().await;
                         guard.clone()
                     };
+                    let message_id = message.message_id;
                     if let Err(error) = Self::dispatch_incoming_message(
                         &http,
                         runtime.token.as_str(),
-                        dispatcher,
+                        dispatcher.clone(),
                         ui_session_tracker,
                         runtime.owner_did.clone(),
                         runtime.bot_account_id.clone(),
@@ -3032,7 +3145,29 @@ impl BotApiTgGateway {
                             runtime.bot_account_id,
                             error
                         );
+                        tokio::time::sleep(Duration::from_millis(1000)).await;
+                        break;
                     }
+                    if let Err(error) = Self::persist_bot_api_offset(
+                        &dispatcher,
+                        &runtime.owner_did,
+                        &runtime.bot_account_id,
+                        &offset_tunnel_instance_id,
+                        next_offset,
+                    )
+                    .await
+                    {
+                        warn!(
+                            "telegram bot api offset persist failed after dispatch, owner={}, bot={}, message_id={}, error={}",
+                            runtime.owner_did.to_string(),
+                            runtime.bot_account_id,
+                            message_id,
+                            error
+                        );
+                        tokio::time::sleep(Duration::from_millis(1000)).await;
+                        break;
+                    }
+                    offset = offset.max(next_offset);
                 }
             }
         })

--- a/src/kernel/buckyos-api/src/msg_center_client.rs
+++ b/src/kernel/buckyos-api/src/msg_center_client.rs
@@ -20,7 +20,7 @@ pub const MSG_CENTER_SERVICE_PORT: u16 = 4050;
 pub const MSG_CENTER_RDB_INSTANCE_ID: &str = "msg-center-main";
 /// Version of the msg-center schema. Bump whenever the DDL below changes in a
 /// way that is not trivially re-idempotent.
-pub const MSG_CENTER_RDB_SCHEMA_VERSION: u64 = 4;
+pub const MSG_CENTER_RDB_SCHEMA_VERSION: u64 = 5;
 pub const UI_SESSION_STATE_ACTIVE_KEY: &str = "active";
 pub const UI_SESSION_STATE_TYPING_KEY: &str = "typing";
 pub const UI_SESSION_STATE_STATUS_LINE_KEY: &str = "status_line";
@@ -128,6 +128,19 @@ CREATE TABLE IF NOT EXISTS msg_refs (
     created_at_ms INTEGER NOT NULL,
     PRIMARY KEY (owner, msg_id)
 );
+
+CREATE TABLE IF NOT EXISTS msg_idempotency (
+    scope           TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    msg_id          TEXT,
+    result_json     TEXT NOT NULL,
+    created_at_ms   INTEGER NOT NULL,
+    updated_at_ms   INTEGER NOT NULL,
+    expires_at_ms   INTEGER,
+    PRIMARY KEY (scope, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS idx_msg_idempotency_expire
+    ON msg_idempotency(expires_at_ms);
 
 CREATE TABLE IF NOT EXISTS contact_metadata (
     key   TEXT PRIMARY KEY,
@@ -289,6 +302,19 @@ CREATE TABLE IF NOT EXISTS msg_refs (
     created_at_ms BIGINT NOT NULL,
     PRIMARY KEY (owner, msg_id)
 );
+
+CREATE TABLE IF NOT EXISTS msg_idempotency (
+    scope           TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    msg_id          TEXT,
+    result_json     TEXT NOT NULL,
+    created_at_ms   BIGINT NOT NULL,
+    updated_at_ms   BIGINT NOT NULL,
+    expires_at_ms   BIGINT,
+    PRIMARY KEY (scope, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS idx_msg_idempotency_expire
+    ON msg_idempotency(expires_at_ms);
 
 CREATE TABLE IF NOT EXISTS contact_metadata (
     key   TEXT PRIMARY KEY,

--- a/src/kernel/buckyos-api/src/msg_center_client.rs
+++ b/src/kernel/buckyos-api/src/msg_center_client.rs
@@ -20,7 +20,7 @@ pub const MSG_CENTER_SERVICE_PORT: u16 = 4050;
 pub const MSG_CENTER_RDB_INSTANCE_ID: &str = "msg-center-main";
 /// Version of the msg-center schema. Bump whenever the DDL below changes in a
 /// way that is not trivially re-idempotent.
-pub const MSG_CENTER_RDB_SCHEMA_VERSION: u64 = 5;
+pub const MSG_CENTER_RDB_SCHEMA_VERSION: u64 = 7;
 pub const UI_SESSION_STATE_ACTIVE_KEY: &str = "active";
 pub const UI_SESSION_STATE_TYPING_KEY: &str = "typing";
 pub const UI_SESSION_STATE_STATUS_LINE_KEY: &str = "status_line";
@@ -133,7 +133,9 @@ CREATE TABLE IF NOT EXISTS msg_idempotency (
     scope           TEXT NOT NULL,
     idempotency_key TEXT NOT NULL,
     msg_id          TEXT,
-    result_json     TEXT NOT NULL,
+    retention_key   TEXT,
+    state           TEXT NOT NULL,
+    result_json     TEXT,
     created_at_ms   INTEGER NOT NULL,
     updated_at_ms   INTEGER NOT NULL,
     expires_at_ms   INTEGER,
@@ -141,6 +143,8 @@ CREATE TABLE IF NOT EXISTS msg_idempotency (
 );
 CREATE INDEX IF NOT EXISTS idx_msg_idempotency_expire
     ON msg_idempotency(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_msg_idempotency_retention_expire
+    ON msg_idempotency(retention_key, expires_at_ms);
 
 CREATE TABLE IF NOT EXISTS contact_metadata (
     key   TEXT PRIMARY KEY,
@@ -307,7 +311,9 @@ CREATE TABLE IF NOT EXISTS msg_idempotency (
     scope           TEXT NOT NULL,
     idempotency_key TEXT NOT NULL,
     msg_id          TEXT,
-    result_json     TEXT NOT NULL,
+    retention_key   TEXT,
+    state           TEXT NOT NULL,
+    result_json     TEXT,
     created_at_ms   BIGINT NOT NULL,
     updated_at_ms   BIGINT NOT NULL,
     expires_at_ms   BIGINT,
@@ -315,6 +321,8 @@ CREATE TABLE IF NOT EXISTS msg_idempotency (
 );
 CREATE INDEX IF NOT EXISTS idx_msg_idempotency_expire
     ON msg_idempotency(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_msg_idempotency_retention_expire
+    ON msg_idempotency(retention_key, expires_at_ms);
 
 CREATE TABLE IF NOT EXISTS contact_metadata (
     key   TEXT PRIMARY KEY,


### PR DESCRIPTION
## 背景

消息域新版设计中，`notify` 只是加速消费模块及时拉取消息，不应作为可靠处理完成标志。真正不可丢的恢复点应落在持久状态里：入站幂等键要跨重启保留，平台 cursor/offset 要在消息成功进入 MessageCenter 后再推进。

这次修复围绕两个缺口：

1. `dispatch_idempotency` / `post_send_idempotency` 原先只在内存 `HashMap` 中保存，服务重启后会丢失，和文档中“入站幂等键持久化”的要求不一致。
2. Telegram Bot API 入站 `offset` 原先是 task 内局部变量，重启后不可恢复；并且旧逻辑会在处理 update 前先推进内存 offset，存在平台侧确认后本地未成功落库的丢消息风险。

## 主要改动

- 新增 `msg_idempotency` RDB 表，并将 MessageCenter schema version 从 `4` 提升到 `5`。
- 为 `dispatch` / `post_send` 增加 RDB 持久幂等结果：
  - 先查内存缓存。
  - 未命中时查 RDB。
  - 成功生成结果后同时写 RDB 与内存缓存。
  - 持久化记录带 `expires_at_ms`，当前 TTL 为 30 天。
- 调整 Telegram Bot API 入站 offset 处理：
  - 启动 polling 前从持久状态读取 offset。
  - dispatcher 缺失时暂停 polling，不推进 offset。
  - message update 先执行 `dispatch_incoming_message`。
  - 只有 dispatch 成功后才持久化 `next_offset`，持久化成功后才更新内存 offset。
  - 非 message update 作为可跳过事件，持久化 `next_offset` 后再跳过。
- 增加测试覆盖：MessageCenter 重启后，同一个 dispatch idempotency key 仍命中已持久化结果，不重复写 inbox record。

## 可靠性语义

修复后，Bot API 入站链路变为：

```text
读取持久 offset
→ getUpdates(offset)
→ dispatch_incoming_message 成功进入 MessageCenter
→ 持久化 next_offset
→ 更新内存 offset
```

如果 dispatch 失败、dispatcher 缺失、进程崩溃或 offset 持久化失败，都不会在 BuckyOS 本地推进恢复点。重复上报由持久化 idempotency key 收敛。

## 验证情况

- `git diff --check` 通过。
- `cargo fmt` 未运行成功：当前 toolchain `1.95.0-x86_64-pc-windows-msvc` 未安装 `rustfmt` 组件。
- `cargo test -p msg_center` 开始正常构建，但在依赖编译阶段超时，未进入本包错误输出。
- `cargo check -p buckyos-api` 也在依赖检查阶段超时，未进入本包错误输出。

## 风险与后续

- 这次复用了现有 `ui_session_states` 来保存 Telegram Bot API offset，避免扩大 API 面；后续如果希望更语义化，可以单独抽象 tunnel runtime state 表。
- 完整 Rust 测试仍需要在依赖已缓存或 CI 环境中跑完确认。