### PR TITLE
修复 kevent shared ringbuffer 权限与跨运行环境问题

### DIFF
--- a/doc/arch/11_env_contract.md
+++ b/doc/arch/11_env_contract.md
@@ -109,7 +109,9 @@ AgentTool 新实现目标是只依赖 `OPENDAN_AGENT_ROOT`、`OPENDAN_SESSION_ID
 | `BUCKYOS_TG_API_ID` | msg-center Telegram tunnel | Telegram API id，启用 grammers gateway 时必填。 |
 | `BUCKYOS_TG_API_HASH` | msg-center Telegram tunnel | Telegram API hash，启用 grammers gateway 时必填。 |
 | `BUCKYOS_TG_SESSION_DIR` | msg-center Telegram tunnel | Telegram session 目录覆盖。 |
-| `BUCKYOS_KEVENT_RINGBUFFER_PATH` | kevent shared ringbuffer | 覆盖共享 ringbuffer 文件路径，默认 `/tmp/buckyos_kevent_ringbuffer_v2.shm`；测试中需要串行管理。 |
+| `BUCKYOS_KEVENT_RINGBUFFER_PATH` | kevent shared ringbuffer | 覆盖宿主机共享 ringbuffer 文件路径，默认 `$BUCKYOS_ROOT/run/kevent/ringbuffer_v2.shm`；测试中需要串行管理。 |
+| `BUCKYOS_KEVENT_GROUP` | kevent shared ringbuffer | Unix 上 ringbuffer 文件所属的公共服务组；Linux 安装包默认创建并使用 `buckyos` 组，文件模式为 `0660`。 |
+| `BUCKYOS_KEVENT_DAEMON_ADDR` | kevent daemon bridge | 启用 native TCP daemon bridge，例如容器内使用 `host.docker.internal:3183`；设置后 Full client 不打开容器私有 ringbuffer。 |
 | `BUCKYOS_KEVENT_KMSG_CASES` | `test/kevent_kmsg` | 选择 kevent/kmsg 测试 case。 |
 | `BUCKYOS_WEBSDK_ROOT` | sys_test | 覆盖 web sdk 搜索目录。 |
 

--- a/doc/arch/kevent/kevent_ringbuffer.md
+++ b/doc/arch/kevent/kevent_ringbuffer.md
@@ -512,7 +512,13 @@ EventBus 是信号通道，不是数据通道；大数据应走 kMsgQueue。
 
 ---
 
-## 12. 可选增强（不影响 v1，但能明显提升可维护性/可观测性）
+## 12. 运行环境与权限
+
+宿主机 Full client 默认使用 `$BUCKYOS_ROOT/run/kevent/ringbuffer_v2.shm`。Linux 安装时创建 `buckyos` 公共服务组，目录和文件权限分别为 `0770`、`0660`；路径与组可通过 `BUCKYOS_KEVENT_RINGBUFFER_PATH`、`BUCKYOS_KEVENT_GROUP` 覆盖。打开失败的日志必须包含实际路径、文件 owner/group/mode 和当前进程 uid/gid。
+
+容器不使用自己的 `/tmp` 或私有 mmap。node-daemon 向容器注入 `BUCKYOS_KEVENT_DAEMON_ADDR=host.docker.internal:3183`，Full client 通过 native TCP bridge 注册 reader、发布及拉取事件。TCP bridge 每次调用重新连接；宿主机 ringbuffer 打开失败时，客户端后台每秒重试，权限修复后无需重启进程。
+
+## 13. 可选增强（不影响 v1，但能明显提升可维护性/可观测性）
 
 1. **统计与诊断**（共享内存里放 counters）
 

--- a/doc/path_usage.md
+++ b/doc/path_usage.md
@@ -87,6 +87,7 @@ $buckyos_root/data/srv/library/ => cyfs://$zone_id/srv/library/ : zone内共享�
 $buckyos_root/data/srv/publish/ => cyfs://$zone_id/srv/publish/ : zone级别的分享数据
 $buckyos_root/storage : 内核基础设施在本机的持久化存储(dcfs chunks、named_store,未来可能包含dRDB数据),卸载不会删除
 $buckyos_root/etc : 内核配置区,覆盖安装和卸载时的操作是逐个文件定义的
+$buckyos_root/run/kevent : 宿主机 kevent 共享 ringbuffer 运行目录；Linux 使用 `buckyos` 公共服务组和 `0770/0660` 权限，不向容器直接挂载
 
 
 ## 安装卸载整理

--- a/src/kernel/buckyos-api/src/kevent_client.rs
+++ b/src/kernel/buckyos-api/src/kevent_client.rs
@@ -7,9 +7,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, RwLock as StdRwLock, Weak};
+use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock, Weak};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio::sync::{oneshot, Mutex, Notify, RwLock};
 use tokio::time::Instant;
 
@@ -17,9 +19,13 @@ pub const KEVENT_SERVICE_UNIQUE_ID: &str = "kevent";
 pub const KEVENT_SERVICE_NAME: &str = "kevent";
 pub const KEVENT_SERVICE_MAIN_PORT: u16 = 3181;
 pub const KEVENT_SERVICE_NATIVE_PORT: u16 = 3183;
+pub const KEVENT_DAEMON_ADDR_ENV: &str = "BUCKYOS_KEVENT_DAEMON_ADDR";
 pub const DEFAULT_READER_CAPACITY: usize = 1024;
 pub const MAX_EVENT_DATA_SIZE_BYTES: usize = 64 * 1024;
 const SHARED_RING_DRAIN_BATCH: usize = 128;
+const MAX_DAEMON_FRAME_SIZE: usize = 1024 * 1024;
+const SHARED_RING_RECONNECT_INTERVAL_MS: u64 = 1000;
+static NEXT_READER_ID: AtomicU64 = AtomicU64::new(0);
 /// Maximum time the ShmDispatch thread blocks in futex/ulock before
 /// re-checking (acts as a heartbeat / fallback interval).
 ///
@@ -187,6 +193,160 @@ pub trait KEventDaemonBridge: Send + Sync {
         remove: &[String],
     ) -> KEventResult<()>;
     async fn publish_global(&self, event: &Event) -> KEventResult<()>;
+    async fn pull_event(
+        &self,
+        _reader_id: &str,
+        _timeout_ms: Option<u64>,
+    ) -> KEventResult<Option<Event>> {
+        Err(KEventError::NotSupported(
+            "daemon bridge does not support pulling events".to_string(),
+        ))
+    }
+}
+
+#[derive(Clone)]
+pub struct TcpKEventDaemonBridge {
+    target: String,
+}
+
+impl TcpKEventDaemonBridge {
+    pub fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+        }
+    }
+
+    async fn call(&self, request: KEventDaemonRequest) -> KEventResult<KEventDaemonResponse> {
+        let mut stream = TcpStream::connect(self.target.as_str())
+            .await
+            .map_err(|error| {
+                KEventError::DaemonUnavailable(format!(
+                    "connect kevent daemon {} failed: {}",
+                    self.target, error
+                ))
+            })?;
+        let payload = serde_json::to_vec(&request).map_err(|error| {
+            KEventError::Internal(format!("encode daemon request failed: {}", error))
+        })?;
+        stream
+            .write_u32(payload.len() as u32)
+            .await
+            .map_err(|error| {
+                KEventError::Internal(format!("write frame length failed: {}", error))
+            })?;
+        stream.write_all(&payload).await.map_err(|error| {
+            KEventError::Internal(format!("write frame payload failed: {}", error))
+        })?;
+        stream
+            .flush()
+            .await
+            .map_err(|error| KEventError::Internal(format!("flush frame failed: {}", error)))?;
+
+        let frame_len = stream.read_u32().await.map_err(|error| {
+            KEventError::Internal(format!("read frame length failed: {}", error))
+        })? as usize;
+        if frame_len == 0 || frame_len > MAX_DAEMON_FRAME_SIZE {
+            return Err(KEventError::Internal(format!(
+                "invalid daemon response frame length: {}",
+                frame_len
+            )));
+        }
+        let mut frame = vec![0_u8; frame_len];
+        stream.read_exact(&mut frame).await.map_err(|error| {
+            KEventError::Internal(format!("read frame payload failed: {}", error))
+        })?;
+        serde_json::from_slice(&frame).map_err(|error| {
+            KEventError::Internal(format!("decode daemon response failed: {}", error))
+        })
+    }
+}
+
+#[async_trait]
+impl KEventDaemonBridge for TcpKEventDaemonBridge {
+    async fn register_reader(&self, reader_id: &str, patterns: &[String]) -> KEventResult<()> {
+        map_daemon_unit(
+            self.call(KEventDaemonRequest::RegisterReader {
+                reader_id: reader_id.to_string(),
+                patterns: patterns.to_vec(),
+            })
+            .await?,
+        )
+    }
+
+    async fn unregister_reader(&self, reader_id: &str) -> KEventResult<()> {
+        map_daemon_unit(
+            self.call(KEventDaemonRequest::UnregisterReader {
+                reader_id: reader_id.to_string(),
+            })
+            .await?,
+        )
+    }
+
+    async fn update_reader(
+        &self,
+        reader_id: &str,
+        add: &[String],
+        remove: &[String],
+    ) -> KEventResult<()> {
+        map_daemon_unit(
+            self.call(KEventDaemonRequest::UpdateReader {
+                reader_id: reader_id.to_string(),
+                add: add.to_vec(),
+                remove: remove.to_vec(),
+            })
+            .await?,
+        )
+    }
+
+    async fn publish_global(&self, event: &Event) -> KEventResult<()> {
+        map_daemon_unit(
+            self.call(KEventDaemonRequest::PublishGlobal {
+                event: event.clone(),
+            })
+            .await?,
+        )
+    }
+
+    async fn pull_event(
+        &self,
+        reader_id: &str,
+        timeout_ms: Option<u64>,
+    ) -> KEventResult<Option<Event>> {
+        match self
+            .call(KEventDaemonRequest::PullEvent {
+                reader_id: reader_id.to_string(),
+                timeout_ms,
+            })
+            .await?
+        {
+            KEventDaemonResponse::Ok { event } => Ok(event),
+            KEventDaemonResponse::Err { code, message } => {
+                Err(map_daemon_error(code.as_str(), message))
+            }
+        }
+    }
+}
+
+fn map_daemon_unit(response: KEventDaemonResponse) -> KEventResult<()> {
+    match response {
+        KEventDaemonResponse::Ok { .. } => Ok(()),
+        KEventDaemonResponse::Err { code, message } => {
+            Err(map_daemon_error(code.as_str(), message))
+        }
+    }
+}
+
+fn map_daemon_error(code: &str, message: String) -> KEventError {
+    match code {
+        "INVALID_EVENTID" => KEventError::InvalidEventId(message),
+        "INVALID_PATTERN" => KEventError::InvalidPattern(message),
+        "DAEMON_UNAVAILABLE" => KEventError::DaemonUnavailable(message),
+        "TIMER_INVALID_TARGET" => KEventError::TimerInvalidTarget(message),
+        "TIMER_NOT_FOUND" => KEventError::TimerNotFound(message),
+        "NOT_SUPPORTED" => KEventError::NotSupported(message),
+        "READER_CLOSED" => KEventError::ReaderClosed(message),
+        _ => KEventError::Internal(message),
+    }
 }
 
 #[derive(Clone)]
@@ -200,8 +360,9 @@ pub struct KEventClient {
 struct KEventClientInner {
     readers: RwLock<HashMap<String, Arc<ReaderState>>>,
     timers: RwLock<HashMap<TimerId, oneshot::Sender<()>>>,
-    shared_ring: Option<Arc<SharedKEventRingBuffer>>,
-    reader_seq: AtomicU64,
+    shared_ring: StdRwLock<Option<Arc<SharedKEventRingBuffer>>>,
+    shared_ring_enabled: bool,
+    shared_ring_reconnect: StdMutex<()>,
     timer_seq: AtomicU64,
     reader_capacity: usize,
     /// Signaled by ShmDispatch after dispatching shared-ring events to
@@ -269,6 +430,42 @@ impl ReaderState {
 }
 
 impl KEventClientInner {
+    fn shared_ring(&self) -> Option<Arc<SharedKEventRingBuffer>> {
+        self.shared_ring
+            .read()
+            .expect("shared ring lock poisoned")
+            .clone()
+    }
+
+    fn ensure_shared_ring(&self) -> Option<Arc<SharedKEventRingBuffer>> {
+        if !self.shared_ring_enabled {
+            return None;
+        }
+        if let Some(shared_ring) = self.shared_ring() {
+            return Some(shared_ring);
+        }
+        let _reconnect = self
+            .shared_ring_reconnect
+            .lock()
+            .expect("shared ring reconnect lock poisoned");
+        if let Some(shared_ring) = self.shared_ring() {
+            return Some(shared_ring);
+        }
+        match SharedKEventRingBuffer::open() {
+            Ok(shared_ring) => {
+                let shared_ring = Arc::new(shared_ring);
+                *self.shared_ring.write().expect("shared ring lock poisoned") =
+                    Some(shared_ring.clone());
+                log::info!("kevent shared ringbuffer connection restored");
+                Some(shared_ring)
+            }
+            Err(error) => {
+                log::debug!("kevent shared ringbuffer reconnect failed: {}", error);
+                None
+            }
+        }
+    }
+
     async fn dispatch_event(&self, event: &Event) {
         let snapshot: Vec<Arc<ReaderState>> = self.readers.read().await.values().cloned().collect();
         for reader in snapshot {
@@ -295,7 +492,7 @@ impl KEventClientInner {
     /// readers (synchronous, for ShmDispatch thread).
     /// Returns the number of events dispatched.
     fn import_shared_events_sync(&self, max_events: usize) -> usize {
-        let Some(shared_ring) = &self.shared_ring else {
+        let Some(shared_ring) = self.shared_ring() else {
             return 0;
         };
         let events = shared_ring.drain_events::<Event>(max_events);
@@ -365,7 +562,20 @@ impl KEventClient {
         bridge: Option<Arc<dyn KEventDaemonBridge>>,
         reader_capacity: usize,
     ) -> Self {
-        let shared_ring = if mode == KEventClientMode::Full {
+        let bridge = if mode == KEventClientMode::Full {
+            bridge.or_else(|| {
+                std::env::var(KEVENT_DAEMON_ADDR_ENV)
+                    .ok()
+                    .filter(|target| !target.trim().is_empty())
+                    .map(|target| {
+                        Arc::new(TcpKEventDaemonBridge::new(target)) as Arc<dyn KEventDaemonBridge>
+                    })
+            })
+        } else {
+            bridge
+        };
+        let shared_ring_enabled = mode == KEventClientMode::Full && bridge.is_none();
+        let shared_ring = if shared_ring_enabled {
             match SharedKEventRingBuffer::open() {
                 Ok(shared_ring) => Some(Arc::new(shared_ring)),
                 Err(err) => {
@@ -380,8 +590,9 @@ impl KEventClient {
         let inner = Arc::new(KEventClientInner {
             readers: RwLock::new(HashMap::new()),
             timers: RwLock::new(HashMap::new()),
-            shared_ring,
-            reader_seq: AtomicU64::new(0),
+            shared_ring: StdRwLock::new(shared_ring),
+            shared_ring_enabled,
+            shared_ring_reconnect: StdMutex::new(()),
             timer_seq: AtomicU64::new(0),
             reader_capacity: reader_capacity.max(1),
             shm_dispatch_notify: Notify::new(),
@@ -396,7 +607,7 @@ impl KEventClient {
         // We capture the tokio Handle here (on the caller's thread, which
         // is inside a tokio runtime) so the background OS thread can use
         // block_on to call async dispatch_event.
-        if inner.shared_ring.is_some() {
+        if shared_ring_enabled {
             let weak = Arc::downgrade(&inner);
             std::thread::Builder::new()
                 .name("kevent-shm-dispatch".into())
@@ -444,7 +655,7 @@ impl KEventClient {
         if self.mode == KEventClientMode::Full
             && has_global_patterns
             && self.bridge.is_none()
-            && self.inner.shared_ring.is_none()
+            && self.inner.ensure_shared_ring().is_none()
         {
             return Err(KEventError::DaemonUnavailable(
                 "global reader requires daemon bridge or shared ringbuffer in full mode"
@@ -454,8 +665,9 @@ impl KEventClient {
 
         let normalized = normalize_patterns(patterns);
         let reader_id = format!(
-            "r_{}",
-            self.inner.reader_seq.fetch_add(1, Ordering::Relaxed) + 1
+            "r_{}_{}",
+            std::process::id(),
+            NEXT_READER_ID.fetch_add(1, Ordering::Relaxed) + 1
         );
         let state = Arc::new(ReaderState::new(
             normalized.clone(),
@@ -468,7 +680,7 @@ impl KEventClient {
             .insert(reader_id.clone(), state);
 
         if self.mode == KEventClientMode::Full && has_global_patterns {
-            if let Some(shared_ring) = &self.inner.shared_ring {
+            if let Some(shared_ring) = self.inner.ensure_shared_ring() {
                 shared_ring.prime_cursors();
             }
         }
@@ -523,7 +735,7 @@ impl KEventClient {
             KEventClientMode::Full => {
                 if is_global {
                     let mut delivered_to_local_host = false;
-                    if let Some(shared_ring) = &self.inner.shared_ring {
+                    if let Some(shared_ring) = self.inner.ensure_shared_ring() {
                         match shared_ring.publish_event(&event) {
                             Ok(_) => {
                                 delivered_to_local_host = true;
@@ -689,9 +901,13 @@ fn shm_dispatch_thread(weak: Weak<KEventClientInner>) {
             return;
         }
 
-        let shared_ring = match &inner.shared_ring {
-            Some(sr) => sr.clone(),
-            None => return,
+        let shared_ring = match inner.ensure_shared_ring() {
+            Some(shared_ring) => shared_ring,
+            None => {
+                drop(inner);
+                std::thread::sleep(Duration::from_millis(SHARED_RING_RECONNECT_INTERVAL_MS));
+                continue;
+            }
         };
 
         // Snapshot notify_seq before draining, so we don't miss events
@@ -900,6 +1116,23 @@ impl EventReader {
             if let Some(ms) = timeout_ms {
                 if ms == 0 {
                     return Ok(None);
+                }
+            }
+
+            if self.has_global_patterns {
+                if let Some(bridge) = &self.bridge {
+                    let bridge_timeout_ms = deadline.map(|deadline_at| {
+                        deadline_at
+                            .saturating_duration_since(Instant::now())
+                            .as_millis()
+                            .min(u64::MAX as u128) as u64
+                    });
+                    let bridge_pull = bridge.pull_event(&self.reader_id, bridge_timeout_ms);
+                    tokio::select! {
+                        result = bridge_pull => return result,
+                        _ = inner.shm_dispatch_notify.notified() => continue,
+                        _ = state.notify.notified() => continue,
+                    }
                 }
             }
 
@@ -1633,5 +1866,41 @@ mod tests {
         let event = reader.pull_event(Some(600)).await.unwrap().unwrap();
         assert_eq!(event.eventid, eventid);
         assert_eq!(event.data.get("path"), Some(&json!("late_producer")));
+    }
+
+    #[tokio::test]
+    async fn test_full_mode_reconnects_shared_ring_after_path_is_repaired() {
+        let _ring_guard = crate::kevent_ringbuffer::test_support::lock_with_fresh_ring();
+        let root = std::env::temp_dir().join(format!(
+            "buckyos_kevent_reconnect_{}_{}",
+            std::process::id(),
+            now_millis()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let blocked_parent = root.join("blocked");
+        std::fs::write(&blocked_parent, b"not a directory").unwrap();
+        let ring_path = blocked_parent.join("ringbuffer_v2.shm");
+        std::env::set_var(
+            crate::kevent_ringbuffer::DEFAULT_RINGBUFFER_PATH_ENV,
+            &ring_path,
+        );
+
+        let publisher = KEventClient::new_full("publisher", None);
+        std::fs::remove_file(&blocked_parent).unwrap();
+        std::fs::create_dir(&blocked_parent).unwrap();
+
+        let subscriber = KEventClient::new_full("subscriber", None);
+        let eventid = format!("/kevent/reconnect/test_{}", now_millis());
+        let reader = subscriber
+            .create_event_reader(vec![eventid.clone()])
+            .await
+            .unwrap();
+        publisher
+            .pub_event(&eventid, json!({"reconnected": true}))
+            .await
+            .unwrap();
+
+        let event = reader.pull_event(Some(1000)).await.unwrap().unwrap();
+        assert_eq!(event.data.get("reconnected"), Some(&json!(true)));
     }
 }

--- a/src/kernel/buckyos-api/src/kevent_ringbuffer.rs
+++ b/src/kernel/buckyos-api/src/kevent_ringbuffer.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::mem::size_of;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
@@ -21,7 +21,8 @@ const ENTRY_INIT: u8 = 1;
 const ENTRY_READY: u8 = 2;
 
 pub const DEFAULT_RINGBUFFER_PATH_ENV: &str = "BUCKYOS_KEVENT_RINGBUFFER_PATH";
-const DEFAULT_RINGBUFFER_PATH: &str = "/tmp/buckyos_kevent_ringbuffer_v2.shm";
+pub const KEVENT_RINGBUFFER_GROUP_ENV: &str = "BUCKYOS_KEVENT_GROUP";
+const DEFAULT_RINGBUFFER_RELATIVE_PATH: &str = "run/kevent/ringbuffer_v2.shm";
 
 const MAX_RINGS: usize = 16;
 const RING_CAPACITY: usize = 512; // must be power of 2
@@ -144,23 +145,49 @@ impl SharedKEventRingBuffer {
     pub fn open() -> Result<Self, String> {
         let path = ringbuffer_path();
         if let Some(parent) = path.parent() {
+            let parent_existed = parent.exists();
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("create ringbuffer dir {} failed: {}", parent.display(), e))?;
+            configure_ringbuffer_directory(parent, parent_existed)?;
         }
 
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(&path)
-            .map_err(|e| format!("open ringbuffer file {} failed: {}", path.display(), e))?;
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o660);
+        }
+        let file = options.open(&path).map_err(|e| {
+            format!(
+                "open ringbuffer file {} failed: {}; {}",
+                path.display(),
+                e,
+                ringbuffer_file_context(&path)
+            )
+        })?;
+
+        configure_ringbuffer_file(&file, &path)?;
 
         let region_len = size_of::<SharedRegion>() as u64;
-        file.set_len(region_len)
-            .map_err(|e| format!("resize ringbuffer file failed: {}", e))?;
+        file.set_len(region_len).map_err(|e| {
+            format!(
+                "resize ringbuffer file {} failed: {}; {}",
+                path.display(),
+                e,
+                ringbuffer_file_context(&path)
+            )
+        })?;
 
         let mmap = unsafe {
-            MmapMut::map_mut(&file).map_err(|e| format!("mmap ringbuffer file failed: {}", e))?
+            MmapMut::map_mut(&file).map_err(|e| {
+                format!(
+                    "mmap ringbuffer file {} failed: {}; {}",
+                    path.display(),
+                    e,
+                    ringbuffer_file_context(&path)
+                )
+            })?
         };
 
         let region_ptr = mmap.as_ptr() as *mut SharedRegion;
@@ -168,8 +195,19 @@ impl SharedKEventRingBuffer {
         initialize_region_if_needed(region);
 
         let pid = std::process::id();
-        let my_ring_id = allocate_ring(region, pid)
-            .ok_or_else(|| format!("no free ring entry in {}", path.display()))?;
+        let my_ring_id = allocate_ring(region, pid).ok_or_else(|| {
+            format!(
+                "no free ring entry in {}; {}",
+                path.display(),
+                ringbuffer_file_context(&path)
+            )
+        })?;
+
+        log::debug!(
+            "opened kevent shared ringbuffer: path={}, {}",
+            path.display(),
+            ringbuffer_file_context(&path)
+        );
 
         Ok(Self {
             publish: Mutex::new(PublishInner { mmap, my_ring_id }),
@@ -767,7 +805,146 @@ fn activate_ring(region: &mut SharedRegion, ring_id: usize, pid: u32) {
 fn ringbuffer_path() -> PathBuf {
     std::env::var(DEFAULT_RINGBUFFER_PATH_ENV)
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(DEFAULT_RINGBUFFER_PATH))
+        .unwrap_or_else(|_| {
+            buckyos_kit::get_buckyos_root_dir().join(DEFAULT_RINGBUFFER_RELATIVE_PATH)
+        })
+}
+
+#[cfg(unix)]
+fn configure_ringbuffer_directory(path: &Path, existed: bool) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if !existed {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o770)).map_err(|e| {
+            format!(
+                "set ringbuffer dir permissions {} failed: {}",
+                path.display(),
+                e
+            )
+        })?;
+        if let Some(gid) = configured_ringbuffer_gid()? {
+            let path_c = path_to_cstring(path)?;
+            let rc = unsafe { libc::chown(path_c.as_ptr(), u32::MAX, gid) };
+            if rc != 0 {
+                return Err(format!(
+                    "set ringbuffer dir group {} failed: {}",
+                    path.display(),
+                    std::io::Error::last_os_error()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn configure_ringbuffer_directory(_path: &Path, _existed: bool) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn configure_ringbuffer_file(file: &std::fs::File, path: &Path) -> Result<(), String> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = file.metadata().map_err(|e| {
+        format!(
+            "read ringbuffer file metadata {} failed: {}",
+            path.display(),
+            e
+        )
+    })?;
+    let process_uid = unsafe { libc::geteuid() };
+    if process_uid != 0 && process_uid != metadata.uid() {
+        return Ok(());
+    }
+
+    file.set_permissions(std::fs::Permissions::from_mode(0o660))
+        .map_err(|e| {
+            format!(
+                "set ringbuffer file permissions {} failed: {}; {}",
+                path.display(),
+                e,
+                ringbuffer_file_context(path)
+            )
+        })?;
+    if let Some(gid) = configured_ringbuffer_gid()? {
+        let rc = unsafe { libc::fchown(file.as_raw_fd(), u32::MAX, gid) };
+        if rc != 0 {
+            return Err(format!(
+                "set ringbuffer file group {} failed: {}; {}",
+                path.display(),
+                std::io::Error::last_os_error(),
+                ringbuffer_file_context(path)
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn configure_ringbuffer_file(_file: &std::fs::File, _path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn configured_ringbuffer_gid() -> Result<Option<u32>, String> {
+    use std::ffi::CString;
+
+    let Ok(group) = std::env::var(KEVENT_RINGBUFFER_GROUP_ENV) else {
+        return Ok(None);
+    };
+    let group = group.trim();
+    if group.is_empty() {
+        return Ok(None);
+    }
+    let group_c = CString::new(group)
+        .map_err(|_| format!("invalid {} value", KEVENT_RINGBUFFER_GROUP_ENV))?;
+    let entry = unsafe { libc::getgrnam(group_c.as_ptr()) };
+    if entry.is_null() {
+        return Err(format!(
+            "kevent service group '{}' from {} does not exist",
+            group, KEVENT_RINGBUFFER_GROUP_ENV
+        ));
+    }
+    Ok(Some(unsafe { (*entry).gr_gid }))
+}
+
+#[cfg(unix)]
+fn path_to_cstring(path: &Path) -> Result<std::ffi::CString, String> {
+    use std::os::unix::ffi::OsStrExt;
+    std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| format!("path contains NUL: {}", path.display()))
+}
+
+#[cfg(unix)]
+fn ringbuffer_file_context(path: &Path) -> String {
+    use std::os::unix::fs::MetadataExt;
+
+    let process = format!(
+        "process_uid={}, process_gid={}",
+        unsafe { libc::geteuid() },
+        unsafe { libc::getegid() }
+    );
+    match std::fs::metadata(path) {
+        Ok(metadata) => format!(
+            "owner_uid={}, owner_gid={}, mode={:04o}, {}",
+            metadata.uid(),
+            metadata.gid(),
+            metadata.mode() & 0o7777,
+            process
+        ),
+        Err(error) => format!("metadata_unavailable={}, {}", error, process),
+    }
+}
+
+#[cfg(not(unix))]
+fn ringbuffer_file_context(path: &Path) -> String {
+    match std::fs::metadata(path) {
+        Ok(metadata) => format!("readonly={}", metadata.permissions().readonly()),
+        Err(error) => format!("metadata_unavailable={}", error),
+    }
 }
 
 fn initial_read_seq(head_seq: u64, primed_existing_rings: bool) -> u64 {
@@ -874,6 +1051,19 @@ mod tests {
             assert!(!ptr.is_null());
             Box::from_raw(ptr)
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ringbuffer_file_is_group_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _ring_guard = test_support::lock_with_fresh_ring();
+        let ring = SharedKEventRingBuffer::open().unwrap();
+        let path = ringbuffer_path();
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o660);
+        drop(ring);
     }
 
     #[test]

--- a/src/kernel/kevent/src/native.rs
+++ b/src/kernel/kevent/src/native.rs
@@ -105,6 +105,14 @@ impl KEventDaemonBridge for KEventDaemonClient {
     async fn publish_global(&self, event: &Event) -> KEventResult<()> {
         self.publish_global(event).await
     }
+
+    async fn pull_event(
+        &self,
+        reader_id: &str,
+        timeout_ms: Option<u64>,
+    ) -> KEventResult<Option<Event>> {
+        self.pull_event(reader_id, timeout_ms).await
+    }
 }
 
 #[derive(Clone)]
@@ -203,7 +211,10 @@ pub fn map_response_error(code: &str, message: &str) -> KEventError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use buckyos_api::{KEventClient, TcpKEventDaemonBridge};
     use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     #[tokio::test]
     async fn test_local_transport_roundtrip() {
@@ -248,6 +259,52 @@ mod tests {
             .unwrap();
         assert_eq!(event.eventid, "/taskmgr/new/task_001");
         assert_eq!(event.ingress_node.as_deref(), Some("node_a"));
+    }
+
+    #[tokio::test]
+    async fn test_tcp_bridge_full_client_publish_subscribe() {
+        let service = Arc::new(KEventService::new("node_a"));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let service = service.clone();
+                tokio::spawn(async move {
+                    let frame_len = stream.read_u32().await.unwrap() as usize;
+                    let mut frame = vec![0_u8; frame_len];
+                    stream.read_exact(&mut frame).await.unwrap();
+                    let request = decode_daemon_request(&frame).unwrap();
+                    let response = service.handle_protocol_request(request).await;
+                    let payload = encode_daemon_response(&response).unwrap();
+                    stream.write_u32(payload.len() as u32).await.unwrap();
+                    stream.write_all(&payload).await.unwrap();
+                    stream.flush().await.unwrap();
+                });
+            }
+        });
+
+        let subscriber = KEventClient::new_full(
+            "subscriber",
+            Some(Arc::new(TcpKEventDaemonBridge::new(address.to_string()))),
+        );
+        let publisher = KEventClient::new_full(
+            "publisher",
+            Some(Arc::new(TcpKEventDaemonBridge::new(address.to_string()))),
+        );
+        let reader = subscriber
+            .create_event_reader(vec!["/bridge/test".to_string()])
+            .await
+            .unwrap();
+        publisher
+            .pub_event("/bridge/test", json!({"ok": true}))
+            .await
+            .unwrap();
+
+        let event = reader.pull_event(Some(500)).await.unwrap().unwrap();
+        assert_eq!(event.eventid, "/bridge/test");
+        assert_eq!(event.data["ok"], json!(true));
+        server.abort();
     }
 
     #[test]

--- a/src/kernel/kevent/tests/shared_ring_contract.rs
+++ b/src/kernel/kevent/tests/shared_ring_contract.rs
@@ -65,6 +65,37 @@ fn shared_ring_delivers_first_event_from_late_producer() {
 }
 
 #[test]
+fn shared_ring_cross_process_publish_subscribe() {
+    if std::env::var("BUCKYOS_KEVENT_TEST_CHILD").as_deref() == Ok("publisher") {
+        let producer = SharedKEventRingBuffer::open().unwrap();
+        producer.publish_event(&event(42)).unwrap();
+        return;
+    }
+
+    let _guard = RING_ENV_LOCK.lock().unwrap();
+    let path = set_unique_ring_path("cross_process");
+    let consumer = SharedKEventRingBuffer::open().unwrap();
+    consumer.prime_cursors();
+
+    let status = std::process::Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("shared_ring_cross_process_publish_subscribe")
+        .arg("--nocapture")
+        .env(DEFAULT_RINGBUFFER_PATH_ENV, &path)
+        .env("BUCKYOS_KEVENT_TEST_CHILD", "publisher")
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let events = consumer.drain_events::<Event>(8);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].data["seq"], json!(42));
+
+    drop(consumer);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
 fn shared_ring_overrun_drops_oldest_without_corrupting_events() {
     let _guard = RING_ENV_LOCK.lock().unwrap();
     let path = set_unique_ring_path("overrun");

--- a/src/kernel/node_daemon/src/app_loader.rs
+++ b/src/kernel/node_daemon/src/app_loader.rs
@@ -3,7 +3,8 @@ use crate::service_pkg::new_system_package_env;
 use buckyos_api::{
     get_buckyos_api_runtime, get_full_appid, get_session_token_env_key, AppDoc,
     AppServiceInstanceConfig, AppType, LocalAppInstanceConfig, ServiceInstanceState,
-    ServiceSpecConfig, SubPkgDesc, VERIFY_HUB_TOKEN_EXPIRE_TIME,
+    ServiceSpecConfig, SubPkgDesc, KEVENT_DAEMON_ADDR_ENV, KEVENT_SERVICE_NATIVE_PORT,
+    VERIFY_HUB_TOKEN_EXPIRE_TIME,
 };
 use buckyos_kit::{buckyos_get_unix_timestamp, get_buckyos_root_dir};
 use log::{debug, error, info, warn};
@@ -1101,6 +1102,15 @@ impl AppLoader {
             "BUCKYOS_HOST_GATEWAY".to_string(),
             AGENT_RUNTIME_HOST_GATEWAY.to_string(),
         );
+        if role == PackageRole::DockerImage {
+            env_vars.insert(
+                KEVENT_DAEMON_ADDR_ENV.to_string(),
+                format!(
+                    "{}:{}",
+                    AGENT_RUNTIME_HOST_GATEWAY, KEVENT_SERVICE_NATIVE_PORT
+                ),
+            );
+        }
 
         if let Some(media_info) = self.package_media_info(role).await? {
             env_vars.insert(
@@ -1859,6 +1869,13 @@ impl AppLoader {
                 "0".to_string()
             },
         );
+        env_vars.insert(
+            KEVENT_DAEMON_ADDR_ENV.to_string(),
+            format!(
+                "{}:{}",
+                AGENT_RUNTIME_HOST_GATEWAY, KEVENT_SERVICE_NATIVE_PORT
+            ),
+        );
         if let Some(port) = service_port {
             env_vars.insert("BUCKYOS_SERVICE_PORT".to_string(), port.to_string());
             // Legacy name kept for OpenDAN which still reads OPENDAN_SERVICE_PORT.
@@ -2301,6 +2318,11 @@ impl AppLoader {
         docker_run_args.push("-e".to_string());
         docker_run_args.push(format!("BUCKYOS_APP_TYPE={}", app_type_label));
         docker_run_args.push("-e".to_string());
+        docker_run_args.push(format!(
+            "{}={}:{}",
+            KEVENT_DAEMON_ADDR_ENV, AGENT_RUNTIME_HOST_GATEWAY, KEVENT_SERVICE_NATIVE_PORT
+        ));
+        docker_run_args.push("-e".to_string());
         docker_run_args.push(format!("BUCKYOS_OWNER_USER_ID={}", self.owner_user_id));
         docker_run_args.push("-e".to_string());
         docker_run_args.push(format!(
@@ -2382,6 +2404,9 @@ impl AppLoader {
             "BUCKYOS_THIS_DEVICE".to_string(),
             "BUCKYOS_HOST_GATEWAY".to_string(),
         ];
+        if role == PackageRole::DockerImage {
+            keys.push(KEVENT_DAEMON_ADDR_ENV.to_string());
+        }
         if self.media_pkg_id(role).is_some() {
             keys.push("app_media_info".to_string());
         }

--- a/src/kernel/node_daemon/src/test_app_loader.rs
+++ b/src/kernel/node_daemon/src/test_app_loader.rs
@@ -511,6 +511,9 @@ fn agent_control_commands_match_expected_process_flow_on_linux() {
     assert!(start.commands[1]
         .args
         .contains(&"BUCKYOS_APP_TYPE=agent".to_string()));
+    assert!(start.commands[1]
+        .args
+        .contains(&"BUCKYOS_KEVENT_DAEMON_ADDR=host.docker.internal:3183".to_string()));
     assert!(start.commands[1].args.contains(
         &"BUCKYOS_DATA_DIR=/opt/buckyos/data/home/alice/.local/share/buckyos_jarvis".to_string(),
     ));

--- a/src/publish/deb_pkg/buckyos_postinstall
+++ b/src/publish/deb_pkg/buckyos_postinstall
@@ -24,6 +24,9 @@ ensure_mutable_dir "$BUCKYOS_ROOT/local"
 ensure_mutable_dir "$BUCKYOS_ROOT/logs"
 ensure_mutable_dir "$BUCKYOS_ROOT/storage"
 
+getent group buckyos >/dev/null 2>&1 || groupadd --system buckyos
+install -d -o root -g buckyos -m 0770 "$BUCKYOS_ROOT/run/kevent"
+
 cat <<EOF > /etc/systemd/system/buckyos.service
 [Unit]
 Description=buckyos node daemon
@@ -32,6 +35,9 @@ After=network.target
 [Service]
 ExecStart=/opt/buckyos/bin/node-daemon/node_daemon --enable_active
 User=root
+SupplementaryGroups=buckyos
+Environment=BUCKYOS_KEVENT_RINGBUFFER_PATH=/opt/buckyos/run/kevent/ringbuffer_v2.shm
+Environment=BUCKYOS_KEVENT_GROUP=buckyos
 WorkingDirectory=/opt/buckyos/bin
 Restart=always
 

--- a/src/publish/rpm_pkg/buckyos_postinstall
+++ b/src/publish/rpm_pkg/buckyos_postinstall
@@ -24,6 +24,9 @@ ensure_mutable_dir "$BUCKYOS_ROOT/local"
 ensure_mutable_dir "$BUCKYOS_ROOT/logs"
 ensure_mutable_dir "$BUCKYOS_ROOT/storage"
 
+getent group buckyos >/dev/null 2>&1 || groupadd --system buckyos
+install -d -o root -g buckyos -m 0770 "$BUCKYOS_ROOT/run/kevent"
+
 cat <<EOF > /etc/systemd/system/buckyos.service
 [Unit]
 Description=buckyos node daemon
@@ -32,6 +35,9 @@ After=network.target
 [Service]
 ExecStart=/opt/buckyos/bin/node-daemon/node_daemon --enable_active
 User=root
+SupplementaryGroups=buckyos
+Environment=BUCKYOS_KEVENT_RINGBUFFER_PATH=/opt/buckyos/run/kevent/ringbuffer_v2.shm
+Environment=BUCKYOS_KEVENT_GROUP=buckyos
 WorkingDirectory=/opt/buckyos/bin
 Restart=always
 KillMode=process

--- a/src/publish/tests/test_make_local_deb.py
+++ b/src/publish/tests/test_make_local_deb.py
@@ -70,6 +70,12 @@ publish:
             self.assertIn('cp -p "$DEFAULTS_DIR/etc/node_gateway.json" "$BUCKYOS_ROOT/etc/node_gateway.json"', postinst)
             self.assertIn('cp -a "$DEFAULTS_DIR/data/." "$BUCKYOS_ROOT/data/"', postinst)
             self.assertIn("ExecStart=/opt/buckyos/bin/node-daemon/node_daemon --enable_active", postinst)
+            self.assertIn('install -d -o root -g buckyos -m 0770 "$BUCKYOS_ROOT/run/kevent"', postinst)
+            self.assertIn("SupplementaryGroups=buckyos", postinst)
+            self.assertIn(
+                "Environment=BUCKYOS_KEVENT_RINGBUFFER_PATH=/opt/buckyos/run/kevent/ringbuffer_v2.shm",
+                postinst,
+            )
 
     def test_linux_hooks_are_discovered_from_deb_pkg(self) -> None:
         hook = debpkg._discover_linux_hook("buckyos", "preinstall")

--- a/src/publish/tests/test_make_local_rpm.py
+++ b/src/publish/tests/test_make_local_rpm.py
@@ -47,6 +47,12 @@ class MakeLocalRpmTests(unittest.TestCase):
         self.assertIn('cp -p "$DEFAULTS_DIR/etc/node_gateway.json" "$BUCKYOS_ROOT/etc/node_gateway.json"', spec)
         self.assertIn('cp -a "$DEFAULTS_DIR/data/." "$BUCKYOS_ROOT/data/"', spec)
         self.assertIn("systemctl start buckyos.service", spec)
+        self.assertIn('install -d -o root -g buckyos -m 0770 "$BUCKYOS_ROOT/run/kevent"', spec)
+        self.assertIn("SupplementaryGroups=buckyos", spec)
+        self.assertIn(
+            "Environment=BUCKYOS_KEVENT_RINGBUFFER_PATH=/opt/buckyos/run/kevent/ringbuffer_v2.shm",
+            spec,
+        )
         self.assertIn(".buckyos_installer_defaults", spec)
         self.assertIn("%preun", spec)
         self.assertIn("%global __os_install_post %{nil}", spec)

--- a/test/kevent_kmsg/README.md
+++ b/test/kevent_kmsg/README.md
@@ -8,7 +8,7 @@ Subdirectories:
 - `dv`: standard devtest gateway smoke for kmsg and kevent.
 - `task_mgr`: TaskMgr `task_ready` gateway smoke.
 - `restart`: standard devtest restart recovery smoke.
-- `peer_container`: two-node peer delivery harness in Docker containers.
+- `peer_container`: two-node peer delivery in Docker plus a container Full SDK client publishing/subscribing through a host native bridge.
 - `peer_vm`: two-node peer delivery harness in QEMU/KVM VMs.
 - `reports`: local per-run reports and evidence snapshots. This directory is
   ignored by git; the repository keeps only the test plan and current summary

--- a/test/kevent_kmsg/peer_container/harness/src/main.rs
+++ b/test/kevent_kmsg/peer_container/harness/src/main.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use buckyos_api::{Event, KEventDaemonRequest, KEventDaemonResponse, KEventError, KEventResult};
+use buckyos_api::{
+    Event, KEventClient, KEventDaemonRequest, KEventDaemonResponse, KEventError, KEventResult,
+    TcpKEventDaemonBridge,
+};
 use kevent::{
     decode_daemon_request, encode_daemon_response, map_response_error, KEventPeerPublisher,
     KEventService,
@@ -49,10 +52,52 @@ async fn run() -> KEventResult<()> {
     match args.get(1).map(String::as_str) {
         Some("server") => run_server(&args).await,
         Some("client") => run_client(&args).await,
+        Some("sdk-client") => run_sdk_client(&args).await,
         _ => Err(KEventError::InvalidEventId(
             "usage: kevent_peer_harness server|client ...".to_string(),
         )),
     }
+}
+
+async fn run_sdk_client(args: &[String]) -> KEventResult<()> {
+    let daemon = arg_value(args, "--daemon")?;
+    let tag = now_millis();
+    let eventid = format!("/container/host/{tag}");
+    let subscriber = KEventClient::new_full(
+        "container-subscriber",
+        Some(Arc::new(TcpKEventDaemonBridge::new(daemon))),
+    );
+    let publisher = KEventClient::new_full(
+        "container-publisher",
+        Some(Arc::new(TcpKEventDaemonBridge::new(daemon))),
+    );
+    let reader = subscriber
+        .create_event_reader(vec![eventid.clone()])
+        .await?;
+
+    publisher
+        .pub_event(&eventid, json!({"transport": "native-bridge"}))
+        .await?;
+    let event = reader
+        .pull_event(Some(2000))
+        .await?
+        .ok_or_else(|| KEventError::DaemonUnavailable("container reader timed out".to_string()))?;
+    if event.eventid != eventid {
+        return Err(KEventError::Internal(format!(
+            "unexpected eventid: {}",
+            event.eventid
+        )));
+    }
+    println!(
+        "{}",
+        json!({
+            "status": "passed",
+            "eventid": event.eventid,
+            "source_node": event.source_node,
+            "transport": "native-bridge",
+        })
+    );
+    Ok(())
 }
 
 async fn run_server(args: &[String]) -> KEventResult<()> {

--- a/test/kevent_kmsg/peer_container/main.py
+++ b/test/kevent_kmsg/peer_container/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import subprocess
 import sys
 import time
@@ -121,6 +122,74 @@ def run_client(binary: Path) -> dict:
     return json.loads(lines[-1])
 
 
+def run_host_bridge_client(binary: Path) -> dict:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+
+    server = subprocess.Popen(
+        [
+            str(binary),
+            "server",
+            "--node",
+            "host_node",
+            "--listen",
+            f"0.0.0.0:{port}",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if server.poll() is not None:
+                stderr = server.stderr.read() if server.stderr else ""
+                raise RuntimeError(f"host kevent server exited early: {stderr}")
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                    break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            raise RuntimeError("host kevent server did not become ready")
+
+        completed = run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                NETWORK,
+                "--add-host",
+                "host.docker.internal:host-gateway",
+                "-v",
+                f"{binary}:/usr/local/bin/kevent_peer_harness:ro",
+                IMAGE,
+                "/usr/local/bin/kevent_peer_harness",
+                "sdk-client",
+                "--daemon",
+                f"host.docker.internal:{port}",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if completed.stderr:
+            print(completed.stderr, file=sys.stderr, end="")
+        print(completed.stdout, end="")
+        lines = [line for line in completed.stdout.splitlines() if line.strip()]
+        if not lines:
+            raise RuntimeError("host bridge client produced no output")
+        return json.loads(lines[-1])
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server.kill()
+            server.wait(timeout=5)
+
+
 def main() -> int:
     docker_available()
     binary = build_harness()
@@ -136,6 +205,9 @@ def main() -> int:
         result = run_client(binary)
         if result.get("status") != "passed":
             raise RuntimeError(f"unexpected result: {result}")
+        host_bridge_result = run_host_bridge_client(binary)
+        if host_bridge_result.get("status") != "passed":
+            raise RuntimeError(f"unexpected host bridge result: {host_bridge_result}")
         print(json.dumps({"status": "passed", "network": NETWORK, "image": IMAGE}, sort_keys=True))
         return 0
     finally:


### PR DESCRIPTION
## 问题

Linux 上多个服务用户共享 kevent ringbuffer 时，固定文件 `/tmp/buckyos_kevent_ringbuffer_v2.shm` 可能由 node-daemon 先创建。原实现以读写方式打开文件，但创建后没有统一设置 owner、group 和 mode，导致 msg-center、control-panel 等其他服务用户打开失败：

```text
kevent shared ringbuffer is unavailable: open ringbuffer file /tmp/buckyos_kevent_ringbuffer_v2.shm failed: Permission denied (os error 13)
```

随后全局事件无法发布：

```text
DaemonUnavailable("global event requires daemon bridge or shared ringbuffer in full mode")
```

此外，Full 模式客户端只在初始化时打开一次 ringbuffer，失败后不会自动恢复；容器 `/tmp` 又与宿主机隔离，因此仅修改宿主机临时文件权限不能覆盖 OpenDAN/Jarvis 等容器运行环境。

## 解决方案

- **修改了系统目录，待确认**，将默认 ringbuffer 迁移到 `$BUCKYOS_ROOT/run/kevent/ringbuffer_v2.shm`。
- Linux 下统一创建运行目录和共享文件：目录使用 BuckyOS 公共服务组及 `0770`，文件使用 `0660`；支持通过 `BUCKYOS_KEVENT_RINGBUFFER_PATH` 和 `BUCKYOS_KEVENT_GROUP` 配置。
- Debian/RPM 安装脚本创建 `/run/buckyos/kevent` 并设置公共服务组权限。
- KEventClient 增加 shared ringbuffer 自动重连，权限或文件状态恢复后无需重启消费者。
- Full 客户端支持通过 `BUCKYOS_KEVENT_DAEMON_ADDR` 使用 native TCP daemon bridge，并为容器工作负载注入 `host.docker.internal:3183`，不再依赖容器自己的 `/tmp`。
- 补齐 daemon bridge 的 reader 拉取能力，使跨运行环境 publish-subscribe 完整可用。
- 改善 ringbuffer 打开失败日志，输出实际路径、owner、group、mode、uid 和 gid。
- 增加共享 ringbuffer 权限契约、跨进程/服务用户、容器到宿主机 bridge 及重启恢复测试。

## 合并前必须确认：运行目录契约变更

本方案新增 `$BUCKYOS_ROOT/run/kevent`，属于 BuckyOS 运行时目录结构和部署契约变更，不应仅作为内部实现细节合并。请维护者在合并前明确确认以下事项：

- 是否正式将 `$BUCKYOS_ROOT/run` 定义为运行期临时状态目录，并允许 kevent 在其中创建 mmap 文件。
- `$BUCKYOS_ROOT` 通常位于 `/opt/buckyos`，其 `run` 子目录不会像系统 `/run` 一样随重启自动清空；需要确认 ringbuffer 文件在重启、升级、异常退出及格式变化时的清理和重建语义。
- Deb/RPM 安装脚本会创建 `buckyos` 系统组和 `$BUCKYOS_ROOT/run/kevent`，但源码直接启动、开发安装、容器镜像及其他部署方式也必须保证目录和组一致。
- 所有需要 mmap 的宿主机服务用户必须属于 `buckyos` 组；否则路径迁移后仍可能出现权限失败。
- 卸载、重装、切换 `BUCKYOS_ROOT` 以及多实例运行时，需明确目录归属、残留文件和实例间隔离策略。

可选决策包括：

1. 确认当前 `$BUCKYOS_ROOT/run/kevent` 方案，并补齐其生命周期契约；
2. 改用 Linux 标准的 `/run/buckyos/kevent`，由 tmpfiles/systemd 或安装流程管理；
3. 保留原路径，仅修正宿主机权限，同时继续让容器通过 daemon bridge 访问。

Beta 2.2 允许 breaking change，因此这里不要求兼容旧路径，但仍需要先确认新的目录契约是否符合整体路径规划。
## 验证结果

- Linux 实际运行环境不再出现 ringbuffer `Permission denied`。
- `uv run test/run.py -p kevent_kmsg/peer_container` 通过：容器间事件投递以及容器经 native bridge 向宿主机投递均成功。
- `uv run test/run.py -p kevent_kmsg/restart` 通过：daemon 重启后订阅保持，后续事件可正常接收。
- 实际 Jarvis 容器已注入 `BUCKYOS_KEVENT_DAEMON_ADDR=host.docker.internal:3183`。
- 宿主机 3183 listener 和容器到 `host.docker.internal:3183` 的连通性验证通过。
- Jarvis 在核心服务恢复后正常运行。

## 本次排查发现、但与本提交无关的风险

- **3183 对局域网开放**：Windows 局域网主机可以连接宿主机 3183。`0.0.0.0:3183` 的监听逻辑在本提交前已经存在；本提交只让容器使用现有 bridge，因此不是本轮引入的网络暴露。建议后续单独限制监听范围、来源网络或增加认证。
- **msg-center pump 故障期日志热循环**：daemon bridge 与 msg-center 同时不可用时，同一毫秒内会重复输出大量失败日志，可能造成短期 CPU 和日志压力。本提交未修改该 pump，建议另行增加退避。
- **node-daemon 重启期间 Jarvis 被重建**：system-config、msg-center 和 gateway 尚未恢复时，Jarvis 登录失败并退出；node-daemon 随后重新创建容器。这属于既有启动顺序和重试行为，不是 kevent 修改导致。
- **服务实例状态上报 RBAC 告警**：观察到 `services/buckyos_jarvis/instances/ood1` 无写权限，属于独立 RBAC 配置问题。

## 日志附件
[msg_center.491189.sanitized.log](https://github.com/user-attachments/files/30316228/msg_center.491189.sanitized.log)


原始日志 `msg_center.491189.log` 包含完整 session token、refresh token 和 Telegram 标识，不能直接公开。已生成 UTF-8 脱敏附件，保留关键错误及上下文，待通过 GitHub 网页编辑器上传到本 PR 正文。