### PR TITLE
fix(msg-center): 修复 #517 遗留的幂等隔离与入站恢复问题

### DIFF
--- a/doc/message_hub/Message Center Durable Data Schema.md
+++ b/doc/message_hub/Message Center Durable Data Schema.md
@@ -1,0 +1,114 @@
+# MessageCenter Durable Data Schema
+
+## 1. Overview
+
+Service: `msg-center`
+
+MessageCenter persists mailbox projections, delivery state, contacts, groups,
+idempotency results, tunnel recovery cursors, and UI session state in the
+platform-provided RDB instance. Message objects remain content-addressed in
+named store. The corresponding behavior and RPC model are described in
+`doc/message_hub/Message Center.md` and
+`doc/message_hub/Message Tunnel Design.md`.
+
+## 2. Data Classification
+
+### Durable Data
+
+| Data item | Reason |
+|---|---|
+| `mailbox_records`, `msg_refs` | User mailbox truth and object references |
+| `delivery_records` | Delivery queue state and diagnostic history |
+| `msg_idempotency` | Prevents replay after restart |
+| `msg_tunnel_cursors` | External ingress recovery position |
+| Contact and group tables | User and group configuration/state |
+
+### Disposable Data
+
+| Data item | Reason |
+|---|---|
+| `ui_session_states` | Typing, active state, and UI presentation hints may be rebuilt |
+| In-memory message/receipt caches | Named store or authoritative records remain available |
+| kevent notifications | Acceleration signals only |
+
+## 3. Storage Strategy
+
+All structured durable data uses the platform RDB instance and supports both
+SQLite and PostgreSQL DDL. Message bodies and attachments use named store
+objects. No durable state is stored in service-private filesystem paths.
+
+## 4. Schema Definitions
+
+### Table: `msg_idempotency`
+
+| Column | Type | Nullable | Description |
+|---|---|---|---|
+| `scope` | TEXT | No | Operation: `dispatch` or `post_send` |
+| `owner_scope` | TEXT | No | Stable recipient owner for dispatch or message author for post-send |
+| `idempotency_key` | TEXT | No | Caller/platform replay key |
+| `msg_id` | TEXT | Yes | Content-addressed message id |
+| `retention_key` | TEXT | Yes | Stable external conversation or local sender bucket |
+| `state` | TEXT | No | `pending` or `completed` |
+| `result_json` | TEXT | Yes | Serialized RPC result |
+| `created_at_ms` | INTEGER/BIGINT | No | Creation time |
+| `updated_at_ms` | INTEGER/BIGINT | No | Last update time |
+| `expires_at_ms` | INTEGER/BIGINT | Yes | Physical cleanup eligibility time |
+
+Primary key: `(scope, owner_scope, idempotency_key)`.
+
+Indexes:
+
+- `idx_msg_idempotency_expire(expires_at_ms)` supports global expiry cleanup.
+- `idx_msg_idempotency_retention_expire(retention_key, expires_at_ms)` supports conversation-bucket cleanup.
+
+### Table: `msg_tunnel_cursors`
+
+| Column | Type | Nullable | Description |
+|---|---|---|---|
+| `tunnel_key` | TEXT | No | Platform, owner, tunnel account, and tunnel instance identity |
+| `cursor_key` | TEXT | No | Cursor kind, such as `bot_api_update_offset` |
+| `value_json` | TEXT | No | Opaque validated cursor value |
+| `updated_at_ms` | INTEGER/BIGINT | No | Last successful persistence time |
+
+Primary key: `(tunnel_key, cursor_key)`. This table is internal to msg-center;
+the public UI SessionState RPC cannot read or modify it.
+
+### Existing durable tables
+
+`mailbox_records`, `delivery_records`, `msg_refs`, contact tables, and group
+tables retain their schema defined by `MSG_CENTER_RDB_SCHEMA_SQLITE` and
+`MSG_CENTER_RDB_SCHEMA_POSTGRES`. Message objects retain their existing named
+store object schema.
+
+## 5. Schema Version
+
+The shared msg-center RDB instance schema version is `8`, stored in the
+scheduler-provided RDB instance spec. Every DDL or frozen-key semantic change
+increments this version.
+
+## 6. Upgrade Compatibility Strategy
+
+Beta 2.2 is in no-compat mode. Version 7 instances are rebuilt as version 8;
+there is no in-place migration. Durable version 8 fields and key semantics are
+frozen until the next explicit schema version.
+
+## 7. Extensibility Rules
+
+- Frozen: idempotency primary-key meaning, state transitions, cursor primary key,
+  timestamp units, and stored RPC result schema.
+- Extensible: new operation scopes, cursor keys, tables, and additive columns
+  with a schema-version bump.
+- Cursor JSON is opaque to storage but must be validated by its tunnel before use.
+
+## 8. Query Patterns
+
+| Query | Support | Cost |
+|---|---|---|
+| Resolve idempotency result | `msg_idempotency` primary key | Constant lookup |
+| Load/store one tunnel cursor | `msg_tunnel_cursors` primary key | Constant lookup/upsert |
+| Clean one conversation bucket | retention/expiry index | Background maintenance |
+| Clean global expired rows | expiry index, 10,000-row batches | Background maintenance |
+| Enumerate oversized buckets | retention/expiry index scan | Hourly background maintenance |
+
+Idempotency maintenance never runs in `dispatch` or `post_send` request paths.
+The background worker runs immediately at service startup and then hourly.

--- a/doc/message_hub/Message Center.md
+++ b/doc/message_hub/Message Center.md
@@ -413,13 +413,18 @@ MessageCenter 可以建立 `thread.topic → session_id` 的映射（同 topic �
 ### 6.3.1 `msg_idempotency`
 
 `msg_idempotency` 是 `dispatch` / `post_send` 的持久幂等边界。主键是
-`(scope, idempotency_key)`，其中 `scope` 取 `dispatch` 或 `post_send`。
+`(scope, owner_scope, idempotency_key)`，其中 `scope` 取 `dispatch` 或
+`post_send`。`owner_scope` 对 dispatch 使用稳定的接收方 owner（tunnel 入站为
+`contact_mgr_owner`），对 post_send 使用消息 author；不同 owner 可以安全复用
+同一个调用方幂等键。
 每条记录包含：
 
 - `state`：`pending` 或 `completed`。
 - `msg_id`：已确定的内容寻址消息 id。
 - `result_json`：`completed` 记录保存对应 RPC result 的 JSON；`pending` 记录为空。
-- `retention_key`：清理分桶，按外部会话或本地发送者维度控制保留量。
+- `retention_key`：清理分桶。外部入站按 platform + tunnel/bot account +
+  chat/topic 会话分桶，不得使用单条消息的发送者账号；本地出站按发送者和 topic
+  分桶。
 - `expires_at_ms`：清理候选时间。
 
 服务在同一个本地 RDB 事务内完成：占用幂等键为 `pending`，写入全部
@@ -437,11 +442,11 @@ mailbox / delivery 副作用，再把同一行更新为 `completed` 并写入
 行；未过期记录不得删除，其它 bucket 不受分桶清理影响。全表超过 100,000 行
 时启动全局清理，按相同顺序删除任意 bucket 的过期记录，逐轮降到 80,000 行。
 全局清理每批最多删除 10,000 行，避免服务启动或长期停机后在一个事务中清空
-大量记录。服务每小时枚举并清理一次超限 bucket，再启动一批全局清理；若该批
-删满 10,000 行且仍高于目标水位，后续消息写入会继续执行全局清理批次，直到
-降到目标水位或某批没有删满。30 天内的记录不受任一容量水位影响。
+大量记录。独立后台任务在服务启动时和之后每小时枚举并清理一次超限 bucket，
+再执行全局清理；全局清理每批让出执行权，直到降到目标水位或某批没有删满。
+清理不进入 dispatch/post_send 请求路径。30 天内的记录不受任一容量水位影响。
 
-`result_json` 使用 schema version 7 下 RPC result 的 serde JSON 表示，不再
+`result_json` 使用 schema version 8 下 RPC result 的 serde JSON 表示，不再
 额外嵌套 envelope：
 
 - `scope=dispatch`：对象字段为 `ok: bool`、`msg_id: ObjId string`，以及可选的
@@ -453,21 +458,21 @@ mailbox / delivery 副作用，再把同一行更新为 `completed` 并写入
   `target_did`、`transport`；`transport` 为 `{"kind":"native"}`，或
   `{"kind":"tunnel","platform":string,"tunnel_instance_id":string}`。
 
-`scope`、主键语义、`state` 状态机及上述结果字段在 version 7 内冻结；未来增加
+`scope`、`owner_scope`、主键语义、`state` 状态机及上述结果字段在 version 8 内冻结；未来增加
 或改变结果字段必须提升 MessageCenter RDB schema version。当前共享 schema
-version 为 7，存放在 scheduler 下发的 msg-center RDB instance spec 中。
-beta2.2 尚处于 breaking-change 阶段，version 5/6 到 version 7 采用 no-compat
+version 为 8，存放在 scheduler 下发的 msg-center RDB instance spec 中。
+beta2.2 尚处于 breaking-change 阶段，version 7 到 version 8 采用 no-compat
 策略：旧实例数据必须重建，不提供表内迁移。
 
 主要查询及索引：
 
-- `(scope, idempotency_key)` 精确命中由主键支持。
+- `(scope, owner_scope, idempotency_key)` 精确命中由主键支持。
 - 超限 bucket 枚举和 bucket 行数统计由
   `idx_msg_idempotency_retention_expire(retention_key, expires_at_ms)` 支持。
 - bucket 内按过期时间选择删除候选由同一索引支持；每小时的超限 bucket 枚举
   会扫描该索引，是受 sweep 间隔控制的维护成本，不进入每次读取路径。
 - 全局清理的过期候选由 `idx_msg_idempotency_expire(expires_at_ms)` 支持，并受
-  全局水位和单批 10,000 行上限约束；连续批次由后续消息写入驱动。
+  全局水位和单批 10,000 行上限约束；连续批次由后台清理任务驱动。
 
 ### 6.4 崩溃恢复
 

--- a/doc/message_hub/Message Tunnel Design.md
+++ b/doc/message_hub/Message Tunnel Design.md
@@ -257,15 +257,17 @@ delivery_id = hash(msg_id + target_did + executor_did)      # executor_did 即 t
 
 要求：同一平台事件重复上报得到同一 key；key 不含重试次数/批次/本地时间；持久化存储（带 TTL/容量控制），不能只放内存。
 
-`MessageCenter` 以 `msg_idempotency(scope, idempotency_key)` 保存入站和
+`MessageCenter` 以 `msg_idempotency(scope, owner_scope, idempotency_key)` 保存入站和
 `post_send` 幂等结果。记录先在事务内占用为 `pending`，全部 mailbox /
 delivery 副作用写入成功后再更新为 `completed` 和结果 JSON。TTL 只作为物理
 清理候选依据，不作为命中依据；只要 DB 记录仍在，就必须命中。清理先按
-`retention_key` 分桶控制热点：同一个外部会话或本地发送者 bucket 超过 3,000
+`retention_key` 分桶控制热点：外部会话必须使用稳定的 platform + tunnel/bot
+account + chat/topic 标识，不能按消息发送者拆桶；本地出站按发送者和 topic
+分桶。同一个外部会话或本地发送者 bucket 超过 3,000
 行后，只删除该 bucket 内已过期记录并尽量降到 2,000 行。另有全表
 100,000 → 80,000 的容量水位，用于清理大量低基数 bucket 中的过期记录；全局
-清理单批最多删除 10,000 行，删满且仍高于目标水位时由后续消息写入
-继续触发批次。两层清理都不得删除 30 天内的记录。
+清理单批最多删除 10,000 行。启动时及每小时运行的后台任务继续执行批次，
+清理不进入消息请求路径。两层清理都不得删除 30 天内的记录。
 
 **平台层幂等**：平台支持 client message id 时带上 `delivery_id`；发送超时后状态未知时，回报 retryable failure 并标记 duplicate risk，重试前尽量用外部 id 查询确认。
 
@@ -289,7 +291,7 @@ remote read           远端已读（平台 read receipt，若有）            
 ### 6.5 顺序与漏消息恢复
 
 - 顺序：只承诺同一外部会话内尽量按平台顺序提交；严格因果用 `thread.reply_to` / `correlation_id` / `ext_ids`。
-- 入站恢复：平台 offset/cursor 持久化，处理成功后推进；重启后按 cursor/时间窗补拉。offset/cursor 读取失败或数据非法时必须暂停 polling 并重试，不能退回 0 开始拉取。
+- 入站恢复：平台 offset/cursor 存入 msg-center 专用的 durable tunnel cursor 表，不能复用对外可写的 UI SessionState；处理成功后推进，重启后按 cursor/时间窗补拉。offset/cursor 读取失败或数据非法时必须暂停 polling 并重试，不能退回 0 开始拉取。
 - 出站恢复：`DELIVERY_QUEUE` 扫描（`WAIT` 到期 + `SENDING` 租约超时）。
 - webhook/stream/kevent 只能作为加速信号，不能作为唯一真相。
 

--- a/doc/message_hub/Message Tunnel Minimal Spec.md
+++ b/doc/message_hub/Message Tunnel Minimal Spec.md
@@ -140,9 +140,9 @@ WAIT → SENDING → SENT
 
 - 出站幂等键：`msg_id + target_did + executor_did`；重复提交/重放收敛到同一 `DeliveryRecord`。
 - 入站幂等键：`{platform}:{tunnel_account_id}:{chat_id}:{external_message_id}`；无稳定 id 时用 `{event_timestamp}:{payload_hash}` 组合；必须持久化（带 TTL），不能只放内存。
-- 持久幂等记录使用 `pending` / `completed` 状态；业务副作用和 completed 结果必须在同一个本地 RDB 事务内提交。TTL 只作为物理清理候选依据，不作为命中依据。清理采用两层容量水位：单个 `retention_key` bucket 超过 3,000 行后删除该 bucket 的过期记录并尽量降到 2,000 行；全表超过 100,000 行后分批删除所有 bucket 的过期记录并逐轮降到 80,000 行，单批最多删除 10,000 行，删满后由后续消息写入继续触发。30 天内的记录不得删除。
+- 持久幂等记录使用 `(scope, owner_scope, idempotency_key)` 主键和 `pending` / `completed` 状态；业务副作用和 completed 结果必须在同一个本地 RDB 事务内提交。TTL 只作为物理清理候选依据，不作为命中依据。清理采用两层容量水位：外部入站以 platform + tunnel/bot account + chat/topic 为 `retention_key`，不能按消息发送者拆桶；单 bucket 超过 3,000 行后删除过期记录并尽量降到 2,000 行；全表超过 100,000 行后分批删除并逐轮降到 80,000 行，单批最多删除 10,000 行。清理由启动时及每小时运行的后台任务执行，不进入消息请求路径。30 天内的记录不得删除。
 - 投递语义四级：submission accepted → transport accepted（`SENT`）→ remote delivered → remote read；`SENT` 只承诺 transport accepted。
-- 恢复：入站靠平台 offset/cursor 持久化补拉；offset/cursor 读取失败或数据非法时暂停 polling 并重试，不能退回 0；出站靠 `DELIVERY_QUEUE` 扫描（`WAIT` 到期 + `SENDING` 租约超时 sweep）；webhook/stream/kevent 只是加速信号。
+- 恢复：入站靠 msg-center 专用 durable tunnel cursor 持久化平台 offset/cursor，不能复用 UI SessionState；读取失败或数据非法时暂停 polling 并重试，不能退回 0；出站靠 `DELIVERY_QUEUE` 扫描（`WAIT` 到期 + `SENDING` 租约超时 sweep）；webhook/stream/kevent 只是加速信号。
 - 顺序：同一外部会话内尽量按平台顺序提交；严格因果用 `thread.reply_to`/`correlation_id`/`ext_ids`。
 
 ## 7. 流式 AI 消息

--- a/src/frame/msg_center/src/main.rs
+++ b/src/frame/msg_center/src/main.rs
@@ -956,6 +956,7 @@ pub async fn start_msg_center_service() -> Result<()> {
     let center = MessageCenter::open_from_service_spec()
         .await
         .map_err(|err| anyhow::anyhow!("create message center failed: {:?}", err))?;
+    center.start_idempotency_sweep();
 
     let executor_mgr = Arc::new(DeliveryExecutorMgr::new());
     register_message_hub(&center, executor_mgr.as_ref()).await?;

--- a/src/frame/msg_center/src/msg_box_db.rs
+++ b/src/frame/msg_center/src/msg_box_db.rs
@@ -345,6 +345,7 @@ ON CONFLICT(delivery_id) DO NOTHING
         &self,
         tx: &mut Transaction<'_, Any>,
         scope: &str,
+        owner_scope: &str,
         idempotency_key: &str,
         retention_key: Option<&str>,
         now_ms: u64,
@@ -352,17 +353,18 @@ ON CONFLICT(delivery_id) DO NOTHING
     ) -> std::result::Result<Option<T>, RPCErrors> {
         let sql = self.render_sql(
             "SELECT state, result_json, expires_at_ms FROM msg_idempotency
-             WHERE scope = ? AND idempotency_key = ?",
+             WHERE scope = ? AND owner_scope = ? AND idempotency_key = ?",
         );
         let row = sqlx::query(&sql)
             .bind(scope.to_string())
+            .bind(owner_scope.to_string())
             .bind(idempotency_key.to_string())
             .fetch_optional(&mut **tx)
             .await
             .map_err(|error| {
                 RPCErrors::ReasonError(format!(
-                    "failed to query msg idempotency key {}:{}: {}",
-                    scope, idempotency_key, error
+                    "failed to query msg idempotency key {}:{}:{}: {}",
+                    scope, owner_scope, idempotency_key, error
                 ))
             })?;
 
@@ -374,34 +376,35 @@ ON CONFLICT(delivery_id) DO NOTHING
             if state == "completed" {
                 let Some(result_json) = result_json else {
                     return Err(RPCErrors::ReasonError(format!(
-                        "completed msg idempotency key {}:{} has no result",
-                        scope, idempotency_key
+                        "completed msg idempotency key {}:{}:{} has no result",
+                        scope, owner_scope, idempotency_key
                     )));
                 };
                 let result = serde_json::from_str(&result_json).map_err(|error| {
                     RPCErrors::ReasonError(format!(
-                        "failed to decode msg idempotency result {}:{}: {}",
-                        scope, idempotency_key, error
+                        "failed to decode msg idempotency result {}:{}:{}: {}",
+                        scope, owner_scope, idempotency_key, error
                     ))
                 })?;
                 return Ok(Some(result));
             } else {
                 return Err(RPCErrors::ReasonError(format!(
-                    "msg idempotency key {}:{} is pending",
-                    scope, idempotency_key
+                    "msg idempotency key {}:{}:{} is pending",
+                    scope, owner_scope, idempotency_key
                 )));
             }
         }
 
         let sql = self.render_sql(
             "INSERT INTO msg_idempotency(
-                scope, idempotency_key, msg_id, retention_key, state, result_json,
+                scope, owner_scope, idempotency_key, msg_id, retention_key, state, result_json,
                 created_at_ms, updated_at_ms, expires_at_ms
-             ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(scope, idempotency_key) DO NOTHING",
+             ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(scope, owner_scope, idempotency_key) DO NOTHING",
         );
         let result = sqlx::query(&sql)
             .bind(scope.to_string())
+            .bind(owner_scope.to_string())
             .bind(idempotency_key.to_string())
             .bind(Option::<String>::None)
             .bind(retention_key.map(|value| value.to_string()))
@@ -414,14 +417,14 @@ ON CONFLICT(delivery_id) DO NOTHING
             .await
             .map_err(|error| {
                 RPCErrors::ReasonError(format!(
-                    "failed to reserve msg idempotency key {}:{}: {}",
-                    scope, idempotency_key, error
+                    "failed to reserve msg idempotency key {}:{}:{}: {}",
+                    scope, owner_scope, idempotency_key, error
                 ))
             })?;
         if result.rows_affected() == 0 {
             return Err(RPCErrors::ReasonError(format!(
-                "msg idempotency key {}:{} is already reserved",
-                scope, idempotency_key
+                "msg idempotency key {}:{}:{} is already reserved",
+                scope, owner_scope, idempotency_key
             )));
         }
         Ok(None)
@@ -431,6 +434,7 @@ ON CONFLICT(delivery_id) DO NOTHING
         &self,
         tx: &mut Transaction<'_, Any>,
         scope: &str,
+        owner_scope: &str,
         idempotency_key: &str,
         msg_id: Option<&ObjId>,
         retention_key: Option<&str>,
@@ -440,15 +444,15 @@ ON CONFLICT(delivery_id) DO NOTHING
     ) -> std::result::Result<(), RPCErrors> {
         let result_json = serde_json::to_string(result).map_err(|error| {
             RPCErrors::ReasonError(format!(
-                "failed to encode msg idempotency result {}:{}: {}",
-                scope, idempotency_key, error
+                "failed to encode msg idempotency result {}:{}:{}: {}",
+                scope, owner_scope, idempotency_key, error
             ))
         })?;
         let sql = self.render_sql(
             "UPDATE msg_idempotency
              SET msg_id = ?, retention_key = ?, state = 'completed', result_json = ?,
                  updated_at_ms = ?, expires_at_ms = ?
-             WHERE scope = ? AND idempotency_key = ? AND state = 'pending'",
+             WHERE scope = ? AND owner_scope = ? AND idempotency_key = ? AND state = 'pending'",
         );
         let updated = sqlx::query(&sql)
             .bind(msg_id.map(|id| id.to_string()))
@@ -457,19 +461,20 @@ ON CONFLICT(delivery_id) DO NOTHING
             .bind(to_sql_i64(now_ms))
             .bind(expires_at_ms.map(to_sql_i64))
             .bind(scope.to_string())
+            .bind(owner_scope.to_string())
             .bind(idempotency_key.to_string())
             .execute(&mut **tx)
             .await
             .map_err(|error| {
                 RPCErrors::ReasonError(format!(
-                    "failed to complete msg idempotency key {}:{}: {}",
-                    scope, idempotency_key, error
+                    "failed to complete msg idempotency key {}:{}:{}: {}",
+                    scope, owner_scope, idempotency_key, error
                 ))
             })?;
         if updated.rows_affected() == 0 {
             return Err(RPCErrors::ReasonError(format!(
-                "msg idempotency key {}:{} was not pending",
-                scope, idempotency_key
+                "msg idempotency key {}:{}:{} was not pending",
+                scope, owner_scope, idempotency_key
             )));
         }
         Ok(())
@@ -994,24 +999,26 @@ LIMIT 1
     pub async fn get_idempotency_result<T: DeserializeOwned>(
         &self,
         scope: &str,
+        owner_scope: &str,
         idempotency_key: &str,
         _now_ms: u64,
     ) -> std::result::Result<Option<IdempotencyStoredResult<T>>, RPCErrors> {
         let sql = self.render_sql(
             "SELECT result_json, expires_at_ms FROM msg_idempotency
-             WHERE scope = ? AND idempotency_key = ?
+             WHERE scope = ? AND owner_scope = ? AND idempotency_key = ?
                AND state = 'completed'
                AND result_json IS NOT NULL",
         );
         let row = sqlx::query(&sql)
             .bind(scope.to_string())
+            .bind(owner_scope.to_string())
             .bind(idempotency_key.to_string())
             .fetch_optional(self.pool())
             .await
             .map_err(|error| {
                 RPCErrors::ReasonError(format!(
-                    "failed to query msg idempotency key {}:{}: {}",
-                    scope, idempotency_key, error
+                    "failed to query msg idempotency key {}:{}:{}: {}",
+                    scope, owner_scope, idempotency_key, error
                 ))
             })?;
         let Some(row) = row else {
@@ -1022,8 +1029,8 @@ LIMIT 1
             .map_err(|e| decode_err("result_json", &e))?;
         let result = serde_json::from_str(&result_json).map_err(|error| {
             RPCErrors::ReasonError(format!(
-                "failed to decode msg idempotency result {}:{}: {}",
-                scope, idempotency_key, error
+                "failed to decode msg idempotency result {}:{}:{}: {}",
+                scope, owner_scope, idempotency_key, error
             ))
         })?;
         Ok(Some(IdempotencyStoredResult { result }))
@@ -1033,6 +1040,7 @@ LIMIT 1
     pub async fn upsert_idempotency_result<T: Serialize>(
         &self,
         scope: &str,
+        owner_scope: &str,
         idempotency_key: &str,
         msg_id: Option<&ObjId>,
         retention_key: Option<&str>,
@@ -1042,16 +1050,16 @@ LIMIT 1
     ) -> std::result::Result<(), RPCErrors> {
         let result_json = serde_json::to_string(result).map_err(|error| {
             RPCErrors::ReasonError(format!(
-                "failed to encode msg idempotency result {}:{}: {}",
-                scope, idempotency_key, error
+                "failed to encode msg idempotency result {}:{}:{}: {}",
+                scope, owner_scope, idempotency_key, error
             ))
         })?;
         let sql = self.render_sql(
             "INSERT INTO msg_idempotency(
-                scope, idempotency_key, msg_id, retention_key, state, result_json,
+                scope, owner_scope, idempotency_key, msg_id, retention_key, state, result_json,
                 created_at_ms, updated_at_ms, expires_at_ms
-             ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(scope, idempotency_key) DO UPDATE SET
+             ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(scope, owner_scope, idempotency_key) DO UPDATE SET
                 msg_id = excluded.msg_id,
                 retention_key = excluded.retention_key,
                 state = excluded.state,
@@ -1061,6 +1069,7 @@ LIMIT 1
         );
         sqlx::query(&sql)
             .bind(scope.to_string())
+            .bind(owner_scope.to_string())
             .bind(idempotency_key.to_string())
             .bind(msg_id.map(|id| id.to_string()))
             .bind(retention_key.map(|value| value.to_string()))
@@ -1073,16 +1082,17 @@ LIMIT 1
             .await
             .map_err(|error| {
                 RPCErrors::ReasonError(format!(
-                    "failed to upsert msg idempotency key {}:{}: {}",
-                    scope, idempotency_key, error
+                    "failed to upsert msg idempotency key {}:{}:{}: {}",
+                    scope, owner_scope, idempotency_key, error
                 ))
-        })?;
+            })?;
         Ok(())
     }
 
     pub async fn commit_dispatch_records<T>(
         &self,
         scope: &str,
+        owner_scope: &str,
         idempotency_key: Option<&str>,
         retention_key: Option<&str>,
         msg_id: &ObjId,
@@ -1096,13 +1106,17 @@ LIMIT 1
         T: Serialize + DeserializeOwned + Clone,
     {
         let mut tx = self.pool().begin().await.map_err(|error| {
-            RPCErrors::ReasonError(format!("begin msg-center dispatch transaction failed: {}", error))
+            RPCErrors::ReasonError(format!(
+                "begin msg-center dispatch transaction failed: {}",
+                error
+            ))
         })?;
         if let Some(key) = idempotency_key {
             if let Some(cached) = self
                 .prepare_idempotency_tx::<T>(
                     &mut tx,
                     scope,
+                    owner_scope,
                     key,
                     retention_key,
                     now_ms,
@@ -1127,6 +1141,7 @@ LIMIT 1
             self.complete_idempotency_tx(
                 &mut tx,
                 scope,
+                owner_scope,
                 key,
                 Some(msg_id),
                 retention_key,
@@ -1148,6 +1163,7 @@ LIMIT 1
     pub async fn commit_post_send_records<T>(
         &self,
         scope: &str,
+        owner_scope: &str,
         idempotency_key: Option<&str>,
         retention_key: Option<&str>,
         msg_id: &ObjId,
@@ -1162,13 +1178,17 @@ LIMIT 1
         T: Serialize + DeserializeOwned + Clone,
     {
         let mut tx = self.pool().begin().await.map_err(|error| {
-            RPCErrors::ReasonError(format!("begin msg-center post_send transaction failed: {}", error))
+            RPCErrors::ReasonError(format!(
+                "begin msg-center post_send transaction failed: {}",
+                error
+            ))
         })?;
         if let Some(key) = idempotency_key {
             if let Some(cached) = self
                 .prepare_idempotency_tx::<T>(
                     &mut tx,
                     scope,
+                    owner_scope,
                     key,
                     retention_key,
                     now_ms,
@@ -1196,6 +1216,7 @@ LIMIT 1
             self.complete_idempotency_tx(
                 &mut tx,
                 scope,
+                owner_scope,
                 key,
                 Some(msg_id),
                 retention_key,
@@ -1224,8 +1245,9 @@ LIMIT 1
         if max_rows <= target_rows {
             return Ok(0);
         }
-        let count_sql = self
-            .render_sql("SELECT COUNT(*) AS row_count FROM msg_idempotency WHERE retention_key = ?");
+        let count_sql = self.render_sql(
+            "SELECT COUNT(*) AS row_count FROM msg_idempotency WHERE retention_key = ?",
+        );
         let row = sqlx::query(&count_sql)
             .bind(retention_key.to_string())
             .fetch_one(self.pool())
@@ -1416,6 +1438,78 @@ LIMIT 1
                 ))
             })?;
         Ok(row.is_some())
+    }
+
+    pub async fn upsert_tunnel_cursor(
+        &self,
+        tunnel_key: &str,
+        cursor_key: &str,
+        value: &Value,
+        updated_at_ms: u64,
+    ) -> std::result::Result<(), RPCErrors> {
+        let value_json = serde_json::to_string(value).map_err(|error| {
+            RPCErrors::ReasonError(format!(
+                "failed to encode tunnel cursor {}:{}: {}",
+                tunnel_key, cursor_key, error
+            ))
+        })?;
+        let sql = self.render_sql(
+            "INSERT INTO msg_tunnel_cursors(tunnel_key, cursor_key, value_json, updated_at_ms)
+             VALUES(?, ?, ?, ?)
+             ON CONFLICT(tunnel_key, cursor_key) DO UPDATE SET
+                value_json = excluded.value_json,
+                updated_at_ms = excluded.updated_at_ms",
+        );
+        sqlx::query(&sql)
+            .bind(tunnel_key.to_string())
+            .bind(cursor_key.to_string())
+            .bind(value_json)
+            .bind(to_sql_i64(updated_at_ms))
+            .execute(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to upsert tunnel cursor {}:{}: {}",
+                    tunnel_key, cursor_key, error
+                ))
+            })?;
+        Ok(())
+    }
+
+    pub async fn get_tunnel_cursor(
+        &self,
+        tunnel_key: &str,
+        cursor_key: &str,
+    ) -> std::result::Result<Option<Value>, RPCErrors> {
+        let sql = self.render_sql(
+            "SELECT value_json FROM msg_tunnel_cursors
+             WHERE tunnel_key = ? AND cursor_key = ?",
+        );
+        let row = sqlx::query(&sql)
+            .bind(tunnel_key.to_string())
+            .bind(cursor_key.to_string())
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to query tunnel cursor {}:{}: {}",
+                    tunnel_key, cursor_key, error
+                ))
+            })?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let value_json: String = row
+            .try_get("value_json")
+            .map_err(|error| decode_err("value_json", &error))?;
+        serde_json::from_str(&value_json)
+            .map(Some)
+            .map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "failed to decode tunnel cursor {}:{}: {}",
+                    tunnel_key, cursor_key, error
+                ))
+            })
     }
 
     pub async fn upsert_ui_session_state(
@@ -2147,6 +2241,7 @@ mod tests {
         });
         mgr.upsert_idempotency_result(
             "dispatch",
+            "owner-a",
             "idem-expiring",
             None,
             Some("bucket-a"),
@@ -2158,12 +2253,12 @@ mod tests {
         .unwrap();
 
         let hit: Option<IdempotencyStoredResult<Value>> = mgr
-            .get_idempotency_result("dispatch", "idem-expiring", 150)
+            .get_idempotency_result("dispatch", "owner-a", "idem-expiring", 150)
             .await
             .unwrap();
         assert!(hit.is_some());
         let expired: Option<IdempotencyStoredResult<Value>> = mgr
-            .get_idempotency_result("dispatch", "idem-expiring", 201)
+            .get_idempotency_result("dispatch", "owner-a", "idem-expiring", 201)
             .await
             .unwrap();
         assert!(expired.is_some());
@@ -2176,6 +2271,7 @@ mod tests {
 
         mgr.upsert_idempotency_result(
             "dispatch",
+            "owner-a",
             "idem-fresh",
             None,
             Some("bucket-a"),
@@ -2187,6 +2283,7 @@ mod tests {
         .unwrap();
         mgr.upsert_idempotency_result(
             "dispatch",
+            "owner-a",
             "idem-other-bucket-expiring",
             None,
             Some("bucket-b"),
@@ -2202,12 +2299,12 @@ mod tests {
             .unwrap();
         assert_eq!(deleted, 1);
         let fresh: Option<IdempotencyStoredResult<Value>> = mgr
-            .get_idempotency_result("dispatch", "idem-fresh", 201)
+            .get_idempotency_result("dispatch", "owner-a", "idem-fresh", 201)
             .await
             .unwrap();
         assert!(fresh.is_some());
         let other_bucket: Option<IdempotencyStoredResult<Value>> = mgr
-            .get_idempotency_result("dispatch", "idem-other-bucket-expiring", 201)
+            .get_idempotency_result("dispatch", "owner-a", "idem-other-bucket-expiring", 201)
             .await
             .unwrap();
         assert!(other_bucket.is_some());
@@ -2221,6 +2318,7 @@ mod tests {
             for suffix in 0..2 {
                 mgr.upsert_idempotency_result(
                     "dispatch",
+                    "owner-a",
                     &format!("{bucket}-{suffix}"),
                     None,
                     Some(bucket),
@@ -2234,6 +2332,7 @@ mod tests {
         }
         mgr.upsert_idempotency_result(
             "dispatch",
+            "owner-a",
             "bucket-c-0",
             None,
             Some("bucket-c"),
@@ -2255,6 +2354,7 @@ mod tests {
                 let result: Option<IdempotencyStoredResult<Value>> = mgr
                     .get_idempotency_result(
                         "dispatch",
+                        "owner-a",
                         &format!("{bucket}-{suffix}"),
                         201,
                     )
@@ -2264,7 +2364,7 @@ mod tests {
             }
         }
         let under_capacity: Option<IdempotencyStoredResult<Value>> = mgr
-            .get_idempotency_result("dispatch", "bucket-c-0", 201)
+            .get_idempotency_result("dispatch", "owner-a", "bucket-c-0", 201)
             .await
             .unwrap();
         assert!(under_capacity.is_some());
@@ -2277,6 +2377,7 @@ mod tests {
         for suffix in 0..4 {
             mgr.upsert_idempotency_result(
                 "dispatch",
+                "owner-a",
                 &format!("expired-{suffix}"),
                 None,
                 Some(&format!("bucket-{suffix}")),
@@ -2290,6 +2391,7 @@ mod tests {
         for suffix in 0..2 {
             mgr.upsert_idempotency_result(
                 "dispatch",
+                "owner-a",
                 &format!("fresh-{suffix}"),
                 None,
                 Some(&format!("fresh-bucket-{suffix}")),
@@ -2304,13 +2406,7 @@ mod tests {
         let mut continue_to_target = false;
         for expected_remaining in [5, 4, 3, 2] {
             let (deleted, remaining) = mgr
-                .sweep_expired_idempotency_global_by_capacity(
-                    201,
-                    4,
-                    2,
-                    1,
-                    continue_to_target,
-                )
+                .sweep_expired_idempotency_global_by_capacity(201, 4, 2, 1, continue_to_target)
                 .await
                 .unwrap();
             assert_eq!(deleted, 1);
@@ -2325,14 +2421,14 @@ mod tests {
         assert_eq!((deleted, remaining), (0, 2));
         for suffix in 0..4 {
             let result: Option<IdempotencyStoredResult<Value>> = mgr
-                .get_idempotency_result("dispatch", &format!("expired-{suffix}"), 201)
+                .get_idempotency_result("dispatch", "owner-a", &format!("expired-{suffix}"), 201)
                 .await
                 .unwrap();
             assert!(result.is_none());
         }
         for suffix in 0..2 {
             let result: Option<IdempotencyStoredResult<Value>> = mgr
-                .get_idempotency_result("dispatch", &format!("fresh-{suffix}"), 201)
+                .get_idempotency_result("dispatch", "owner-a", &format!("fresh-{suffix}"), 201)
                 .await
                 .unwrap();
             assert!(result.is_some());

--- a/src/frame/msg_center/src/msg_center.rs
+++ b/src/frame/msg_center/src/msg_center.rs
@@ -57,8 +57,6 @@ const IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS: u64 = 10_000;
 struct MessageCenterState {
     messages: HashMap<String, MsgObject>,
     receipts: HashMap<String, MsgReceiptObj>,
-    last_idempotency_sweep_ms: u64,
-    idempotency_global_sweep_active: bool,
 }
 
 /// Registry entry for a registered message tunnel: maps the stable
@@ -254,93 +252,77 @@ impl MessageCenter {
 
     async fn load_dispatch_idempotency(
         &self,
+        owner_scope: &str,
         key: &str,
     ) -> std::result::Result<Option<DispatchResult>, RPCErrors> {
         let now_ms = Self::now_ms();
         let stored: Option<IdempotencyStoredResult<DispatchResult>> = self
             .msg_box_db
-            .get_idempotency_result(IDEMPOTENCY_SCOPE_DISPATCH, key, now_ms)
+            .get_idempotency_result(IDEMPOTENCY_SCOPE_DISPATCH, owner_scope, key, now_ms)
             .await?;
         Ok(stored.map(|stored| stored.result))
     }
 
     async fn load_post_send_idempotency(
         &self,
+        owner_scope: &str,
         key: &str,
     ) -> std::result::Result<Option<PostSendResult>, RPCErrors> {
         let now_ms = Self::now_ms();
         let stored: Option<IdempotencyStoredResult<PostSendResult>> = self
             .msg_box_db
-            .get_idempotency_result(IDEMPOTENCY_SCOPE_POST_SEND, key, now_ms)
+            .get_idempotency_result(IDEMPOTENCY_SCOPE_POST_SEND, owner_scope, key, now_ms)
             .await?;
         Ok(stored.map(|stored| stored.result))
     }
 
-    async fn maybe_sweep_expired_idempotency(&self) {
+    pub async fn sweep_expired_idempotency(&self) {
         let now_ms = Self::now_ms();
-        let sweep_plan = self
-            .with_state_write(|state| {
-                let periodic_sweep_due = now_ms.saturating_sub(state.last_idempotency_sweep_ms)
-                    >= IDEMPOTENCY_SWEEP_INTERVAL_MS;
-                if !periodic_sweep_due && !state.idempotency_global_sweep_active {
-                    return Ok(None);
-                }
-                if periodic_sweep_due {
-                    state.last_idempotency_sweep_ms = now_ms;
-                }
-                Ok(Some((
-                    periodic_sweep_due,
-                    state.idempotency_global_sweep_active,
-                )))
-            })
-            .unwrap_or(None);
-        let Some((periodic_sweep_due, global_sweep_active)) = sweep_plan else {
-            return;
-        };
-        let bucket_deleted = if periodic_sweep_due {
-            match self
-                .msg_box_db
-                .sweep_expired_idempotency_buckets_by_capacity(
-                    now_ms,
-                    IDEMPOTENCY_BUCKET_MAX_ROWS,
-                    IDEMPOTENCY_BUCKET_TARGET_ROWS,
-                )
-                .await
-            {
-                Ok(deleted) => deleted,
-                Err(error) => {
-                    warn!("msg_center idempotency bucket sweep failed: {}", error);
-                    0
-                }
-            }
-        } else {
-            0
-        };
-        let global_deleted = match self
+        let bucket_deleted = match self
             .msg_box_db
-            .sweep_expired_idempotency_global_by_capacity(
+            .sweep_expired_idempotency_buckets_by_capacity(
                 now_ms,
-                IDEMPOTENCY_GLOBAL_MAX_ROWS,
-                IDEMPOTENCY_GLOBAL_TARGET_ROWS,
-                IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS,
-                global_sweep_active,
+                IDEMPOTENCY_BUCKET_MAX_ROWS,
+                IDEMPOTENCY_BUCKET_TARGET_ROWS,
             )
             .await
         {
-            Ok((deleted, remaining_rows)) => {
-                let continue_sweep = remaining_rows > IDEMPOTENCY_GLOBAL_TARGET_ROWS
-                    && deleted >= IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS;
-                let _ = self.with_state_write(|state| {
-                    state.idempotency_global_sweep_active = continue_sweep;
-                    Ok(())
-                });
-                deleted
-            }
+            Ok(deleted) => deleted,
             Err(error) => {
-                warn!("msg_center idempotency global sweep failed: {}", error);
+                warn!("msg_center idempotency bucket sweep failed: {}", error);
                 0
             }
         };
+        let mut global_deleted = 0_u64;
+        let mut continue_to_target = false;
+        loop {
+            match self
+                .msg_box_db
+                .sweep_expired_idempotency_global_by_capacity(
+                    now_ms,
+                    IDEMPOTENCY_GLOBAL_MAX_ROWS,
+                    IDEMPOTENCY_GLOBAL_TARGET_ROWS,
+                    IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS,
+                    continue_to_target,
+                )
+                .await
+            {
+                Ok((deleted, remaining_rows)) => {
+                    global_deleted = global_deleted.saturating_add(deleted);
+                    if remaining_rows <= IDEMPOTENCY_GLOBAL_TARGET_ROWS
+                        || deleted < IDEMPOTENCY_GLOBAL_SWEEP_BATCH_ROWS
+                    {
+                        break;
+                    }
+                    continue_to_target = true;
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => {
+                    warn!("msg_center idempotency global sweep failed: {}", error);
+                    break;
+                }
+            }
+        }
         let deleted = bucket_deleted.saturating_add(global_deleted);
         if deleted > 0 {
             info!(
@@ -348,6 +330,19 @@ impl MessageCenter {
                 deleted
             );
         }
+    }
+
+    pub fn start_idempotency_sweep(&self) {
+        let center = self.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_millis(
+                IDEMPOTENCY_SWEEP_INTERVAL_MS,
+            ));
+            loop {
+                ticker.tick().await;
+                center.sweep_expired_idempotency().await;
+            }
+        });
     }
 
     fn sanitize_token(raw: &str) -> String {
@@ -538,25 +533,26 @@ impl MessageCenter {
             .map(|value| value.to_string())
     }
 
-    fn dispatch_idempotency_retention_key(
+    pub(crate) fn dispatch_idempotency_retention_key(
         msg: &MsgObject,
         ingress: Option<&IngressContext>,
     ) -> String {
         if let Some(ctx) = ingress {
             let platform = Self::normalize_non_empty(ctx.platform.as_deref())
                 .unwrap_or_else(|| "unknown".to_string());
-            let source_account = Self::normalize_non_empty(ctx.source_account_id.as_deref())
-                .unwrap_or_else(|| {
-                    ctx.transport_did
-                        .as_ref()
-                        .map(|did| did.to_string())
-                        .unwrap_or_else(|| "unknown".to_string())
-                });
+            let tunnel_account = ctx
+                .extra
+                .as_ref()
+                .and_then(|extra| extra.get("tunnel_account_id"))
+                .and_then(Value::as_str)
+                .and_then(|value| Self::normalize_non_empty(Some(value)))
+                .or_else(|| ctx.transport_did.as_ref().map(|did| did.to_string()))
+                .unwrap_or_else(|| "unknown".to_string());
             let session = Self::normalize_non_empty(ctx.chat_id.as_deref())
                 .or_else(|| Self::normalize_non_empty(msg.thread.topic.as_deref()))
                 .or_else(|| Self::normalize_non_empty(ctx.context_id.as_deref()))
                 .unwrap_or_else(|| "unknown".to_string());
-            return format!("dispatch:{}:{}:{}", platform, source_account, session);
+            return format!("dispatch:{}:{}:{}", platform, tunnel_account, session);
         }
 
         if let Some(topic) = Self::normalize_non_empty(msg.thread.topic.as_deref()) {
@@ -570,6 +566,31 @@ impl MessageCenter {
                 .unwrap_or_else(|| format!("dispatch:sender:{}", msg.from.to_string()));
         }
         format!("dispatch:sender:{}", msg.from.to_string())
+    }
+
+    fn dispatch_idempotency_owner_scope(
+        msg: &MsgObject,
+        ingress: Option<&IngressContext>,
+    ) -> String {
+        if let Some(owner) = ingress.and_then(|ctx| ctx.contact_mgr_owner.as_ref()) {
+            return owner.to_string();
+        }
+        let mut targets = msg.to.iter().map(|did| did.to_string()).collect::<Vec<_>>();
+        targets.sort();
+        targets.dedup();
+        if targets.is_empty() {
+            return msg.from.to_string();
+        }
+        let mut hasher = Sha256::new();
+        for target in targets {
+            hasher.update(target.as_bytes());
+            hasher.update([0]);
+        }
+        format!("targets:{}", hex::encode(hasher.finalize()))
+    }
+
+    fn post_send_idempotency_owner_scope(msg: &MsgObject) -> String {
+        msg.from.to_string()
     }
 
     fn post_send_idempotency_retention_key(msg: &MsgObject) -> String {
@@ -1012,8 +1033,13 @@ impl MessageCenter {
         ingress_ctx: Option<IngressContext>,
         idempotency_key: Option<String>,
     ) -> std::result::Result<DispatchResult, RPCErrors> {
+        let idempotency_owner_scope =
+            Self::dispatch_idempotency_owner_scope(&msg, ingress_ctx.as_ref());
         if let Some(key) = idempotency_key.as_ref() {
-            if let Some(cached) = self.load_dispatch_idempotency(key).await? {
+            if let Some(cached) = self
+                .load_dispatch_idempotency(&idempotency_owner_scope, key)
+                .await?
+            {
                 return Ok(cached);
             }
         }
@@ -1068,15 +1094,17 @@ impl MessageCenter {
                     ingress,
                 ),
             };
-        let retention_key =
-            Self::dispatch_idempotency_retention_key(&stored_msg, ingress.as_ref());
+        let retention_key = Self::dispatch_idempotency_retention_key(&stored_msg, ingress.as_ref());
 
         Self::store_message(&stored_msg_id, &stored_msg_json).await?;
 
         // Re-check idempotency before doing any work; a concurrent caller may
         // have completed the same dispatch while we were awaiting store_message.
         if let Some(key) = idempotency_key.as_ref() {
-            if let Some(cached) = self.load_dispatch_idempotency(key).await? {
+            if let Some(cached) = self
+                .load_dispatch_idempotency(&idempotency_owner_scope, key)
+                .await?
+            {
                 return Ok(cached);
             }
         }
@@ -1118,11 +1146,11 @@ impl MessageCenter {
                 };
                 let now_ms = Self::now_ms();
                 let expires_at_ms = Self::idempotency_expires_at(now_ms);
-                self.maybe_sweep_expired_idempotency().await;
                 match self
                     .msg_box_db
                     .commit_dispatch_records(
                         IDEMPOTENCY_SCOPE_DISPATCH,
+                        &idempotency_owner_scope,
                         idempotency_key.as_deref(),
                         Some(retention_key.as_str()),
                         &stored_msg_id,
@@ -1280,11 +1308,11 @@ impl MessageCenter {
 
         let now_ms = Self::now_ms();
         let expires_at_ms = Self::idempotency_expires_at(now_ms);
-        self.maybe_sweep_expired_idempotency().await;
         match self
             .msg_box_db
             .commit_dispatch_records(
                 IDEMPOTENCY_SCOPE_DISPATCH,
+                &idempotency_owner_scope,
                 idempotency_key.as_deref(),
                 Some(retention_key.as_str()),
                 &stored_msg_id,
@@ -1317,8 +1345,13 @@ impl MessageCenter {
             ));
         }
 
+        let idempotency_owner_scope = Self::post_send_idempotency_owner_scope(&msg);
+
         if let Some(key) = idempotency_key.as_ref() {
-            if let Some(cached) = self.load_post_send_idempotency(key).await? {
+            if let Some(cached) = self
+                .load_post_send_idempotency(&idempotency_owner_scope, key)
+                .await?
+            {
                 return Ok(cached);
             }
         }
@@ -1379,11 +1412,11 @@ impl MessageCenter {
             };
             let now_ms = Self::now_ms();
             let expires_at_ms = Self::idempotency_expires_at(now_ms);
-            self.maybe_sweep_expired_idempotency().await;
             match self
                 .msg_box_db
                 .commit_post_send_records(
                     IDEMPOTENCY_SCOPE_POST_SEND,
+                    &idempotency_owner_scope,
                     idempotency_key.as_deref(),
                     Some(retention_key.as_str()),
                     &stored_msg_id,
@@ -1419,11 +1452,11 @@ impl MessageCenter {
                     };
                     let now_ms = Self::now_ms();
                     let expires_at_ms = Self::idempotency_expires_at(now_ms);
-                    self.maybe_sweep_expired_idempotency().await;
                     match self
                         .msg_box_db
                         .commit_post_send_records(
                             IDEMPOTENCY_SCOPE_POST_SEND,
+                            &idempotency_owner_scope,
                             idempotency_key.as_deref(),
                             Some(retention_key.as_str()),
                             &stored_msg_id,
@@ -1450,7 +1483,10 @@ impl MessageCenter {
         Self::store_message(&stored_msg_id, &stored_msg_json).await?;
 
         if let Some(key) = idempotency_key.as_ref() {
-            if let Some(cached) = self.load_post_send_idempotency(key).await? {
+            if let Some(cached) = self
+                .load_post_send_idempotency(&idempotency_owner_scope, key)
+                .await?
+            {
                 return Ok(cached);
             }
         }
@@ -1502,11 +1538,11 @@ impl MessageCenter {
             reason: None,
         };
         let expires_at_ms = Self::idempotency_expires_at(now_ms);
-        self.maybe_sweep_expired_idempotency().await;
         match self
             .msg_box_db
             .commit_post_send_records(
                 IDEMPOTENCY_SCOPE_POST_SEND,
+                &idempotency_owner_scope,
                 idempotency_key.as_deref(),
                 Some(retention_key.as_str()),
                 &stored_msg_id,
@@ -2149,6 +2185,31 @@ impl MessageCenter {
         let session_id = Self::normalize_ui_session_arg("session_id", &session_id)?;
         self.msg_box_db.list_ui_session_state(&session_id).await
     }
+
+    async fn get_tunnel_cursor_internal(
+        &self,
+        tunnel_key: String,
+        cursor_key: String,
+    ) -> std::result::Result<Option<Value>, RPCErrors> {
+        let tunnel_key = Self::normalize_ui_session_arg("tunnel_key", &tunnel_key)?;
+        let cursor_key = Self::normalize_ui_session_arg("cursor_key", &cursor_key)?;
+        self.msg_box_db
+            .get_tunnel_cursor(&tunnel_key, &cursor_key)
+            .await
+    }
+
+    async fn update_tunnel_cursor_internal(
+        &self,
+        tunnel_key: String,
+        cursor_key: String,
+        value: Value,
+    ) -> std::result::Result<(), RPCErrors> {
+        let tunnel_key = Self::normalize_ui_session_arg("tunnel_key", &tunnel_key)?;
+        let cursor_key = Self::normalize_ui_session_arg("cursor_key", &cursor_key)?;
+        self.msg_box_db
+            .upsert_tunnel_cursor(&tunnel_key, &cursor_key, &value, Self::now_ms())
+            .await
+    }
 }
 
 #[async_trait]
@@ -2376,6 +2437,27 @@ impl MsgCenterHandler for MessageCenter {
         _ctx: RPCContext,
     ) -> std::result::Result<Vec<UiSessionStateEntry>, RPCErrors> {
         self.list_ui_session_state_internal(session_id).await
+    }
+
+    async fn handle_get_tunnel_cursor(
+        &self,
+        tunnel_key: String,
+        cursor_key: String,
+        _ctx: RPCContext,
+    ) -> std::result::Result<Option<Value>, RPCErrors> {
+        self.get_tunnel_cursor_internal(tunnel_key, cursor_key)
+            .await
+    }
+
+    async fn handle_update_tunnel_cursor(
+        &self,
+        tunnel_key: String,
+        cursor_key: String,
+        value: Value,
+        _ctx: RPCContext,
+    ) -> std::result::Result<(), RPCErrors> {
+        self.update_tunnel_cursor_internal(tunnel_key, cursor_key, value)
+            .await
     }
 
     async fn handle_resolve_did(

--- a/src/frame/msg_center/src/test_msg_center.rs
+++ b/src/frame/msg_center/src/test_msg_center.rs
@@ -1155,3 +1155,87 @@ async fn idempotency_key_survives_message_center_restart() {
         .unwrap();
     assert_eq!(inbox.len(), 1);
 }
+
+#[tokio::test]
+async fn idempotency_key_is_isolated_by_message_owner() {
+    let (center, _tmp) = new_center("idempotency_owner_scope").await;
+    let transport_did = DID::new("bns", "tg-owner-scope-tunnel");
+    center
+        .register_tunnel(
+            "tg-owner-scope".to_string(),
+            transport_did.clone(),
+            "telegram".to_string(),
+        )
+        .unwrap();
+    let target = DID::new("msgtunnel", "888.user.tg-owner-scope");
+    let first = center
+        .handle_post_send(
+            make_msg(
+                DID::new("bns", "owner-scope-a"),
+                vec![target.clone()],
+                MsgObjKind::Chat,
+            ),
+            Some("shared-caller-key".to_string()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+    let second = center
+        .handle_post_send(
+            make_msg(
+                DID::new("bns", "owner-scope-b"),
+                vec![target],
+                MsgObjKind::Chat,
+            ),
+            Some("shared-caller-key".to_string()),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(first.msg_id, second.msg_id);
+    assert_ne!(first.deliveries, second.deliveries);
+    let first_delivery = center
+        .handle_get_next_delivery(transport_did.clone(), Some(true), None, ctx())
+        .await
+        .unwrap();
+    let second_delivery = center
+        .handle_get_next_delivery(transport_did, Some(true), None, ctx())
+        .await
+        .unwrap();
+    assert!(first_delivery.is_some());
+    assert!(second_delivery.is_some());
+}
+
+#[test]
+fn telegram_retention_bucket_uses_bot_and_chat_not_sender() {
+    let msg = make_msg(
+        DID::new("bns", "external-sender"),
+        vec![DID::new("bns", "recipient")],
+        MsgObjKind::Chat,
+    );
+    let ingress = |sender: &str, bot: &str| IngressContext {
+        transport_did: Some(DID::new("bns", "tg-retention-tunnel")),
+        platform: Some("telegram".to_string()),
+        chat_id: Some("-100123".to_string()),
+        source_account_id: Some(sender.to_string()),
+        extra: Some(json!({"tunnel_account_id": bot})),
+        ..Default::default()
+    };
+
+    let first = MessageCenter::dispatch_idempotency_retention_key(
+        &msg,
+        Some(&ingress("telegram-user-1", "@zone_bot")),
+    );
+    let second = MessageCenter::dispatch_idempotency_retention_key(
+        &msg,
+        Some(&ingress("telegram-user-2", "@zone_bot")),
+    );
+    let other_bot = MessageCenter::dispatch_idempotency_retention_key(
+        &msg,
+        Some(&ingress("telegram-user-1", "@other_bot")),
+    );
+
+    assert_eq!(first, second);
+    assert_ne!(first, other_bot);
+}

--- a/src/frame/msg_center/src/tg_tunnel.rs
+++ b/src/frame/msg_center/src/tg_tunnel.rs
@@ -48,7 +48,7 @@ const TG_BOT_API_ENDPOINT: &str = "https://api.telegram.org";
 const TG_UI_SESSION_IDLE_TIMEOUT_MS: u64 = 10 * 60 * 1000;
 const TG_UI_SESSION_REFRESH_INTERVAL_MS: u64 = 5 * 1000;
 const TG_TASK_SHUTDOWN_TIMEOUT_MS: u64 = 5_000;
-const TG_BOT_API_OFFSET_STATE_KEY: &str = "bot_api_offset";
+const TG_BOT_API_OFFSET_CURSOR_KEY: &str = "bot_api_update_offset";
 const TG_BUILTIN_COMMANDS: &[(&str, &str)] = &[
     ("new", "Create a new session"),
     ("clean", "Delete current session and create a new one"),
@@ -100,7 +100,6 @@ impl ManagedTask {
             }
         }
     }
-
 }
 
 #[derive(Debug, Clone)]
@@ -979,6 +978,7 @@ impl TgMessageConverter {
             extra: Some(json!({
                 "tg_message_id": message.id(),
                 "chat_type": chat_type,
+                "tunnel_account_id": bot_account_id,
             })),
         };
 
@@ -2918,6 +2918,7 @@ impl BotApiTgGateway {
             extra: Some(json!({
                 "tg_message_id": message.message_id,
                 "chat_type": chat_kind,
+                "tunnel_account_id": bot_account_id,
             })),
         };
         info!(
@@ -3025,13 +3026,13 @@ impl BotApiTgGateway {
         trimmed.to_string()
     }
 
-    fn bot_api_offset_session_id(
+    fn bot_api_cursor_tunnel_key(
         owner_did: &DID,
         bot_account_id: &str,
         tunnel_instance_id: &str,
     ) -> String {
         format!(
-            "tg:bot-api-offset:{}:{}:{}",
+            "telegram:{}:{}:{}",
             owner_did.to_string(),
             bot_account_id,
             tunnel_instance_id
@@ -3044,29 +3045,26 @@ impl BotApiTgGateway {
         bot_account_id: &str,
         tunnel_instance_id: &str,
     ) -> AnyResult<i64> {
-        let session_id =
-            Self::bot_api_offset_session_id(owner_did, bot_account_id, tunnel_instance_id);
+        let tunnel_key =
+            Self::bot_api_cursor_tunnel_key(owner_did, bot_account_id, tunnel_instance_id);
         match dispatcher
-            .handle_get_ui_session_state(
-                session_id,
-                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+            .handle_get_tunnel_cursor(
+                tunnel_key,
+                TG_BOT_API_OFFSET_CURSOR_KEY.to_string(),
                 RPCContext::default(),
             )
             .await
         {
             Ok(Some(entry)) => {
-                let offset = entry.value.as_i64().or_else(|| {
-                    entry
-                        .value
-                        .as_u64()
-                        .and_then(|value| i64::try_from(value).ok())
-                });
+                let offset = entry
+                    .as_i64()
+                    .or_else(|| entry.as_u64().and_then(|value| i64::try_from(value).ok()));
                 offset.filter(|value| *value >= 0).ok_or_else(|| {
                     anyhow::anyhow!(
                         "invalid telegram bot api offset state for owner={}, bot={}, value={}",
                         owner_did.to_string(),
                         bot_account_id,
-                        entry.value
+                        entry
                     )
                 })
             }
@@ -3087,17 +3085,16 @@ impl BotApiTgGateway {
         tunnel_instance_id: &str,
         offset: i64,
     ) -> AnyResult<()> {
-        let session_id =
-            Self::bot_api_offset_session_id(owner_did, bot_account_id, tunnel_instance_id);
+        let tunnel_key =
+            Self::bot_api_cursor_tunnel_key(owner_did, bot_account_id, tunnel_instance_id);
         dispatcher
-            .handle_update_ui_session_state(
-                session_id,
-                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+            .handle_update_tunnel_cursor(
+                tunnel_key,
+                TG_BOT_API_OFFSET_CURSOR_KEY.to_string(),
                 json!(offset.max(0)),
                 RPCContext::default(),
             )
             .await
-            .map(|_| ())
             .map_err(|error| anyhow::anyhow!("persist telegram bot api offset failed: {}", error))
     }
 
@@ -3312,23 +3309,24 @@ impl TgGateway for BotApiTgGateway {
                     return Err(error);
                 }
             };
-            let me = match Self::call_api_with_client::<TgBotApiMe>(&self.http, &token, "getMe", None)
-                .await
-                .with_context(|| {
-                    format!(
-                        "telegram bot api getMe failed for owner {} (bot account {})",
-                        binding.owner_did.to_string(),
-                        binding.bot_account_id
-                    )
-                }) {
-                Ok(me) => me,
-                Err(error) => {
-                    for (_, task) in started_tasks.drain() {
-                        task.stop("bot-api-start-rollback").await;
+            let me =
+                match Self::call_api_with_client::<TgBotApiMe>(&self.http, &token, "getMe", None)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "telegram bot api getMe failed for owner {} (bot account {})",
+                            binding.owner_did.to_string(),
+                            binding.bot_account_id
+                        )
+                    }) {
+                    Ok(me) => me,
+                    Err(error) => {
+                        for (_, task) in started_tasks.drain() {
+                            task.stop("bot-api-start-rollback").await;
+                        }
+                        return Err(error);
                     }
-                    return Err(error);
-                }
-            };
+                };
             info!(
                 "telegram bot api ready: owner={}, bot_id={}, username={:?}",
                 binding.owner_did.to_string(),
@@ -4551,24 +4549,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bot_api_offset_invalid_state_returns_error() {
+    async fn bot_api_offset_uses_internal_cursor_state() {
         let (center, _tmp) = new_msg_center().await;
         let owner = DID::new("bns", "alice");
         let bot_account_id = "@alice_bot";
         let tunnel_instance_id = "default";
-        let session_id =
-            BotApiTgGateway::bot_api_offset_session_id(&owner, bot_account_id, tunnel_instance_id);
+        let tunnel_key =
+            BotApiTgGateway::bot_api_cursor_tunnel_key(&owner, bot_account_id, tunnel_instance_id);
         center
             .handle_update_ui_session_state(
-                session_id,
-                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+                tunnel_key.clone(),
+                TG_BOT_API_OFFSET_CURSOR_KEY.to_string(),
                 json!("not-an-offset"),
                 RPCContext::default(),
             )
             .await
             .unwrap();
 
-        let handler: Arc<dyn MsgCenterHandler> = Arc::new(center);
+        let handler: Arc<dyn MsgCenterHandler> = Arc::new(center.clone());
+        let offset = BotApiTgGateway::load_bot_api_offset(
+            &handler,
+            &owner,
+            bot_account_id,
+            tunnel_instance_id,
+        )
+        .await
+        .unwrap();
+        assert_eq!(offset, 0);
+
+        center
+            .handle_update_tunnel_cursor(
+                tunnel_key.clone(),
+                TG_BOT_API_OFFSET_CURSOR_KEY.to_string(),
+                json!("not-an-offset"),
+                RPCContext::default(),
+            )
+            .await
+            .unwrap();
         let error = BotApiTgGateway::load_bot_api_offset(
             &handler,
             &owner,
@@ -4577,14 +4594,14 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(error.to_string().contains("invalid telegram bot api offset"));
+        assert!(error
+            .to_string()
+            .contains("invalid telegram bot api offset"));
 
-        let session_id =
-            BotApiTgGateway::bot_api_offset_session_id(&owner, bot_account_id, tunnel_instance_id);
         handler
-            .handle_update_ui_session_state(
-                session_id,
-                TG_BOT_API_OFFSET_STATE_KEY.to_string(),
+            .handle_update_tunnel_cursor(
+                tunnel_key,
+                TG_BOT_API_OFFSET_CURSOR_KEY.to_string(),
                 json!(-1),
                 RPCContext::default(),
             )
@@ -4598,7 +4615,28 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(error.to_string().contains("invalid telegram bot api offset"));
+        assert!(error
+            .to_string()
+            .contains("invalid telegram bot api offset"));
+
+        BotApiTgGateway::persist_bot_api_offset(
+            &handler,
+            &owner,
+            bot_account_id,
+            tunnel_instance_id,
+            42,
+        )
+        .await
+        .unwrap();
+        let offset = BotApiTgGateway::load_bot_api_offset(
+            &handler,
+            &owner,
+            bot_account_id,
+            tunnel_instance_id,
+        )
+        .await
+        .unwrap();
+        assert_eq!(offset, 42);
     }
 
     fn build_record(

--- a/src/kernel/buckyos-api/src/msg_center_client.rs
+++ b/src/kernel/buckyos-api/src/msg_center_client.rs
@@ -20,7 +20,7 @@ pub const MSG_CENTER_SERVICE_PORT: u16 = 4050;
 pub const MSG_CENTER_RDB_INSTANCE_ID: &str = "msg-center-main";
 /// Version of the msg-center schema. Bump whenever the DDL below changes in a
 /// way that is not trivially re-idempotent.
-pub const MSG_CENTER_RDB_SCHEMA_VERSION: u64 = 7;
+pub const MSG_CENTER_RDB_SCHEMA_VERSION: u64 = 8;
 pub const UI_SESSION_STATE_ACTIVE_KEY: &str = "active";
 pub const UI_SESSION_STATE_TYPING_KEY: &str = "typing";
 pub const UI_SESSION_STATE_STATUS_LINE_KEY: &str = "status_line";
@@ -131,6 +131,7 @@ CREATE TABLE IF NOT EXISTS msg_refs (
 
 CREATE TABLE IF NOT EXISTS msg_idempotency (
     scope           TEXT NOT NULL,
+    owner_scope     TEXT NOT NULL,
     idempotency_key TEXT NOT NULL,
     msg_id          TEXT,
     retention_key   TEXT,
@@ -139,12 +140,20 @@ CREATE TABLE IF NOT EXISTS msg_idempotency (
     created_at_ms   INTEGER NOT NULL,
     updated_at_ms   INTEGER NOT NULL,
     expires_at_ms   INTEGER,
-    PRIMARY KEY (scope, idempotency_key)
+    PRIMARY KEY (scope, owner_scope, idempotency_key)
 );
 CREATE INDEX IF NOT EXISTS idx_msg_idempotency_expire
     ON msg_idempotency(expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_msg_idempotency_retention_expire
     ON msg_idempotency(retention_key, expires_at_ms);
+
+CREATE TABLE IF NOT EXISTS msg_tunnel_cursors (
+    tunnel_key    TEXT NOT NULL,
+    cursor_key    TEXT NOT NULL,
+    value_json    TEXT NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    PRIMARY KEY (tunnel_key, cursor_key)
+);
 
 CREATE TABLE IF NOT EXISTS contact_metadata (
     key   TEXT PRIMARY KEY,
@@ -309,6 +318,7 @@ CREATE TABLE IF NOT EXISTS msg_refs (
 
 CREATE TABLE IF NOT EXISTS msg_idempotency (
     scope           TEXT NOT NULL,
+    owner_scope     TEXT NOT NULL,
     idempotency_key TEXT NOT NULL,
     msg_id          TEXT,
     retention_key   TEXT,
@@ -317,12 +327,20 @@ CREATE TABLE IF NOT EXISTS msg_idempotency (
     created_at_ms   BIGINT NOT NULL,
     updated_at_ms   BIGINT NOT NULL,
     expires_at_ms   BIGINT,
-    PRIMARY KEY (scope, idempotency_key)
+    PRIMARY KEY (scope, owner_scope, idempotency_key)
 );
 CREATE INDEX IF NOT EXISTS idx_msg_idempotency_expire
     ON msg_idempotency(expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_msg_idempotency_retention_expire
     ON msg_idempotency(retention_key, expires_at_ms);
+
+CREATE TABLE IF NOT EXISTS msg_tunnel_cursors (
+    tunnel_key    TEXT NOT NULL,
+    cursor_key    TEXT NOT NULL,
+    value_json    TEXT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    PRIMARY KEY (tunnel_key, cursor_key)
+);
 
 CREATE TABLE IF NOT EXISTS contact_metadata (
     key   TEXT PRIMARY KEY,
@@ -3492,6 +3510,29 @@ pub trait MsgCenterHandler: Send + Sync {
         ctx: RPCContext,
     ) -> std::result::Result<Vec<UiSessionStateEntry>, RPCErrors>;
 
+    async fn handle_get_tunnel_cursor(
+        &self,
+        _tunnel_key: String,
+        _cursor_key: String,
+        _ctx: RPCContext,
+    ) -> std::result::Result<Option<Value>, RPCErrors> {
+        Err(RPCErrors::UnknownMethod(
+            "msg_center.get_tunnel_cursor".to_string(),
+        ))
+    }
+
+    async fn handle_update_tunnel_cursor(
+        &self,
+        _tunnel_key: String,
+        _cursor_key: String,
+        _value: Value,
+        _ctx: RPCContext,
+    ) -> std::result::Result<(), RPCErrors> {
+        Err(RPCErrors::UnknownMethod(
+            "msg_center.update_tunnel_cursor".to_string(),
+        ))
+    }
+
     async fn handle_resolve_did(
         &self,
         platform: String,
@@ -4447,5 +4488,16 @@ mod tests {
             build_msg_tunnel_ui_session_id(" tg ", "bot:one", " chat:1 "),
             "tg:bot_one:chat_1"
         );
+    }
+
+    #[test]
+    fn schema_v8_scopes_idempotency_and_has_durable_tunnel_cursors() {
+        assert_eq!(MSG_CENTER_RDB_SCHEMA_VERSION, 8);
+        for schema in [MSG_CENTER_RDB_SCHEMA_SQLITE, MSG_CENTER_RDB_SCHEMA_POSTGRES] {
+            assert!(schema.contains("owner_scope     TEXT NOT NULL"));
+            assert!(schema.contains("PRIMARY KEY (scope, owner_scope, idempotency_key)"));
+            assert!(schema.contains("CREATE TABLE IF NOT EXISTS msg_tunnel_cursors"));
+            assert!(schema.contains("PRIMARY KEY (tunnel_key, cursor_key)"));
+        }
     }
 }


### PR DESCRIPTION
## 背景

PR #517 已修复 MessageCenter 入站恢复和持久幂等，但复核后仍存在跨 owner 幂等碰撞、Telegram offset 存储边界错误、清理阻塞请求路径，以及 Telegram 群聊 retention bucket 被发送者拆散等问题。本 PR 是 #517 的 follow-up 修复。

## 修复的问题与方案

### 1. 幂等键缺少 owner 隔离

原主键只有 `(scope, idempotency_key)`，不同用户或发送者复用同一个 key 时，后一个请求可能错误复用前一个请求的结果并跳过自己的消息写入。

方案：

- 主键改为 `(scope, owner_scope, idempotency_key)`。
- `dispatch` 优先使用稳定的接收方 owner；没有 owner 时使用规范化后的目标集合摘要。
- `post_send` 使用消息 author 作为 `owner_scope`。
- 增加不同 author 使用相同 key 时仍产生独立投递的回归测试。

### 2. Telegram offset 错用 UI SessionState

原 offset 存在对外可写、语义上可丢弃的 `ui_session_states` 中。客户端可以覆盖同名状态；非法值会使 polling 持续暂停。

方案：

- 新增内部持久表 `msg_tunnel_cursors`。
- Telegram Bot API offset 只通过进程内 tunnel cursor 能力读写，不暴露对应 kRPC 方法。
- UI SessionState 与 cursor 完全隔离。
- 增加 UI 写入同名非法值不影响 offset、合法 cursor 可恢复、非法 cursor 会被拒绝的测试。

### 3. 幂等清理运行在消息请求路径

原实现由 `dispatch/post_send` 同步触发容量扫描和删除，热点 bucket 或大表可能放大请求延迟并造成 SQLite 写锁竞争。

方案：

- 从消息请求路径移除 sweep。
- 服务启动时立即运行一次，之后每小时由后台任务运行。
- 全局清理保持每批最多 10,000 行，并在连续批次之间主动让出执行权。

### 4. Telegram retention bucket 按消息发送者拆分

原 `dispatch` bucket 使用 `source_account_id`；Telegram 将它设置为消息发送者账号，导致同一群聊按成员拆成大量 bucket，`3000 → 2000` 的单会话水位失效。

方案：

- Telegram ingress 写入稳定的 `tunnel_account_id`。
- bucket 改为 `platform + tunnel/bot account + chat/topic`。
- `source_account_id` 继续保留为消息来源信息，不再参与 retention 分桶。
- 增加同一 bot/chat 的不同发送者得到相同 bucket、不同 bot 得到不同 bucket 的测试。

## 数据结构与兼容性

- MessageCenter RDB schema version 从 7 升到 8。
- 新增 `msg_idempotency.owner_scope`。
- 新增 `msg_tunnel_cursors`。
- beta2.2 当前允许 breaking change，本次采用 no-compat：v7 实例需要重建，不提供表内迁移。
- 新增 `Message Center Durable Data Schema.md`，并同步更新 Message Center、Tunnel Design 和 Minimal Spec。

## 验证

- `cargo test -p msg_center --offline`：62 passed，0 failed，1 ignored（需要 Telegram 凭据和网络）。
- `cargo test -p buckyos-api --offline`：113 passed，0 failed。
- `cargo fmt --all -- --check`：通过。
- `git diff --check`：通过。
