### PR TITLE
feat(aicc): 支持聚合 Provider 的模型来源映射

### DIFF
--- a/doc/aicc/aicc-mgr.md
+++ b/doc/aicc/aicc-mgr.md
@@ -96,7 +96,7 @@ services/control_panel/ai_models/provider_secrets
 | Provider type | settings section | instance 字段 |
 | --- | --- | --- |
 | `sn_router` | `sn-ai-provider` | `provider_instance_name`, `provider_type`, `api_token`, `base_url`, `auth_mode`, `timeout_ms` |
-| `openai` / `openrouter` / `custom` | `openai` | `provider_instance_name`, `provider_type`, `api_token`, `base_url`, `auth_mode`, `timeout_ms` |
+| `openai` / `openrouter` / `custom` | `openai` | `provider_instance_name`, `provider_type`, `provider_driver`, `api_token`, `base_url`, `auth_mode`, `timeout_ms` |
 | `google` | `google` | `provider_instance_name`, `provider_type`, `provider_driver`, `api_token`, `base_url`, `timeout_ms`, `models`, `default_model`, `image_models`, `default_image_model`, `features`, `alias_map` |
 | `anthropic` | `claude` | `provider_instance_name`, `provider_type`, `provider_driver`, `api_token`, `base_url`, `timeout_ms`, `models`, `default_model`, `features`, `alias_map` |
 | `minimax` | `minimax` | `provider_instance_name`, `provider_type`, `provider_driver`, `api_token`, `base_url`, `timeout_ms`, `models`, `default_model`, `features`, `alias_map` |
@@ -278,6 +278,7 @@ minimax    -> minimax
       {
         "provider_instance_name": "openai-work",
         "provider_type": "cloud_api",
+        "provider_driver": "openai",
         "api_token": "sk-...",
         "base_url": "https://api.openai.com/v1",
         "auth_mode": "bearer",
@@ -290,8 +291,8 @@ minimax    -> minimax
 
 `openrouter` 和 `custom` 第一版复用 `openai` adapter：
 
-- `provider_driver` 当前 OpenAI instance 不支持配置，driver 会由代码根据 instance name / endpoint 推断，无法精确表达 `openrouter`。因此第一版仅保证 OpenAI-compatible 调用链可用，UI 上的 `provider_type` 需要从 `provider_instance_name` / endpoint 推断。
-- 如果要让后端 inventory 精确返回 `openrouter` / `custom`，需要扩展 `OpenAIInstanceConfig`，这属于实现阶段的协议/共享类型改动。
+- OpenAI instance 支持显式配置 `provider_driver`。OpenAI 使用 `openai`，OpenRouter 使用 `openrouter`，自定义 OpenAI-compatible provider 使用与其 driver metadata 文件一致的 driver id。后端 inventory 会原样返回该值，并用它选择对应的模型 metadata。
+- `provider_type` 只表示部署类型（例如 `cloud_api`），不能代替 `provider_driver`。未配置 `provider_driver` 时，SN endpoint 回退为 `sn-ai-provider`，其他 endpoint 回退为 `openai`；因此 OpenRouter 和 custom instance 应显式配置该字段。
 
 ### 4.4 `provider.delete`
 

--- a/doc/aicc/aicc_api设计.md
+++ b/doc/aicc/aicc_api设计.md
@@ -594,6 +594,11 @@ pub enum AiContent {
 }
 ```
 
+`ProviderState.provider` 保存 opaque state 的稳定所有者/消费者 namespace（例如
+`openai`、`openrouter`、`anthropic` 或 `google`），由各 adapter 定义其可还原的
+namespace；它不保存协议名或原生 item 类型。原生 item 类型继续由 `value` 自描述
+（例如 OpenAI Responses 的 `value.type`）。
+
 JSON 形态（注意图片块是 `type:image` + `source`，不再是 `type:resource` + `resource`）：
 
 ```json

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -27,9 +27,11 @@ priority override.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "provider_driver": "openai",
   "revision": "builtin-2026-05-30",
+  "origin_provider_aliases": {},
+  "origin_mappings": [],
   "models": [],
   "patterns": [],
   "defaults": {},
@@ -40,9 +42,14 @@ priority override.
 
 Fields:
 
-- `schema_version`: currently `1`.
-- `provider_driver`: driver id such as `openai`, `claude`, `google-gemini`, `fal`, `minimax`.
+- `schema_version`: currently `2`.
+- `provider_driver`: driver id such as `openai`, `openrouter`, `claude`,
+  `google-gemini`, `fal`, or `minimax`.
 - `revision`: monotonically changing metadata revision string.
+- `origin_provider_aliases`: optional map from provider-specific origin slugs to
+  canonical BuckyOS driver names.
+- `origin_mappings`: optional ordered rules that derive the physical origin
+  `driver` and `model` from the provider-native model id.
 - `models`: exact rules keyed by `id`.
 - `patterns`: wildcard rules keyed by `pattern`; `*` is the only wildcard.
 - `defaults`: default rule when no exact or pattern rule matches.
@@ -58,19 +65,77 @@ Rules support these fields:
 
 - `id`: exact provider model id for `models`.
 - `pattern`: wildcard provider model id pattern for `patterns`.
-- `model_driver`: optional per-model metadata driver. Defaults to the
-  provider driver, but proxy/aggregator providers can override it when a model
-  should be attributed to its upstream project or publisher.
+- `model_driver`: optional per-model metadata driver. Defaults to the resolved
+  origin driver. A rule can override it when metadata attribution differs from
+  the physical model origin.
 - `exclude`: drops the provider model from inventory.
 - `parameter_scale`: optional display/classification string.
 - `api_types`: AICC API types, for example `llm.chat`, `image.txt2img`, `audio.asr`.
-- `logical_mounts`: logical mounts. Templates `{driver}`, `{model}`, and `{provider_model_id}` are expanded by the resolver.
+- `logical_mounts`: logical mounts. Templates `{driver}`, `{model}`,
+  `{provider_driver}`, and `{provider_model_id}` are expanded by the resolver.
+  The first pair identifies the physical origin; the second pair identifies the
+  current delivery channel.
 - `capabilities`: partial capability patch: `streaming`, `tool_call`, `json_schema`, `web_search`, `vision`, `max_context_tokens`, `max_output_tokens`.
 - `estimated_cost_usd`, `estimated_latency_ms`: default scheduler estimates.
 - `quality_score`, `latency_class`, `cost_class`: routing attributes.
 
 Unknown fallback is intentionally conservative: it does not declare
 `tool_call`, `web_search`, `vision`, or `json_schema`.
+
+## Origin Identity Mappings
+
+Provider model ids are channel-local. An origin provider such as OpenAI can use
+the fallback identity `openai` / `gpt-5.5`. An aggregator such as OpenRouter
+returns a channel id such as `openai/gpt-5.5`, which must resolve to the same
+physical identity before logical mounts and semantic family rules are applied.
+
+Schema v2 defines these template variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `{driver}` | resolved physical origin driver, for example `openai` |
+| `{model}` | resolved physical origin model, for example `gpt-5.5` |
+| `{provider_driver}` | current channel driver, for example `openrouter` |
+| `{provider_model_id}` | current channel model id, for example `openai/gpt-5.5` |
+
+Mappings are evaluated by ascending `priority`; the first successful rule wins.
+If no rule succeeds, the resolver uses `provider_driver` and
+`provider_model_id` as the origin identity.
+
+```json
+{
+  "origin_provider_aliases": {
+    "google": "google-gemini",
+    "x-ai": "xai"
+  },
+  "origin_mappings": [
+    {
+      "mapping_key": "openrouter-path-id",
+      "priority": 100,
+      "match": {
+        "source": "provider_model_id",
+        "regex": "^(?<driver>[^/]+)/(?<model>.+)$"
+      },
+      "transforms": {
+        "driver": [
+          { "op": "lowercase" },
+          { "op": "alias", "table": "origin_provider_aliases", "on_missing": "keep" }
+        ],
+        "model": [
+          { "op": "trim" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+The regex must use named `driver` and `model` captures. Supported transforms
+are `trim`, `lowercase`, and `alias`; alias lookup only accepts the
+`origin_provider_aliases` table and `on_missing: keep`. Invalid mappings are
+ignored. Dynamic provider aliases such as `~x-ai/grok-latest` and router models
+such as `openrouter/auto` should be excluded with ordinary model or pattern
+rules.
 
 ## Variants
 

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -23,6 +23,12 @@ For each model id, match priority is:
 Exact matches win before patterns, even if the pattern comes from a higher
 priority override.
 
+`origin_mappings` is a provider-level rule set, not an incremental patch. The
+resolver uses the complete list from the highest-priority metadata document
+that defines it and does not merge mappings from lower-priority documents.
+Therefore, an override document that defines `origin_mappings` must include the
+provider's complete mapping list.
+
 ## Document
 
 ```json

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -154,6 +154,7 @@ models.
 ```json
 {
   "name": "reasoning.high",
+  "model_pattern": "gpt-*",
   "mount_suffix": "reasoning-high",
   "provider_options": {
     "reasoning": {
@@ -162,6 +163,11 @@ models.
   }
 }
 ```
+
+`model_pattern` matches the complete channel-local `provider_model_id`. It can
+scope variants by origin within an aggregator, for example `openai/*` in
+OpenRouter metadata. When omitted, the variant applies to every otherwise
+eligible model in that driver metadata document.
 
 For a discovered OpenAI model `gpt-5.1`, the resolver emits:
 

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -68,6 +68,9 @@ Rules support these fields:
 - `model_driver`: optional per-model metadata driver. Defaults to the resolved
   origin driver. A rule can override it when metadata attribution differs from
   the physical model origin.
+- `provider_actual_model_id`: optional model id sent to the provider instead of
+  the discovered id. Aggregators can use it to pin a public alias to the
+  inventory's canonical fixed model revision.
 - `exclude`: drops the provider model from inventory.
 - `parameter_scale`: optional display/classification string.
 - `api_types`: AICC API types, for example `llm.chat`, `image.txt2img`, `audio.asr`.
@@ -76,6 +79,8 @@ Rules support these fields:
   The first pair identifies the physical origin; the second pair identifies the
   current delivery channel.
 - `capabilities`: partial capability patch: `streaming`, `tool_call`, `json_schema`, `web_search`, `vision`, `max_context_tokens`, `max_output_tokens`.
+- `input_token_usd`, `output_token_usd`, `cache_input_token_usd`: optional
+  provider token prices in USD per token.
 - `estimated_cost_usd`, `estimated_latency_ms`: default scheduler estimates.
 - `quality_score`, `latency_class`, `cost_class`: routing attributes.
 

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -84,6 +84,12 @@ Rules support these fields:
 - `estimated_cost_usd`, `estimated_latency_ms`: default scheduler estimates.
 - `quality_score`, `latency_class`, `cost_class`: routing attributes.
 
+All exact ids and wildcard patterns, including
+`version_rules[].model_pattern`, match the complete channel-local
+`provider_model_id`. Origin fields are only used for metadata attribution and
+mount template expansion. For example, OpenAI uses `gpt-*`, while OpenRouter
+uses `openai/gpt-*` for the same origin model family.
+
 Unknown fallback is intentionally conservative: it does not declare
 `tool_call`, `web_search`, `vision`, or `json_schema`.
 

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -68,9 +68,6 @@ Rules support these fields:
 - `model_driver`: optional per-model metadata driver. Defaults to the resolved
   origin driver. A rule can override it when metadata attribution differs from
   the physical model origin.
-- `provider_actual_model_id`: optional model id sent to the provider instead of
-  the discovered id. Aggregators can use it to pin a public alias to the
-  inventory's canonical fixed model revision.
 - `exclude`: drops the provider model from inventory.
 - `parameter_scale`: optional display/classification string.
 - `api_types`: AICC API types, for example `llm.chat`, `image.txt2img`, `audio.asr`.

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -152,7 +152,10 @@ are `trim`, `lowercase`, and `alias`; alias lookup only accepts the
 `origin_provider_aliases` table and `on_missing: keep`. Invalid mappings are
 ignored. Dynamic provider aliases such as `~x-ai/grok-latest` and router models
 such as `openrouter/auto` should be excluded with ordinary model or pattern
-rules.
+rules. Aggregators that only admit base OpenAI model ids should place
+`openai/*:*` and `openai/*latest*` exclusion patterns before family allow
+patterns so provider variants and moving aliases cannot inherit base-model
+metadata.
 
 ## Variants
 

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -102,6 +102,9 @@ Provider model ids are channel-local. An origin provider such as OpenAI can use
 the fallback identity `openai` / `gpt-5.5`. An aggregator such as OpenRouter
 returns a channel id such as `openai/gpt-5.5`, which must resolve to the same
 physical identity before logical mounts and semantic family rules are applied.
+The resolver stores the resolved model component in
+`ModelMetadata.origin_model_id`; consumers must use this field instead of
+inferring an origin model from provider-specific id syntax.
 
 Schema v2 defines these template variables:
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -69,6 +69,7 @@ futures-util = "0.3.31"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 schemars = { version = "0.8.22", features = ["preserve_order"] }
+regex = "1.12.2"
 
 # Logging
 log = "0.4.29"

--- a/src/frame/agent_tool/src/llm_compress.rs
+++ b/src/frame/agent_tool/src/llm_compress.rs
@@ -447,7 +447,7 @@ fn is_compressed_pair_at(history: &[AiMessage], idx: usize) -> bool {
 }
 
 fn is_compress_meta_message(msg: &AiMessage) -> bool {
-    msg.role == AiRole::Assistant && msg.text_content().contains(COMPRESS_META_MARKER)
+    msg.role == AiRole::Developer && msg.text_content().contains(COMPRESS_META_MARKER)
 }
 
 fn is_compress_summary_message(msg: &AiMessage) -> bool {
@@ -751,7 +751,7 @@ fn try_fold_agent_loop_history_block(
             range.start, range.end
         ),
     );
-    let assistant = AiMessage::text(AiRole::Assistant, format_mechanical_text(&meta, &body));
+    let assistant = AiMessage::text(AiRole::Developer, format_mechanical_text(&meta, &body));
     let mut out = Vec::with_capacity(
         range
             .start
@@ -1034,7 +1034,7 @@ fn build_compressed_pair(
     });
     vec![
         AiMessage::text(
-            AiRole::Assistant,
+            AiRole::Developer,
             format!(
                 "{}\n{}",
                 COMPRESS_META_MARKER,
@@ -1203,7 +1203,7 @@ mod tests {
 
     fn compressed_pair(summary: &str) -> Vec<AiMessage> {
         vec![
-            AiMessage::text(AiRole::Assistant, COMPRESS_META_MARKER),
+            AiMessage::text(AiRole::Developer, COMPRESS_META_MARKER),
             AiMessage::text(
                 AiRole::User,
                 format!("{}\n{}", COMPRESS_SUMMARY_MARKER, summary),
@@ -1592,7 +1592,7 @@ mod tests {
         assert_eq!(out[0].text_content(), "you are helpful");
         assert_eq!(out[1].role, AiRole::User);
         assert_eq!(out[1].text_content(), format!("q0: {}", big_blob));
-        assert_eq!(out[3].role, AiRole::Assistant);
+        assert_eq!(out[3].role, AiRole::Developer);
         assert!(out[3].text_content().contains(COMPRESS_META_MARKER));
         assert_eq!(out[4].role, AiRole::User);
         assert!(out[4].text_content().contains(COMPRESS_SUMMARY_MARKER));
@@ -1848,7 +1848,7 @@ mod tests {
         let out = try_fold_agent_loop_history_block(&history, &deps, &range).unwrap();
         assert_eq!(out.len(), 3);
         assert_eq!(out[1].role, AiRole::User);
-        assert_eq!(out[2].role, AiRole::Assistant);
+        assert_eq!(out[2].role, AiRole::Developer);
         let text = out[2].text_content();
         let meta = read_mechanical_meta(&out[2]).unwrap();
         assert_eq!(meta.message_pairs_in_history_block, 2);

--- a/src/frame/aicc/Cargo.toml
+++ b/src/frame/aicc/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+regex = { workspace = true }
 buckyos-kit = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }

--- a/src/frame/aicc/driver_metadata/claude.json
+++ b/src/frame/aicc/driver_metadata/claude.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "provider_driver": "claude",
   "revision": "builtin-2026-05-30",
   "models": [],

--- a/src/frame/aicc/driver_metadata/fal.json
+++ b/src/frame/aicc/driver_metadata/fal.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "provider_driver": "fal",
   "revision": "builtin-2026-05-30",
   "models": [

--- a/src/frame/aicc/driver_metadata/gemini.json
+++ b/src/frame/aicc/driver_metadata/gemini.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "provider_driver": "google-gemini",
   "revision": "builtin-2026-05-30",
   "models": [

--- a/src/frame/aicc/driver_metadata/minimax.json
+++ b/src/frame/aicc/driver_metadata/minimax.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "provider_driver": "minimax",
   "revision": "builtin-2026-05-30",
   "models": [],

--- a/src/frame/aicc/driver_metadata/openai.json
+++ b/src/frame/aicc/driver_metadata/openai.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "provider_driver": "openai",
   "revision": "builtin-2026-05-30",
   "models": [

--- a/src/frame/aicc/driver_metadata/openrouter.json
+++ b/src/frame/aicc/driver_metadata/openrouter.json
@@ -1,2091 +1,2093 @@
 {
-    "schema_version":  2,
-    "provider_driver":  "openrouter",
-    "revision":  "builtin-2026-07-27-openai-reviewed",
-    "origin_provider_aliases":  {
-                                    "google":  "google-gemini",
-                                    "google-gemini":  "google-gemini",
-                                    "moonshotai":  "moonshot",
-                                    "x-ai":  "xai"
-                                },
-    "origin_mappings":  [
-                            {
-                                "mapping_key":  "openrouter-path-id",
-                                "priority":  100,
-                                "match":  {
-                                              "source":  "provider_model_id",
-                                              "regex":  "^(?\u003cdriver\u003e[^/]+)/(?\u003cmodel\u003e.+)$"
-                                          },
-                                "transforms":  {
-                                                   "driver":  [
-                                                                  {
-                                                                      "op":  "lowercase"
-                                                                  },
-                                                                  {
-                                                                      "op":  "alias",
-                                                                      "table":  "origin_provider_aliases",
-                                                                      "on_missing":  "keep"
-                                                                  }
-                                                              ],
-                                                   "model":  [
-                                                                 {
-                                                                     "op":  "trim"
-                                                                 }
-                                                             ]
-                                               }
-                            }
-                        ],
-    "models":  [
-                   {
-                       "id":  "openai/gpt-3.5-turbo",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  16385,
-                                            "max_output_tokens":  4096,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.002,
-                       "input_token_usd":  5E-07,
-                       "output_token_usd":  1.5E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-3.5-turbo-0613",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  4095,
-                                            "max_output_tokens":  4096,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.003,
-                       "input_token_usd":  1E-06,
-                       "output_token_usd":  2E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-3.5-turbo-16k",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  16385,
-                                            "max_output_tokens":  4096,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.007,
-                       "input_token_usd":  3E-06,
-                       "output_token_usd":  4E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-3.5-turbo-instruct",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  false,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  4095,
-                                            "max_output_tokens":  4096,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.0035,
-                       "input_token_usd":  1.5E-06,
-                       "output_token_usd":  2E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  8191,
-                                            "max_output_tokens":  4096,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.090000000000000011,
-                       "input_token_usd":  3E-05,
-                       "output_token_usd":  6E-05,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4.1",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1047576,
-                                            "max_output_tokens":  32768,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0099999999999999985,
-                       "input_token_usd":  2E-06,
-                       "output_token_usd":  8E-06,
-                       "cache_input_token_usd":  5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4.1-mini",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1047576,
-                                            "max_output_tokens":  32768,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.002,
-                       "input_token_usd":  4E-07,
-                       "output_token_usd":  1.6E-06,
-                       "cache_input_token_usd":  1E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4.1-nano",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1047576,
-                                            "max_output_tokens":  32768,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0005,
-                       "input_token_usd":  1E-07,
-                       "output_token_usd":  4E-07,
-                       "cache_input_token_usd":  2.5E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0125,
-                       "input_token_usd":  2.5E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o-2024-05-13",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  4096,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.02,
-                       "input_token_usd":  5E-06,
-                       "output_token_usd":  1.5E-05,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o-2024-08-06",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0125,
-                       "input_token_usd":  2.5E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o-2024-11-20",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0125,
-                       "input_token_usd":  2.5E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o-mini",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.00075,
-                       "input_token_usd":  1.5E-07,
-                       "output_token_usd":  6E-07,
-                       "cache_input_token_usd":  7.5E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o-mini-2024-07-18",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.00075,
-                       "input_token_usd":  1.5E-07,
-                       "output_token_usd":  6E-07,
-                       "cache_input_token_usd":  7.5E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o-mini-search-preview",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  false,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.00075,
-                       "input_token_usd":  1.5E-07,
-                       "output_token_usd":  6E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4o-search-preview",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  false,
-                                            "json_schema":  true,
-                                            "web_search":  true,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.0125,
-                       "input_token_usd":  2.5E-06,
-                       "output_token_usd":  1E-05,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4-turbo",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  4096,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.04,
-                       "input_token_usd":  1E-05,
-                       "output_token_usd":  3E-05,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-4-turbo-preview",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  4096,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.04,
-                       "input_token_usd":  1E-05,
-                       "output_token_usd":  3E-05,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.011250000000000001,
-                       "input_token_usd":  1.25E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.1",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.011250000000000001,
-                       "input_token_usd":  1.25E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.1-chat",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.011250000000000001,
-                       "input_token_usd":  1.25E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.1-codex",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.011250000000000001,
-                       "input_token_usd":  1.25E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.1-codex-max",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.011250000000000001,
-                       "input_token_usd":  1.25E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.1-codex-mini",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  100000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0022500000000000003,
-                       "input_token_usd":  2.5E-07,
-                       "output_token_usd":  2E-06,
-                       "cache_input_token_usd":  2.5E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.2",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.01575,
-                       "input_token_usd":  1.75E-06,
-                       "output_token_usd":  1.4E-05,
-                       "cache_input_token_usd":  1.75E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.2-chat",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.01575,
-                       "input_token_usd":  1.75E-06,
-                       "output_token_usd":  1.4E-05,
-                       "cache_input_token_usd":  1.75E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.2-codex",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.01575,
-                       "input_token_usd":  1.75E-06,
-                       "output_token_usd":  1.4E-05,
-                       "cache_input_token_usd":  1.75E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.2-pro",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.18899999999999997,
-                       "input_token_usd":  2.1E-05,
-                       "output_token_usd":  0.000168,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.3-chat",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.01575,
-                       "input_token_usd":  1.75E-06,
-                       "output_token_usd":  1.4E-05,
-                       "cache_input_token_usd":  1.75E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.3-codex",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.01575,
-                       "input_token_usd":  1.75E-06,
-                       "output_token_usd":  1.4E-05,
-                       "cache_input_token_usd":  1.75E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.4",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0175,
-                       "input_token_usd":  2.5E-06,
-                       "output_token_usd":  1.5E-05,
-                       "cache_input_token_usd":  2.5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.4-mini",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.00525,
-                       "input_token_usd":  7.5E-07,
-                       "output_token_usd":  4.5E-06,
-                       "cache_input_token_usd":  7.5E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.4-nano",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0014500000000000001,
-                       "input_token_usd":  2E-07,
-                       "output_token_usd":  1.25E-06,
-                       "cache_input_token_usd":  2E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.4-pro",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.21000000000000002,
-                       "input_token_usd":  3E-05,
-                       "output_token_usd":  0.00018,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.5",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.035,
-                       "input_token_usd":  5E-06,
-                       "output_token_usd":  3E-05,
-                       "cache_input_token_usd":  5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.5-pro",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.21000000000000002,
-                       "input_token_usd":  3E-05,
-                       "output_token_usd":  0.00018,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.6-luna",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.007,
-                       "input_token_usd":  1E-06,
-                       "output_token_usd":  6E-06,
-                       "cache_input_token_usd":  1E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.6-sol",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.035,
-                       "input_token_usd":  5E-06,
-                       "output_token_usd":  3E-05,
-                       "cache_input_token_usd":  5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5.6-terra",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0175,
-                       "input_token_usd":  2.5E-06,
-                       "output_token_usd":  1.5E-05,
-                       "cache_input_token_usd":  2.5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5-chat",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  false,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.011250000000000001,
-                       "input_token_usd":  1.25E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5-codex",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.011250000000000001,
-                       "input_token_usd":  1.25E-06,
-                       "output_token_usd":  1E-05,
-                       "cache_input_token_usd":  1.25E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5-mini",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0022500000000000003,
-                       "input_token_usd":  2.5E-07,
-                       "output_token_usd":  2E-06,
-                       "cache_input_token_usd":  2.5E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5-nano",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.00045,
-                       "input_token_usd":  5E-08,
-                       "output_token_usd":  4E-07,
-                       "cache_input_token_usd":  5E-09,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-5-pro",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.135,
-                       "input_token_usd":  1.5E-05,
-                       "output_token_usd":  0.00012,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-oss-120b",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  131072,
-                                            "max_output_tokens":  131072,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.000207,
-                       "input_token_usd":  3.7E-08,
-                       "output_token_usd":  1.7E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-oss-20b",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  131072,
-                                            "max_output_tokens":  131072,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.00016,
-                       "input_token_usd":  3E-08,
-                       "output_token_usd":  1.3E-07,
-                       "cache_input_token_usd":  3E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/gpt-oss-safeguard-20b",
-                       "api_types":  [
-                                         "llm",
-                                         "rerank"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.openai.{model}",
-                                              "rerank",
-                                              "rerank.openai",
-                                              "rerank.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "web_search":  false,
-                                            "max_context_tokens":  131072,
-                                            "max_output_tokens":  65536,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.000375,
-                       "input_token_usd":  7.5E-08,
-                       "output_token_usd":  3E-07,
-                       "cache_input_token_usd":  3.75E-08,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.9,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
-                   },
-                   {
-                       "id":  "openai/o1",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  false,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.075000000000000011,
-                       "input_token_usd":  1.5E-05,
-                       "output_token_usd":  6E-05,
-                       "cache_input_token_usd":  7.5E-06,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/o1-pro",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  false,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  false,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.74999999999999989,
-                       "input_token_usd":  0.00015,
-                       "output_token_usd":  0.0006,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/o3",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  false,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0099999999999999985,
-                       "input_token_usd":  2E-06,
-                       "output_token_usd":  8E-06,
-                       "cache_input_token_usd":  5E-07,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/o3-deep-research",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  true,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.05,
-                       "input_token_usd":  1E-05,
-                       "output_token_usd":  4E-05,
-                       "cache_input_token_usd":  2.5E-06,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/o3-mini",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  false,
-                                            "vision":  false
-                                        },
-                       "estimated_cost_usd":  0.0055,
-                       "input_token_usd":  1.1E-06,
-                       "output_token_usd":  4.4E-06,
-                       "cache_input_token_usd":  5.5E-07,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/o3-pro",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  false,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.1,
-                       "input_token_usd":  2E-05,
-                       "output_token_usd":  8E-05,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/o4-mini",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  false,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0055,
-                       "input_token_usd":  1.1E-06,
-                       "output_token_usd":  4.4E-06,
-                       "cache_input_token_usd":  2.75E-07,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/o4-mini-deep-research",
-                       "api_types":  [
-                                         "llm"
-                                     ],
-                       "logical_mounts":  [
-                                              "llm.{driver}",
-                                              "llm.gpt",
-                                              "llm.openai.{model}"
-                                          ],
-                       "capabilities":  {
-                                            "streaming":  true,
-                                            "tool_call":  true,
-                                            "json_schema":  true,
-                                            "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000,
-                                            "web_search":  true,
-                                            "vision":  true
-                                        },
-                       "estimated_cost_usd":  0.0099999999999999985,
-                       "input_token_usd":  2E-06,
-                       "output_token_usd":  8E-06,
-                       "cache_input_token_usd":  5E-07,
-                       "estimated_latency_ms":  1200
-                   },
-                   {
-                       "id":  "openai/gpt-5.4-image-2",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-5.6-luna-pro",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-5.6-sol-pro",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-5.6-terra-pro",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-5-image",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-5-image-mini",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-audio",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-audio-mini",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-chat-latest",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/gpt-oss-20b:free",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/o3-mini-high",
-                       "exclude":  true
-                   },
-                   {
-                       "id":  "openai/o4-mini-high",
-                       "exclude":  true
-                   }
-               ],
-    "patterns":  [
-                     {
-                         "pattern":  "openai/*transcribe*",
-                         "api_types":  [
-                                           "audio.asr"
-                                       ],
-                         "logical_mounts":  [
-                                                "audio.asr",
-                                                "audio.asr.{driver}",
-                                                "audio.asr.{model}"
-                                            ],
-                         "estimated_cost_usd":  0.006,
-                         "estimated_latency_ms":  5000
-                     },
-                     {
-                         "pattern":  "openai/*-tts*",
-                         "api_types":  [
-                                           "audio.tts"
-                                       ],
-                         "logical_mounts":  [
-                                                "audio.tts",
-                                                "audio.tts.{driver}",
-                                                "audio.tts.{model}"
-                                            ],
-                         "estimated_cost_usd":  0.015,
-                         "estimated_latency_ms":  3000
-                     },
-                     {
-                         "pattern":  "openai/*audio*",
-                         "exclude":  true
-                     },
-                     {
-                         "pattern":  "openai/*realtime*",
-                         "exclude":  true
-                     },
-                     {
-                         "pattern":  "openai/dall-e-*",
-                         "api_types":  [
-                                           "image.txt2img"
-                                       ],
-                         "logical_mounts":  [
-                                                "image.txt2img.{driver}",
-                                                "image.txt2img.dalle",
-                                                "image.txt2img.{model}"
-                                            ],
-                         "estimated_cost_usd":  0.04,
-                         "estimated_latency_ms":  5000
-                     },
-                     {
-                         "pattern":  "openai/gpt-image-*",
-                         "api_types":  [
-                                           "image.txt2img",
-                                           "image.img2img",
-                                           "image.inpaint"
-                                       ],
-                         "logical_mounts":  [
-                                                "image.txt2img.{driver}",
-                                                "image.txt2img.gpt_image",
-                                                "image.txt2img.{model}",
-                                                "image.img2img",
-                                                "image.img2img.{driver}",
-                                                "image.img2img.{model}",
-                                                "image.inpaint",
-                                                "image.inpaint.{driver}",
-                                                "image.inpaint.{model}"
-                                            ],
-                         "estimated_cost_usd":  0.04,
-                         "estimated_latency_ms":  5000,
-                         "quality_score":  0.9
-                     },
-                     {
-                         "pattern":  "openai/text-embedding-*",
-                         "api_types":  [
-                                           "embedding.text"
-                                       ],
-                         "logical_mounts":  [
-                                                "embedding.text",
-                                                "embedding.text.{driver}",
-                                                "embedding.text.{model}"
-                                            ],
-                         "estimated_cost_usd":  0.0001,
-                         "estimated_latency_ms":  800
-                     },
-                     {
-                         "pattern":  "openai/gpt-*",
-                         "api_types":  [
-                                           "llm",
-                                           "rerank"
-                                       ],
-                         "logical_mounts":  [
-                                                "llm.{driver}",
-                                                "llm.openai.{model}",
-                                                "rerank",
-                                                "rerank.openai",
-                                                "rerank.{model}"
-                                            ],
-                         "capabilities":  {
-                                              "streaming":  true,
-                                              "tool_call":  true,
-                                              "json_schema":  true,
-                                              "web_search":  true,
-                                              "max_context_tokens":  128000,
-                                              "max_output_tokens":  8192
-                                          },
-                         "estimated_cost_usd":  0.01,
-                         "estimated_latency_ms":  1200,
-                         "quality_score":  0.9,
-                         "latency_class":  "normal",
-                         "cost_class":  "medium"
-                     },
-                     {
-                         "pattern":  "openai/chatgpt-*",
-                         "api_types":  [
-                                           "llm"
-                                       ],
-                         "logical_mounts":  [
-                                                "llm.{driver}",
-                                                "llm.openai.{model}"
-                                            ],
-                         "capabilities":  {
-                                              "streaming":  true,
-                                              "tool_call":  true,
-                                              "json_schema":  true,
-                                              "web_search":  true,
-                                              "vision":  true,
-                                              "max_context_tokens":  128000,
-                                              "max_output_tokens":  8192
-                                          },
-                         "estimated_cost_usd":  0.01,
-                         "estimated_latency_ms":  1200
-                     },
-                     {
-                         "pattern":  "openai/o*",
-                         "api_types":  [
-                                           "llm"
-                                       ],
-                         "logical_mounts":  [
-                                                "llm.{driver}",
-                                                "llm.gpt",
-                                                "llm.openai.{model}"
-                                            ],
-                         "capabilities":  {
-                                              "streaming":  true,
-                                              "tool_call":  true,
-                                              "json_schema":  true,
-                                              "max_context_tokens":  128000,
-                                              "max_output_tokens":  8192
-                                          },
-                         "estimated_cost_usd":  0.01,
-                         "estimated_latency_ms":  1200
-                     },
-                     {
-                         "pattern":  "openai/*",
-                         "api_types":  [
-                                           "llm"
-                                       ],
-                         "logical_mounts":  [
-                                                "llm.{driver}",
-                                                "llm.{driver}.{model}"
-                                            ],
-                         "capabilities":  {
-                                              "streaming":  false,
-                                              "tool_call":  false,
-                                              "json_schema":  false,
-                                              "web_search":  false,
-                                              "vision":  false
-                                          },
-                         "estimated_cost_usd":  0.01,
-                         "estimated_latency_ms":  1200
-                     },
-                     {
-                         "pattern":  "*",
-                         "exclude":  true
-                     }
-                 ],
-    "defaults":  {
-                     "api_types":  [
-                                       "llm"
-                                   ],
-                     "logical_mounts":  [
-                                            "llm.{driver}",
-                                            "llm.{driver}.{model}"
-                                        ],
-                     "capabilities":  {
-                                          "streaming":  false,
-                                          "tool_call":  false,
-                                          "json_schema":  false,
-                                          "web_search":  false,
-                                          "vision":  false
-                                      },
-                     "estimated_cost_usd":  0.01,
-                     "estimated_latency_ms":  1200
-                 },
-    "variants":  [
-                     {
-                         "name":  "reasoning.low",
-                         "mount_suffix":  "reasoning-low",
-                         "provider_options":  {
-                                                  "reasoning":  {
-                                                                    "effort":  "low"
-                                                                }
-                                              }
-                     },
-                     {
-                         "name":  "reasoning.high",
-                         "mount_suffix":  "reasoning-high",
-                         "provider_options":  {
-                                                  "reasoning":  {
-                                                                    "effort":  "high"
-                                                                }
-                                              }
-                     }
-                 ],
-    "version_rules":  [
-                          {
-                              "family":  "gpt",
-                              "tier":  "standard",
-                              "model_pattern":  "openai/gpt-*",
-                              "exclude_tier_tokens":  [
-                                                          "pro",
-                                                          "mini",
-                                                          "nano",
-                                                          "nono"
-                                                      ],
-                              "version_rank":  {
-                                                   "prefix":  "gpt"
-                                               },
-                              "stability":  {
-                                                "unstable_tokens":  [
-                                                                        "preview",
-                                                                        "experimental",
-                                                                        "beta"
-                                                                    ],
-                                                "current_requires_stable":  true
-                                            },
-                              "current_mount":  "llm.gpt-standard",
-                              "version_mount":  "llm.openai.{model}",
-                              "auto_mounts":  [
-                                                  "llm.gpt",
-                                                  "llm.gpt-standard",
-                                                  "llm.gpt-pro",
-                                                  "llm.gpt-mini",
-                                                  "llm.gpt-nano",
-                                                  "llm",
-                                                  "llm.summarize",
-                                                  "llm.swift",
-                                                  "llm.plan",
-                                                  "llm.reason",
-                                                  "llm.code"
-                                              ],
-                              "exclude_snapshot_date_suffix":  true,
-                              "capabilities":  {
-                                                   "vision":  true
-                                               }
-                          },
-                          {
-                              "family":  "gpt",
-                              "tier":  "pro",
-                              "model_pattern":  "openai/gpt-*",
-                              "tier_tokens":  [
-                                                  "pro"
-                                              ],
-                              "version_rank":  {
-                                                   "prefix":  "gpt"
-                                               },
-                              "stability":  {
-                                                "unstable_tokens":  [
-                                                                        "preview",
-                                                                        "experimental",
-                                                                        "beta"
-                                                                    ],
-                                                "current_requires_stable":  true
-                                            },
-                              "current_mount":  "llm.gpt-pro",
-                              "version_mount":  "llm.openai.{model}",
-                              "auto_mounts":  [
-                                                  "llm.gpt",
-                                                  "llm.gpt-standard",
-                                                  "llm.gpt-pro",
-                                                  "llm.gpt-mini",
-                                                  "llm.gpt-nano",
-                                                  "llm",
-                                                  "llm.summarize",
-                                                  "llm.swift",
-                                                  "llm.plan",
-                                                  "llm.reason",
-                                                  "llm.code"
-                                              ],
-                              "exclude_snapshot_date_suffix":  true
-                          },
-                          {
-                              "family":  "gpt",
-                              "tier":  "mini",
-                              "model_pattern":  "openai/gpt-*",
-                              "tier_tokens":  [
-                                                  "mini"
-                                              ],
-                              "version_rank":  {
-                                                   "prefix":  "gpt"
-                                               },
-                              "stability":  {
-                                                "unstable_tokens":  [
-                                                                        "preview",
-                                                                        "experimental",
-                                                                        "beta"
-                                                                    ],
-                                                "current_requires_stable":  true
-                                            },
-                              "current_mount":  "llm.gpt-mini",
-                              "version_mount":  "llm.openai.{model}",
-                              "auto_mounts":  [
-                                                  "llm.gpt",
-                                                  "llm.gpt-standard",
-                                                  "llm.gpt-pro",
-                                                  "llm.gpt-mini",
-                                                  "llm.gpt-nano",
-                                                  "llm",
-                                                  "llm.summarize",
-                                                  "llm.swift",
-                                                  "llm.plan",
-                                                  "llm.reason",
-                                                  "llm.code"
-                                              ],
-                              "exclude_snapshot_date_suffix":  true
-                          },
-                          {
-                              "family":  "gpt",
-                              "tier":  "nano",
-                              "model_pattern":  "openai/gpt-*",
-                              "tier_tokens":  [
-                                                  "nano",
-                                                  "nono"
-                                              ],
-                              "version_rank":  {
-                                                   "prefix":  "gpt"
-                                               },
-                              "stability":  {
-                                                "unstable_tokens":  [
-                                                                        "preview",
-                                                                        "experimental",
-                                                                        "beta"
-                                                                    ],
-                                                "current_requires_stable":  true
-                                            },
-                              "current_mount":  "llm.gpt-nano",
-                              "version_mount":  "llm.openai.{model}",
-                              "auto_mounts":  [
-                                                  "llm.gpt",
-                                                  "llm.gpt-standard",
-                                                  "llm.gpt-pro",
-                                                  "llm.gpt-mini",
-                                                  "llm.gpt-nano",
-                                                  "llm",
-                                                  "llm.summarize",
-                                                  "llm.swift",
-                                                  "llm.plan",
-                                                  "llm.reason",
-                                                  "llm.code"
-                                              ],
-                              "exclude_snapshot_date_suffix":  true
-                          }
-                      ],
-    "signature":  null
+  "schema_version": 2,
+  "provider_driver": "openrouter",
+  "revision": "builtin-2026-07-27-openai-reviewed",
+  "origin_provider_aliases": {
+    "google": "google-gemini",
+    "google-gemini": "google-gemini",
+    "moonshotai": "moonshot",
+    "x-ai": "xai"
+  },
+  "origin_mappings": [
+    {
+      "mapping_key": "openrouter-path-id",
+      "priority": 100,
+      "match": {
+        "source": "provider_model_id",
+        "regex": "^(?<driver>[^/]+)/(?<model>.+)$"
+      },
+      "transforms": {
+        "driver": [
+          {
+            "op": "lowercase"
+          },
+          {
+            "op": "alias",
+            "table": "origin_provider_aliases",
+            "on_missing": "keep"
+          }
+        ],
+        "model": [
+          {
+            "op": "trim"
+          }
+        ]
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "openai/gpt-3.5-turbo",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 16385,
+        "max_output_tokens": 4096,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.002,
+      "input_token_usd": 5e-7,
+      "output_token_usd": 0.0000015,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-0613",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 4095,
+        "max_output_tokens": 4096,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.003,
+      "input_token_usd": 0.000001,
+      "output_token_usd": 0.000002,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-16k",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 16385,
+        "max_output_tokens": 4096,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.007,
+      "input_token_usd": 0.000003,
+      "output_token_usd": 0.000004,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-instruct",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": false,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 4095,
+        "max_output_tokens": 4096,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.0035,
+      "input_token_usd": 0.0000015,
+      "output_token_usd": 0.000002,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 8191,
+        "max_output_tokens": 4096,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.09000000000000001,
+      "input_token_usd": 0.00003,
+      "output_token_usd": 0.00006,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4.1",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.009999999999999998,
+      "input_token_usd": 0.000002,
+      "output_token_usd": 0.000008,
+      "cache_input_token_usd": 5e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4.1-mini",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.002,
+      "input_token_usd": 4e-7,
+      "output_token_usd": 0.0000016,
+      "cache_input_token_usd": 1e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4.1-nano",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0005,
+      "input_token_usd": 1e-7,
+      "output_token_usd": 4e-7,
+      "cache_input_token_usd": 2.5e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0125,
+      "input_token_usd": 0.0000025,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 0.00000125,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o-2024-05-13",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 4096,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.02,
+      "input_token_usd": 0.000005,
+      "output_token_usd": 0.000015,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o-2024-08-06",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0125,
+      "input_token_usd": 0.0000025,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 0.00000125,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o-2024-11-20",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0125,
+      "input_token_usd": 0.0000025,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 0.00000125,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o-mini",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.00075,
+      "input_token_usd": 1.5e-7,
+      "output_token_usd": 6e-7,
+      "cache_input_token_usd": 7.5e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o-mini-2024-07-18",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.00075,
+      "input_token_usd": 1.5e-7,
+      "output_token_usd": 6e-7,
+      "cache_input_token_usd": 7.5e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o-mini-search-preview",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": false,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.00075,
+      "input_token_usd": 1.5e-7,
+      "output_token_usd": 6e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4o-search-preview",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": false,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.0125,
+      "input_token_usd": 0.0000025,
+      "output_token_usd": 0.00001,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4-turbo",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 4096,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.04,
+      "input_token_usd": 0.00001,
+      "output_token_usd": 0.00003,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-4-turbo-preview",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 4096,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.04,
+      "input_token_usd": 0.00001,
+      "output_token_usd": 0.00003,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.011250000000000001,
+      "input_token_usd": 0.00000125,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 1.25e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.1",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.011250000000000001,
+      "input_token_usd": 0.00000125,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 1.25e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.1-chat",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.011250000000000001,
+      "input_token_usd": 0.00000125,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 1.25e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.1-codex",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.011250000000000001,
+      "input_token_usd": 0.00000125,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 1.25e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.1-codex-max",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.011250000000000001,
+      "input_token_usd": 0.00000125,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 1.25e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.1-codex-mini",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 100000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0022500000000000003,
+      "input_token_usd": 2.5e-7,
+      "output_token_usd": 0.000002,
+      "cache_input_token_usd": 2.5e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.2",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.01575,
+      "input_token_usd": 0.00000175,
+      "output_token_usd": 0.000014,
+      "cache_input_token_usd": 1.75e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.2-chat",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.01575,
+      "input_token_usd": 0.00000175,
+      "output_token_usd": 0.000014,
+      "cache_input_token_usd": 1.75e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.2-codex",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.01575,
+      "input_token_usd": 0.00000175,
+      "output_token_usd": 0.000014,
+      "cache_input_token_usd": 1.75e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.2-pro",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.18899999999999997,
+      "input_token_usd": 0.000021,
+      "output_token_usd": 0.000168,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.3-chat",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.01575,
+      "input_token_usd": 0.00000175,
+      "output_token_usd": 0.000014,
+      "cache_input_token_usd": 1.75e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.3-codex",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.01575,
+      "input_token_usd": 0.00000175,
+      "output_token_usd": 0.000014,
+      "cache_input_token_usd": 1.75e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.4",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0175,
+      "input_token_usd": 0.0000025,
+      "output_token_usd": 0.000015,
+      "cache_input_token_usd": 2.5e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.4-mini",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.00525,
+      "input_token_usd": 7.5e-7,
+      "output_token_usd": 0.0000045,
+      "cache_input_token_usd": 7.5e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.4-nano",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0014500000000000001,
+      "input_token_usd": 2e-7,
+      "output_token_usd": 0.00000125,
+      "cache_input_token_usd": 2e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.4-pro",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.21000000000000002,
+      "input_token_usd": 0.00003,
+      "output_token_usd": 0.00018,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.5",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.035,
+      "input_token_usd": 0.000005,
+      "output_token_usd": 0.00003,
+      "cache_input_token_usd": 5e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.5-pro",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.21000000000000002,
+      "input_token_usd": 0.00003,
+      "output_token_usd": 0.00018,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.6-luna",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.007,
+      "input_token_usd": 0.000001,
+      "output_token_usd": 0.000006,
+      "cache_input_token_usd": 1e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.6-sol",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.035,
+      "input_token_usd": 0.000005,
+      "output_token_usd": 0.00003,
+      "cache_input_token_usd": 5e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5.6-terra",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0175,
+      "input_token_usd": 0.0000025,
+      "output_token_usd": 0.000015,
+      "cache_input_token_usd": 2.5e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5-chat",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": false,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 16384,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.011250000000000001,
+      "input_token_usd": 0.00000125,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 1.25e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5-codex",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.011250000000000001,
+      "input_token_usd": 0.00000125,
+      "output_token_usd": 0.00001,
+      "cache_input_token_usd": 1.25e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5-mini",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0022500000000000003,
+      "input_token_usd": 2.5e-7,
+      "output_token_usd": 0.000002,
+      "cache_input_token_usd": 2.5e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5-nano",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.00045,
+      "input_token_usd": 5e-8,
+      "output_token_usd": 4e-7,
+      "cache_input_token_usd": 5e-9,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-5-pro",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 400000,
+        "max_output_tokens": 128000,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.135,
+      "input_token_usd": 0.000015,
+      "output_token_usd": 0.00012,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 131072,
+        "max_output_tokens": 131072,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.000207,
+      "input_token_usd": 3.7e-8,
+      "output_token_usd": 1.7e-7,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-oss-20b",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 131072,
+        "max_output_tokens": 131072,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.00016,
+      "input_token_usd": 3e-8,
+      "output_token_usd": 1.3e-7,
+      "cache_input_token_usd": 3e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/gpt-oss-safeguard-20b",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": false,
+        "max_context_tokens": 131072,
+        "max_output_tokens": 65536,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.000375,
+      "input_token_usd": 7.5e-8,
+      "output_token_usd": 3e-7,
+      "cache_input_token_usd": 3.75e-8,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "id": "openai/o1",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": false,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.07500000000000001,
+      "input_token_usd": 0.000015,
+      "output_token_usd": 0.00006,
+      "cache_input_token_usd": 0.0000075,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/o1-pro",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": false,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": false,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.7499999999999999,
+      "input_token_usd": 0.00015,
+      "output_token_usd": 0.0006,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/o3",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": false,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.009999999999999998,
+      "input_token_usd": 0.000002,
+      "output_token_usd": 0.000008,
+      "cache_input_token_usd": 5e-7,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/o3-deep-research",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": true,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.05,
+      "input_token_usd": 0.00001,
+      "output_token_usd": 0.00004,
+      "cache_input_token_usd": 0.0000025,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/o3-mini",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": false,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.0055,
+      "input_token_usd": 0.0000011,
+      "output_token_usd": 0.0000044,
+      "cache_input_token_usd": 5.5e-7,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/o3-pro",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": false,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.1,
+      "input_token_usd": 0.00002,
+      "output_token_usd": 0.00008,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/o4-mini",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": false,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.0055,
+      "input_token_usd": 0.0000011,
+      "output_token_usd": 0.0000044,
+      "cache_input_token_usd": 2.75e-7,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/o4-mini-deep-research",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 200000,
+        "max_output_tokens": 100000,
+        "web_search": true,
+        "vision": true
+      },
+      "estimated_cost_usd": 0.009999999999999998,
+      "input_token_usd": 0.000002,
+      "output_token_usd": 0.000008,
+      "cache_input_token_usd": 5e-7,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "id": "openai/gpt-5.4-image-2",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-5.6-luna-pro",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-5.6-sol-pro",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-5.6-terra-pro",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-5-image",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-5-image-mini",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-audio",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-audio-mini",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-chat-latest",
+      "exclude": true
+    },
+    {
+      "id": "openai/gpt-oss-20b:free",
+      "exclude": true
+    },
+    {
+      "id": "openai/o3-mini-high",
+      "exclude": true
+    },
+    {
+      "id": "openai/o4-mini-high",
+      "exclude": true
+    }
+  ],
+  "patterns": [
+    {
+      "pattern": "openai/*transcribe*",
+      "api_types": [
+        "audio.asr"
+      ],
+      "logical_mounts": [
+        "audio.asr",
+        "audio.asr.{driver}",
+        "audio.asr.{model}"
+      ],
+      "estimated_cost_usd": 0.006,
+      "estimated_latency_ms": 5000
+    },
+    {
+      "pattern": "openai/*-tts*",
+      "api_types": [
+        "audio.tts"
+      ],
+      "logical_mounts": [
+        "audio.tts",
+        "audio.tts.{driver}",
+        "audio.tts.{model}"
+      ],
+      "estimated_cost_usd": 0.015,
+      "estimated_latency_ms": 3000
+    },
+    {
+      "pattern": "openai/*audio*",
+      "exclude": true
+    },
+    {
+      "pattern": "openai/*realtime*",
+      "exclude": true
+    },
+    {
+      "pattern": "openai/dall-e-*",
+      "api_types": [
+        "image.txt2img"
+      ],
+      "logical_mounts": [
+        "image.txt2img.{driver}",
+        "image.txt2img.dalle",
+        "image.txt2img.{model}"
+      ],
+      "estimated_cost_usd": 0.04,
+      "estimated_latency_ms": 5000
+    },
+    {
+      "pattern": "openai/gpt-image-*",
+      "api_types": [
+        "image.txt2img",
+        "image.img2img",
+        "image.inpaint"
+      ],
+      "logical_mounts": [
+        "image.txt2img.{driver}",
+        "image.txt2img.gpt_image",
+        "image.txt2img.{model}",
+        "image.img2img",
+        "image.img2img.{driver}",
+        "image.img2img.{model}",
+        "image.inpaint",
+        "image.inpaint.{driver}",
+        "image.inpaint.{model}"
+      ],
+      "estimated_cost_usd": 0.04,
+      "estimated_latency_ms": 5000,
+      "quality_score": 0.9
+    },
+    {
+      "pattern": "openai/text-embedding-*",
+      "api_types": [
+        "embedding.text"
+      ],
+      "logical_mounts": [
+        "embedding.text",
+        "embedding.text.{driver}",
+        "embedding.text.{model}"
+      ],
+      "estimated_cost_usd": 0.0001,
+      "estimated_latency_ms": 800
+    },
+    {
+      "pattern": "openai/gpt-*",
+      "api_types": [
+        "llm",
+        "rerank"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}",
+        "rerank",
+        "rerank.openai",
+        "rerank.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 8192
+      },
+      "estimated_cost_usd": 0.01,
+      "estimated_latency_ms": 1200,
+      "quality_score": 0.9,
+      "latency_class": "normal",
+      "cost_class": "medium"
+    },
+    {
+      "pattern": "openai/chatgpt-*",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "web_search": true,
+        "vision": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 8192
+      },
+      "estimated_cost_usd": 0.01,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "pattern": "openai/o*",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.gpt",
+        "llm.openai.{model}"
+      ],
+      "capabilities": {
+        "streaming": true,
+        "tool_call": true,
+        "json_schema": true,
+        "max_context_tokens": 128000,
+        "max_output_tokens": 8192
+      },
+      "estimated_cost_usd": 0.01,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "pattern": "openai/*",
+      "api_types": [
+        "llm"
+      ],
+      "logical_mounts": [
+        "llm.{driver}",
+        "llm.{driver}.{model}"
+      ],
+      "capabilities": {
+        "streaming": false,
+        "tool_call": false,
+        "json_schema": false,
+        "web_search": false,
+        "vision": false
+      },
+      "estimated_cost_usd": 0.01,
+      "estimated_latency_ms": 1200
+    },
+    {
+      "pattern": "*",
+      "exclude": true
+    }
+  ],
+  "defaults": {
+    "api_types": [
+      "llm"
+    ],
+    "logical_mounts": [
+      "llm.{driver}",
+      "llm.{driver}.{model}"
+    ],
+    "capabilities": {
+      "streaming": false,
+      "tool_call": false,
+      "json_schema": false,
+      "web_search": false,
+      "vision": false
+    },
+    "estimated_cost_usd": 0.01,
+    "estimated_latency_ms": 1200
+  },
+  "variants": [
+    {
+      "name": "reasoning.low",
+      "model_pattern": "openai/*",
+      "mount_suffix": "reasoning-low",
+      "provider_options": {
+        "reasoning": {
+          "effort": "low"
+        }
+      }
+    },
+    {
+      "name": "reasoning.high",
+      "model_pattern": "openai/*",
+      "mount_suffix": "reasoning-high",
+      "provider_options": {
+        "reasoning": {
+          "effort": "high"
+        }
+      }
+    }
+  ],
+  "version_rules": [
+    {
+      "family": "gpt",
+      "tier": "standard",
+      "model_pattern": "openai/gpt-*",
+      "exclude_tier_tokens": [
+        "pro",
+        "mini",
+        "nano",
+        "nono"
+      ],
+      "version_rank": {
+        "prefix": "gpt"
+      },
+      "stability": {
+        "unstable_tokens": [
+          "preview",
+          "experimental",
+          "beta"
+        ],
+        "current_requires_stable": true
+      },
+      "current_mount": "llm.gpt-standard",
+      "version_mount": "llm.openai.{model}",
+      "auto_mounts": [
+        "llm.gpt",
+        "llm.gpt-standard",
+        "llm.gpt-pro",
+        "llm.gpt-mini",
+        "llm.gpt-nano",
+        "llm",
+        "llm.summarize",
+        "llm.swift",
+        "llm.plan",
+        "llm.reason",
+        "llm.code"
+      ],
+      "exclude_snapshot_date_suffix": true,
+      "capabilities": {
+        "vision": true
+      }
+    },
+    {
+      "family": "gpt",
+      "tier": "pro",
+      "model_pattern": "openai/gpt-*",
+      "tier_tokens": [
+        "pro"
+      ],
+      "version_rank": {
+        "prefix": "gpt"
+      },
+      "stability": {
+        "unstable_tokens": [
+          "preview",
+          "experimental",
+          "beta"
+        ],
+        "current_requires_stable": true
+      },
+      "current_mount": "llm.gpt-pro",
+      "version_mount": "llm.openai.{model}",
+      "auto_mounts": [
+        "llm.gpt",
+        "llm.gpt-standard",
+        "llm.gpt-pro",
+        "llm.gpt-mini",
+        "llm.gpt-nano",
+        "llm",
+        "llm.summarize",
+        "llm.swift",
+        "llm.plan",
+        "llm.reason",
+        "llm.code"
+      ],
+      "exclude_snapshot_date_suffix": true
+    },
+    {
+      "family": "gpt",
+      "tier": "mini",
+      "model_pattern": "openai/gpt-*",
+      "tier_tokens": [
+        "mini"
+      ],
+      "version_rank": {
+        "prefix": "gpt"
+      },
+      "stability": {
+        "unstable_tokens": [
+          "preview",
+          "experimental",
+          "beta"
+        ],
+        "current_requires_stable": true
+      },
+      "current_mount": "llm.gpt-mini",
+      "version_mount": "llm.openai.{model}",
+      "auto_mounts": [
+        "llm.gpt",
+        "llm.gpt-standard",
+        "llm.gpt-pro",
+        "llm.gpt-mini",
+        "llm.gpt-nano",
+        "llm",
+        "llm.summarize",
+        "llm.swift",
+        "llm.plan",
+        "llm.reason",
+        "llm.code"
+      ],
+      "exclude_snapshot_date_suffix": true
+    },
+    {
+      "family": "gpt",
+      "tier": "nano",
+      "model_pattern": "openai/gpt-*",
+      "tier_tokens": [
+        "nano",
+        "nono"
+      ],
+      "version_rank": {
+        "prefix": "gpt"
+      },
+      "stability": {
+        "unstable_tokens": [
+          "preview",
+          "experimental",
+          "beta"
+        ],
+        "current_requires_stable": true
+      },
+      "current_mount": "llm.gpt-nano",
+      "version_mount": "llm.openai.{model}",
+      "auto_mounts": [
+        "llm.gpt",
+        "llm.gpt-standard",
+        "llm.gpt-pro",
+        "llm.gpt-mini",
+        "llm.gpt-nano",
+        "llm",
+        "llm.summarize",
+        "llm.swift",
+        "llm.plan",
+        "llm.reason",
+        "llm.code"
+      ],
+      "exclude_snapshot_date_suffix": true
+    }
+  ],
+  "signature": null
 }

--- a/src/frame/aicc/driver_metadata/openrouter.json
+++ b/src/frame/aicc/driver_metadata/openrouter.json
@@ -1,7 +1,7 @@
 {
     "schema_version":  2,
     "provider_driver":  "openrouter",
-    "revision":  "builtin-2026-07-27-openai-fixed",
+    "revision":  "builtin-2026-07-27-openai-reviewed",
     "origin_provider_aliases":  {
                                     "google":  "google-gemini",
                                     "google-gemini":  "google-gemini",
@@ -38,1529 +38,1863 @@
     "models":  [
                    {
                        "id":  "openai/gpt-3.5-turbo",
-                       "provider_actual_model_id":  "openai/gpt-3.5-turbo",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  16385,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.002,
                        "input_token_usd":  5E-07,
                        "output_token_usd":  1.5E-06,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-3.5-turbo-0613",
-                       "provider_actual_model_id":  "openai/gpt-3.5-turbo-0613",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  4095,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.003,
                        "input_token_usd":  1E-06,
                        "output_token_usd":  2E-06,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-3.5-turbo-16k",
-                       "provider_actual_model_id":  "openai/gpt-3.5-turbo-16k",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  16385,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.007,
                        "input_token_usd":  3E-06,
                        "output_token_usd":  4E-06,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-3.5-turbo-instruct",
-                       "provider_actual_model_id":  "openai/gpt-3.5-turbo-instruct",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  false,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  4095,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.0035,
                        "input_token_usd":  1.5E-06,
                        "output_token_usd":  2E-06,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4",
-                       "provider_actual_model_id":  "openai/gpt-4",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  8191,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.090000000000000011,
                        "input_token_usd":  3E-05,
                        "output_token_usd":  6E-05,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4.1",
-                       "provider_actual_model_id":  "openai/gpt-4.1-2025-04-14",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1047576,
-                                            "max_output_tokens":  32768
+                                            "max_output_tokens":  32768,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0099999999999999985,
                        "input_token_usd":  2E-06,
                        "output_token_usd":  8E-06,
                        "cache_input_token_usd":  5E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4.1-mini",
-                       "provider_actual_model_id":  "openai/gpt-4.1-mini-2025-04-14",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1047576,
-                                            "max_output_tokens":  32768
+                                            "max_output_tokens":  32768,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.002,
                        "input_token_usd":  4E-07,
                        "output_token_usd":  1.6E-06,
                        "cache_input_token_usd":  1E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4.1-nano",
-                       "provider_actual_model_id":  "openai/gpt-4.1-nano-2025-04-14",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1047576,
-                                            "max_output_tokens":  32768
+                                            "max_output_tokens":  32768,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0005,
                        "input_token_usd":  1E-07,
                        "output_token_usd":  4E-07,
                        "cache_input_token_usd":  2.5E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o",
-                       "provider_actual_model_id":  "openai/gpt-4o",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0125,
                        "input_token_usd":  2.5E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-06,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o-2024-05-13",
-                       "provider_actual_model_id":  "openai/gpt-4o-2024-05-13",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.02,
                        "input_token_usd":  5E-06,
                        "output_token_usd":  1.5E-05,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o-2024-08-06",
-                       "provider_actual_model_id":  "openai/gpt-4o-2024-08-06",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0125,
                        "input_token_usd":  2.5E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-06,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o-2024-11-20",
-                       "provider_actual_model_id":  "openai/gpt-4o-2024-11-20",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0125,
                        "input_token_usd":  2.5E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-06,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o-mini",
-                       "provider_actual_model_id":  "openai/gpt-4o-mini",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.00075,
                        "input_token_usd":  1.5E-07,
                        "output_token_usd":  6E-07,
                        "cache_input_token_usd":  7.5E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o-mini-2024-07-18",
-                       "provider_actual_model_id":  "openai/gpt-4o-mini-2024-07-18",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.00075,
                        "input_token_usd":  1.5E-07,
                        "output_token_usd":  6E-07,
                        "cache_input_token_usd":  7.5E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o-mini-search-preview",
-                       "provider_actual_model_id":  "openai/gpt-4o-mini-search-preview-2025-03-11",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  false,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  false,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.00075,
                        "input_token_usd":  1.5E-07,
                        "output_token_usd":  6E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4o-search-preview",
-                       "provider_actual_model_id":  "openai/gpt-4o-search-preview-2025-03-11",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  false,
                                             "json_schema":  true,
                                             "web_search":  true,
-                                            "vision":  false,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.0125,
                        "input_token_usd":  2.5E-06,
                        "output_token_usd":  1E-05,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4-turbo",
-                       "provider_actual_model_id":  "openai/gpt-4-turbo",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.04,
                        "input_token_usd":  1E-05,
                        "output_token_usd":  3E-05,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-4-turbo-preview",
-                       "provider_actual_model_id":  "openai/gpt-4-turbo-preview",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  4096
+                                            "max_output_tokens":  4096,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.04,
                        "input_token_usd":  1E-05,
                        "output_token_usd":  3E-05,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5",
-                       "provider_actual_model_id":  "openai/gpt-5-2025-08-07",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.011250000000000001,
                        "input_token_usd":  1.25E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.1",
-                       "provider_actual_model_id":  "openai/gpt-5.1-20251113",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.011250000000000001,
                        "input_token_usd":  1.25E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.1-chat",
-                       "provider_actual_model_id":  "openai/gpt-5.1-chat-20251113",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.011250000000000001,
                        "input_token_usd":  1.25E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.1-codex",
-                       "provider_actual_model_id":  "openai/gpt-5.1-codex-20251113",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.011250000000000001,
                        "input_token_usd":  1.25E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.1-codex-max",
-                       "provider_actual_model_id":  "openai/gpt-5.1-codex-max-20251204",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.011250000000000001,
                        "input_token_usd":  1.25E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.1-codex-mini",
-                       "provider_actual_model_id":  "openai/gpt-5.1-codex-mini-20251113",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0022500000000000003,
                        "input_token_usd":  2.5E-07,
                        "output_token_usd":  2E-06,
                        "cache_input_token_usd":  2.5E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.2",
-                       "provider_actual_model_id":  "openai/gpt-5.2-20251211",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.01575,
                        "input_token_usd":  1.75E-06,
                        "output_token_usd":  1.4E-05,
                        "cache_input_token_usd":  1.75E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.2-chat",
-                       "provider_actual_model_id":  "openai/gpt-5.2-chat-20251211",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.01575,
                        "input_token_usd":  1.75E-06,
                        "output_token_usd":  1.4E-05,
                        "cache_input_token_usd":  1.75E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.2-codex",
-                       "provider_actual_model_id":  "openai/gpt-5.2-codex-20260114",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.01575,
                        "input_token_usd":  1.75E-06,
                        "output_token_usd":  1.4E-05,
                        "cache_input_token_usd":  1.75E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.2-pro",
-                       "provider_actual_model_id":  "openai/gpt-5.2-pro-20251211",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.18899999999999997,
                        "input_token_usd":  2.1E-05,
                        "output_token_usd":  0.000168,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.3-chat",
-                       "provider_actual_model_id":  "openai/gpt-5.3-chat-20260303",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.01575,
                        "input_token_usd":  1.75E-06,
                        "output_token_usd":  1.4E-05,
                        "cache_input_token_usd":  1.75E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.3-codex",
-                       "provider_actual_model_id":  "openai/gpt-5.3-codex-20260224",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.01575,
                        "input_token_usd":  1.75E-06,
                        "output_token_usd":  1.4E-05,
                        "cache_input_token_usd":  1.75E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.4",
-                       "provider_actual_model_id":  "openai/gpt-5.4-20260305",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0175,
                        "input_token_usd":  2.5E-06,
                        "output_token_usd":  1.5E-05,
                        "cache_input_token_usd":  2.5E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.4-mini",
-                       "provider_actual_model_id":  "openai/gpt-5.4-mini-20260317",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.00525,
                        "input_token_usd":  7.5E-07,
                        "output_token_usd":  4.5E-06,
                        "cache_input_token_usd":  7.5E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.4-nano",
-                       "provider_actual_model_id":  "openai/gpt-5.4-nano-20260317",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0014500000000000001,
                        "input_token_usd":  2E-07,
                        "output_token_usd":  1.25E-06,
                        "cache_input_token_usd":  2E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.4-pro",
-                       "provider_actual_model_id":  "openai/gpt-5.4-pro-20260305",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.21000000000000002,
                        "input_token_usd":  3E-05,
                        "output_token_usd":  0.00018,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.5",
-                       "provider_actual_model_id":  "openai/gpt-5.5-20260423",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.035,
                        "input_token_usd":  5E-06,
                        "output_token_usd":  3E-05,
                        "cache_input_token_usd":  5E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.5-pro",
-                       "provider_actual_model_id":  "openai/gpt-5.5-pro-20260423",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.21000000000000002,
                        "input_token_usd":  3E-05,
                        "output_token_usd":  0.00018,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.6-luna",
-                       "provider_actual_model_id":  "openai/gpt-5.6-luna-20260709",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.007,
                        "input_token_usd":  1E-06,
                        "output_token_usd":  6E-06,
                        "cache_input_token_usd":  1E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.6-sol",
-                       "provider_actual_model_id":  "openai/gpt-5.6-sol-20260709",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.035,
                        "input_token_usd":  5E-06,
                        "output_token_usd":  3E-05,
                        "cache_input_token_usd":  5E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5.6-terra",
-                       "provider_actual_model_id":  "openai/gpt-5.6-terra-20260709",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  1050000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0175,
                        "input_token_usd":  2.5E-06,
                        "output_token_usd":  1.5E-05,
                        "cache_input_token_usd":  2.5E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5-chat",
-                       "provider_actual_model_id":  "openai/gpt-5-chat-2025-08-07",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  false,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  128000,
-                                            "max_output_tokens":  16384
+                                            "max_output_tokens":  16384,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.011250000000000001,
                        "input_token_usd":  1.25E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5-codex",
-                       "provider_actual_model_id":  "openai/gpt-5-codex",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.011250000000000001,
                        "input_token_usd":  1.25E-06,
                        "output_token_usd":  1E-05,
                        "cache_input_token_usd":  1.25E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5-mini",
-                       "provider_actual_model_id":  "openai/gpt-5-mini-2025-08-07",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0022500000000000003,
                        "input_token_usd":  2.5E-07,
                        "output_token_usd":  2E-06,
                        "cache_input_token_usd":  2.5E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5-nano",
-                       "provider_actual_model_id":  "openai/gpt-5-nano-2025-08-07",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.00045,
                        "input_token_usd":  5E-08,
                        "output_token_usd":  4E-07,
                        "cache_input_token_usd":  5E-09,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-5-pro",
-                       "provider_actual_model_id":  "openai/gpt-5-pro-2025-10-06",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  400000,
-                                            "max_output_tokens":  128000
+                                            "max_output_tokens":  128000,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.135,
                        "input_token_usd":  1.5E-05,
                        "output_token_usd":  0.00012,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-oss-120b",
-                       "provider_actual_model_id":  "openai/gpt-oss-120b",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  131072,
-                                            "max_output_tokens":  131072
+                                            "max_output_tokens":  131072,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.000207,
                        "input_token_usd":  3.7E-08,
                        "output_token_usd":  1.7E-07,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-oss-20b",
-                       "provider_actual_model_id":  "openai/gpt-oss-20b",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  131072,
-                                            "max_output_tokens":  131072
+                                            "max_output_tokens":  131072,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.00016,
                        "input_token_usd":  3E-08,
                        "output_token_usd":  1.3E-07,
                        "cache_input_token_usd":  3E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/gpt-oss-safeguard-20b",
-                       "provider_actual_model_id":  "openai/gpt-oss-safeguard-20b",
                        "api_types":  [
-                                         "llm"
+                                         "llm",
+                                         "rerank"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.openai.{model}",
+                                              "rerank",
+                                              "rerank.openai",
+                                              "rerank.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
                                             "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  131072,
-                                            "max_output_tokens":  65536
+                                            "max_output_tokens":  65536,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.000375,
                        "input_token_usd":  7.5E-08,
                        "output_token_usd":  3E-07,
                        "cache_input_token_usd":  3.75E-08,
                        "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
+                       "quality_score":  0.9,
                        "latency_class":  "normal",
                        "cost_class":  "medium"
                    },
                    {
                        "id":  "openai/o1",
-                       "provider_actual_model_id":  "openai/o1-2024-12-17",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  false,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.075000000000000011,
                        "input_token_usd":  1.5E-05,
                        "output_token_usd":  6E-05,
                        "cache_input_token_usd":  7.5E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
                    },
                    {
                        "id":  "openai/o1-pro",
-                       "provider_actual_model_id":  "openai/o1-pro",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  false,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  false,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.74999999999999989,
                        "input_token_usd":  0.00015,
                        "output_token_usd":  0.0006,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
                    },
                    {
                        "id":  "openai/o3",
-                       "provider_actual_model_id":  "openai/o3-2025-04-16",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  false,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0099999999999999985,
                        "input_token_usd":  2E-06,
                        "output_token_usd":  8E-06,
                        "cache_input_token_usd":  5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
                    },
                    {
                        "id":  "openai/o3-deep-research",
-                       "provider_actual_model_id":  "openai/o3-deep-research-2025-06-26",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  true,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.05,
                        "input_token_usd":  1E-05,
                        "output_token_usd":  4E-05,
                        "cache_input_token_usd":  2.5E-06,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
                    },
                    {
                        "id":  "openai/o3-mini",
-                       "provider_actual_model_id":  "openai/o3-mini-2025-01-31",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  false,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  false,
+                                            "vision":  false
                                         },
                        "estimated_cost_usd":  0.0055,
                        "input_token_usd":  1.1E-06,
                        "output_token_usd":  4.4E-06,
                        "cache_input_token_usd":  5.5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
                    },
                    {
                        "id":  "openai/o3-pro",
-                       "provider_actual_model_id":  "openai/o3-pro-2025-06-10",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  false,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.1,
                        "input_token_usd":  2E-05,
                        "output_token_usd":  8E-05,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
                    },
                    {
                        "id":  "openai/o4-mini",
-                       "provider_actual_model_id":  "openai/o4-mini-2025-04-16",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  false,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0055,
                        "input_token_usd":  1.1E-06,
                        "output_token_usd":  4.4E-06,
                        "cache_input_token_usd":  2.75E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
                    },
                    {
                        "id":  "openai/o4-mini-deep-research",
-                       "provider_actual_model_id":  "openai/o4-mini-deep-research-2025-06-26",
                        "api_types":  [
                                          "llm"
                                      ],
                        "logical_mounts":  [
                                               "llm.{driver}",
-                                              "llm.{driver}.{model}"
+                                              "llm.gpt",
+                                              "llm.openai.{model}"
                                           ],
                        "capabilities":  {
                                             "streaming":  true,
                                             "tool_call":  true,
                                             "json_schema":  true,
-                                            "web_search":  false,
-                                            "vision":  true,
                                             "max_context_tokens":  200000,
-                                            "max_output_tokens":  100000
+                                            "max_output_tokens":  100000,
+                                            "web_search":  true,
+                                            "vision":  true
                                         },
                        "estimated_cost_usd":  0.0099999999999999985,
                        "input_token_usd":  2E-06,
                        "output_token_usd":  8E-06,
                        "cache_input_token_usd":  5E-07,
-                       "estimated_latency_ms":  1200,
-                       "quality_score":  0.8,
-                       "latency_class":  "normal",
-                       "cost_class":  "medium"
+                       "estimated_latency_ms":  1200
+                   },
+                   {
+                       "id":  "openai/gpt-5.4-image-2",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-5.6-luna-pro",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-5.6-sol-pro",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-5.6-terra-pro",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-5-image",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-5-image-mini",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-audio",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-audio-mini",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-chat-latest",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/gpt-oss-20b:free",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/o3-mini-high",
+                       "exclude":  true
+                   },
+                   {
+                       "id":  "openai/o4-mini-high",
+                       "exclude":  true
                    }
                ],
     "patterns":  [
+                     {
+                         "pattern":  "openai/*transcribe*",
+                         "api_types":  [
+                                           "audio.asr"
+                                       ],
+                         "logical_mounts":  [
+                                                "audio.asr",
+                                                "audio.asr.{driver}",
+                                                "audio.asr.{model}"
+                                            ],
+                         "estimated_cost_usd":  0.006,
+                         "estimated_latency_ms":  5000
+                     },
+                     {
+                         "pattern":  "openai/*-tts*",
+                         "api_types":  [
+                                           "audio.tts"
+                                       ],
+                         "logical_mounts":  [
+                                                "audio.tts",
+                                                "audio.tts.{driver}",
+                                                "audio.tts.{model}"
+                                            ],
+                         "estimated_cost_usd":  0.015,
+                         "estimated_latency_ms":  3000
+                     },
+                     {
+                         "pattern":  "openai/*audio*",
+                         "exclude":  true
+                     },
+                     {
+                         "pattern":  "openai/*realtime*",
+                         "exclude":  true
+                     },
+                     {
+                         "pattern":  "openai/dall-e-*",
+                         "api_types":  [
+                                           "image.txt2img"
+                                       ],
+                         "logical_mounts":  [
+                                                "image.txt2img.{driver}",
+                                                "image.txt2img.dalle",
+                                                "image.txt2img.{model}"
+                                            ],
+                         "estimated_cost_usd":  0.04,
+                         "estimated_latency_ms":  5000
+                     },
+                     {
+                         "pattern":  "openai/gpt-image-*",
+                         "api_types":  [
+                                           "image.txt2img",
+                                           "image.img2img",
+                                           "image.inpaint"
+                                       ],
+                         "logical_mounts":  [
+                                                "image.txt2img.{driver}",
+                                                "image.txt2img.gpt_image",
+                                                "image.txt2img.{model}",
+                                                "image.img2img",
+                                                "image.img2img.{driver}",
+                                                "image.img2img.{model}",
+                                                "image.inpaint",
+                                                "image.inpaint.{driver}",
+                                                "image.inpaint.{model}"
+                                            ],
+                         "estimated_cost_usd":  0.04,
+                         "estimated_latency_ms":  5000,
+                         "quality_score":  0.9
+                     },
+                     {
+                         "pattern":  "openai/text-embedding-*",
+                         "api_types":  [
+                                           "embedding.text"
+                                       ],
+                         "logical_mounts":  [
+                                                "embedding.text",
+                                                "embedding.text.{driver}",
+                                                "embedding.text.{model}"
+                                            ],
+                         "estimated_cost_usd":  0.0001,
+                         "estimated_latency_ms":  800
+                     },
+                     {
+                         "pattern":  "openai/gpt-*",
+                         "api_types":  [
+                                           "llm",
+                                           "rerank"
+                                       ],
+                         "logical_mounts":  [
+                                                "llm.{driver}",
+                                                "llm.openai.{model}",
+                                                "rerank",
+                                                "rerank.openai",
+                                                "rerank.{model}"
+                                            ],
+                         "capabilities":  {
+                                              "streaming":  true,
+                                              "tool_call":  true,
+                                              "json_schema":  true,
+                                              "web_search":  true,
+                                              "max_context_tokens":  128000,
+                                              "max_output_tokens":  8192
+                                          },
+                         "estimated_cost_usd":  0.01,
+                         "estimated_latency_ms":  1200,
+                         "quality_score":  0.9,
+                         "latency_class":  "normal",
+                         "cost_class":  "medium"
+                     },
+                     {
+                         "pattern":  "openai/chatgpt-*",
+                         "api_types":  [
+                                           "llm"
+                                       ],
+                         "logical_mounts":  [
+                                                "llm.{driver}",
+                                                "llm.openai.{model}"
+                                            ],
+                         "capabilities":  {
+                                              "streaming":  true,
+                                              "tool_call":  true,
+                                              "json_schema":  true,
+                                              "web_search":  true,
+                                              "vision":  true,
+                                              "max_context_tokens":  128000,
+                                              "max_output_tokens":  8192
+                                          },
+                         "estimated_cost_usd":  0.01,
+                         "estimated_latency_ms":  1200
+                     },
+                     {
+                         "pattern":  "openai/o*",
+                         "api_types":  [
+                                           "llm"
+                                       ],
+                         "logical_mounts":  [
+                                                "llm.{driver}",
+                                                "llm.gpt",
+                                                "llm.openai.{model}"
+                                            ],
+                         "capabilities":  {
+                                              "streaming":  true,
+                                              "tool_call":  true,
+                                              "json_schema":  true,
+                                              "max_context_tokens":  128000,
+                                              "max_output_tokens":  8192
+                                          },
+                         "estimated_cost_usd":  0.01,
+                         "estimated_latency_ms":  1200
+                     },
+                     {
+                         "pattern":  "openai/*",
+                         "api_types":  [
+                                           "llm"
+                                       ],
+                         "logical_mounts":  [
+                                                "llm.{driver}",
+                                                "llm.{driver}.{model}"
+                                            ],
+                         "capabilities":  {
+                                              "streaming":  false,
+                                              "tool_call":  false,
+                                              "json_schema":  false,
+                                              "web_search":  false,
+                                              "vision":  false
+                                          },
+                         "estimated_cost_usd":  0.01,
+                         "estimated_latency_ms":  1200
+                     },
                      {
                          "pattern":  "*",
                          "exclude":  true
@@ -1580,10 +1914,29 @@
                                           "json_schema":  false,
                                           "web_search":  false,
                                           "vision":  false
-                                      }
+                                      },
+                     "estimated_cost_usd":  0.01,
+                     "estimated_latency_ms":  1200
                  },
     "variants":  [
-
+                     {
+                         "name":  "reasoning.low",
+                         "mount_suffix":  "reasoning-low",
+                         "provider_options":  {
+                                                  "reasoning":  {
+                                                                    "effort":  "low"
+                                                                }
+                                              }
+                     },
+                     {
+                         "name":  "reasoning.high",
+                         "mount_suffix":  "reasoning-high",
+                         "provider_options":  {
+                                                  "reasoning":  {
+                                                                    "effort":  "high"
+                                                                }
+                                              }
+                     }
                  ],
     "version_rules":  [
                           {

--- a/src/frame/aicc/driver_metadata/openrouter.json
+++ b/src/frame/aicc/driver_metadata/openrouter.json
@@ -1727,6 +1727,14 @@
   ],
   "patterns": [
     {
+      "pattern": "openai/*:*",
+      "exclude": true
+    },
+    {
+      "pattern": "openai/*latest*",
+      "exclude": true
+    },
+    {
       "pattern": "openai/*transcribe*",
       "api_types": [
         "audio.asr"

--- a/src/frame/aicc/driver_metadata/openrouter.json
+++ b/src/frame/aicc/driver_metadata/openrouter.json
@@ -1589,7 +1589,7 @@
                           {
                               "family":  "gpt",
                               "tier":  "standard",
-                              "model_pattern":  "gpt-*",
+                              "model_pattern":  "openai/gpt-*",
                               "exclude_tier_tokens":  [
                                                           "pro",
                                                           "mini",
@@ -1630,7 +1630,7 @@
                           {
                               "family":  "gpt",
                               "tier":  "pro",
-                              "model_pattern":  "gpt-*",
+                              "model_pattern":  "openai/gpt-*",
                               "tier_tokens":  [
                                                   "pro"
                                               ],
@@ -1665,7 +1665,7 @@
                           {
                               "family":  "gpt",
                               "tier":  "mini",
-                              "model_pattern":  "gpt-*",
+                              "model_pattern":  "openai/gpt-*",
                               "tier_tokens":  [
                                                   "mini"
                                               ],
@@ -1700,7 +1700,7 @@
                           {
                               "family":  "gpt",
                               "tier":  "nano",
-                              "model_pattern":  "gpt-*",
+                              "model_pattern":  "openai/gpt-*",
                               "tier_tokens":  [
                                                   "nano",
                                                   "nono"

--- a/src/frame/aicc/driver_metadata/openrouter.json
+++ b/src/frame/aicc/driver_metadata/openrouter.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 2,
+  "provider_driver": "openrouter",
+  "revision": "builtin-2026-07-27",
+  "origin_provider_aliases": {
+    "google": "google-gemini",
+    "google-gemini": "google-gemini",
+    "moonshotai": "moonshot",
+    "x-ai": "xai"
+  },
+  "origin_mappings": [
+    {
+      "mapping_key": "openrouter-path-id",
+      "priority": 100,
+      "match": {
+        "source": "provider_model_id",
+        "regex": "^(?<driver>[^/]+)/(?<model>.+)$"
+      },
+      "transforms": {
+        "driver": [
+          { "op": "lowercase" },
+          { "op": "alias", "table": "origin_provider_aliases", "on_missing": "keep" }
+        ],
+        "model": [
+          { "op": "trim" }
+        ]
+      }
+    }
+  ],
+  "models": [
+    { "id": "openrouter/auto", "exclude": true },
+    { "id": "openrouter/free", "exclude": true },
+    { "id": "openrouter/fusion", "exclude": true }
+  ],
+  "patterns": [
+    { "pattern": "~*", "exclude": true }
+  ],
+  "defaults": {
+    "api_types": ["llm"],
+    "logical_mounts": [
+      "llm.{driver}",
+      "llm.{driver}.{model}"
+    ],
+    "capabilities": {
+      "streaming": false,
+      "tool_call": false,
+      "json_schema": false,
+      "web_search": false,
+      "vision": false
+    }
+  },
+  "variants": [],
+  "version_rules": [],
+  "signature": null
+}

--- a/src/frame/aicc/driver_metadata/openrouter.json
+++ b/src/frame/aicc/driver_metadata/openrouter.json
@@ -1,55 +1,1738 @@
 {
-  "schema_version": 2,
-  "provider_driver": "openrouter",
-  "revision": "builtin-2026-07-27",
-  "origin_provider_aliases": {
-    "google": "google-gemini",
-    "google-gemini": "google-gemini",
-    "moonshotai": "moonshot",
-    "x-ai": "xai"
-  },
-  "origin_mappings": [
-    {
-      "mapping_key": "openrouter-path-id",
-      "priority": 100,
-      "match": {
-        "source": "provider_model_id",
-        "regex": "^(?<driver>[^/]+)/(?<model>.+)$"
-      },
-      "transforms": {
-        "driver": [
-          { "op": "lowercase" },
-          { "op": "alias", "table": "origin_provider_aliases", "on_missing": "keep" }
-        ],
-        "model": [
-          { "op": "trim" }
-        ]
-      }
-    }
-  ],
-  "models": [
-    { "id": "openrouter/auto", "exclude": true },
-    { "id": "openrouter/free", "exclude": true },
-    { "id": "openrouter/fusion", "exclude": true }
-  ],
-  "patterns": [
-    { "pattern": "~*", "exclude": true }
-  ],
-  "defaults": {
-    "api_types": ["llm"],
-    "logical_mounts": [
-      "llm.{driver}",
-      "llm.{driver}.{model}"
-    ],
-    "capabilities": {
-      "streaming": false,
-      "tool_call": false,
-      "json_schema": false,
-      "web_search": false,
-      "vision": false
-    }
-  },
-  "variants": [],
-  "version_rules": [],
-  "signature": null
+    "schema_version":  2,
+    "provider_driver":  "openrouter",
+    "revision":  "builtin-2026-07-27-openai-fixed",
+    "origin_provider_aliases":  {
+                                    "google":  "google-gemini",
+                                    "google-gemini":  "google-gemini",
+                                    "moonshotai":  "moonshot",
+                                    "x-ai":  "xai"
+                                },
+    "origin_mappings":  [
+                            {
+                                "mapping_key":  "openrouter-path-id",
+                                "priority":  100,
+                                "match":  {
+                                              "source":  "provider_model_id",
+                                              "regex":  "^(?\u003cdriver\u003e[^/]+)/(?\u003cmodel\u003e.+)$"
+                                          },
+                                "transforms":  {
+                                                   "driver":  [
+                                                                  {
+                                                                      "op":  "lowercase"
+                                                                  },
+                                                                  {
+                                                                      "op":  "alias",
+                                                                      "table":  "origin_provider_aliases",
+                                                                      "on_missing":  "keep"
+                                                                  }
+                                                              ],
+                                                   "model":  [
+                                                                 {
+                                                                     "op":  "trim"
+                                                                 }
+                                                             ]
+                                               }
+                            }
+                        ],
+    "models":  [
+                   {
+                       "id":  "openai/gpt-3.5-turbo",
+                       "provider_actual_model_id":  "openai/gpt-3.5-turbo",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  16385,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.002,
+                       "input_token_usd":  5E-07,
+                       "output_token_usd":  1.5E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-3.5-turbo-0613",
+                       "provider_actual_model_id":  "openai/gpt-3.5-turbo-0613",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  4095,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.003,
+                       "input_token_usd":  1E-06,
+                       "output_token_usd":  2E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-3.5-turbo-16k",
+                       "provider_actual_model_id":  "openai/gpt-3.5-turbo-16k",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  16385,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.007,
+                       "input_token_usd":  3E-06,
+                       "output_token_usd":  4E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-3.5-turbo-instruct",
+                       "provider_actual_model_id":  "openai/gpt-3.5-turbo-instruct",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  false,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  4095,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.0035,
+                       "input_token_usd":  1.5E-06,
+                       "output_token_usd":  2E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4",
+                       "provider_actual_model_id":  "openai/gpt-4",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  8191,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.090000000000000011,
+                       "input_token_usd":  3E-05,
+                       "output_token_usd":  6E-05,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4.1",
+                       "provider_actual_model_id":  "openai/gpt-4.1-2025-04-14",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1047576,
+                                            "max_output_tokens":  32768
+                                        },
+                       "estimated_cost_usd":  0.0099999999999999985,
+                       "input_token_usd":  2E-06,
+                       "output_token_usd":  8E-06,
+                       "cache_input_token_usd":  5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4.1-mini",
+                       "provider_actual_model_id":  "openai/gpt-4.1-mini-2025-04-14",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1047576,
+                                            "max_output_tokens":  32768
+                                        },
+                       "estimated_cost_usd":  0.002,
+                       "input_token_usd":  4E-07,
+                       "output_token_usd":  1.6E-06,
+                       "cache_input_token_usd":  1E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4.1-nano",
+                       "provider_actual_model_id":  "openai/gpt-4.1-nano-2025-04-14",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1047576,
+                                            "max_output_tokens":  32768
+                                        },
+                       "estimated_cost_usd":  0.0005,
+                       "input_token_usd":  1E-07,
+                       "output_token_usd":  4E-07,
+                       "cache_input_token_usd":  2.5E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o",
+                       "provider_actual_model_id":  "openai/gpt-4o",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.0125,
+                       "input_token_usd":  2.5E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o-2024-05-13",
+                       "provider_actual_model_id":  "openai/gpt-4o-2024-05-13",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.02,
+                       "input_token_usd":  5E-06,
+                       "output_token_usd":  1.5E-05,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o-2024-08-06",
+                       "provider_actual_model_id":  "openai/gpt-4o-2024-08-06",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.0125,
+                       "input_token_usd":  2.5E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o-2024-11-20",
+                       "provider_actual_model_id":  "openai/gpt-4o-2024-11-20",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.0125,
+                       "input_token_usd":  2.5E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o-mini",
+                       "provider_actual_model_id":  "openai/gpt-4o-mini",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.00075,
+                       "input_token_usd":  1.5E-07,
+                       "output_token_usd":  6E-07,
+                       "cache_input_token_usd":  7.5E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o-mini-2024-07-18",
+                       "provider_actual_model_id":  "openai/gpt-4o-mini-2024-07-18",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.00075,
+                       "input_token_usd":  1.5E-07,
+                       "output_token_usd":  6E-07,
+                       "cache_input_token_usd":  7.5E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o-mini-search-preview",
+                       "provider_actual_model_id":  "openai/gpt-4o-mini-search-preview-2025-03-11",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  false,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  false,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.00075,
+                       "input_token_usd":  1.5E-07,
+                       "output_token_usd":  6E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4o-search-preview",
+                       "provider_actual_model_id":  "openai/gpt-4o-search-preview-2025-03-11",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  false,
+                                            "json_schema":  true,
+                                            "web_search":  true,
+                                            "vision":  false,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.0125,
+                       "input_token_usd":  2.5E-06,
+                       "output_token_usd":  1E-05,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4-turbo",
+                       "provider_actual_model_id":  "openai/gpt-4-turbo",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.04,
+                       "input_token_usd":  1E-05,
+                       "output_token_usd":  3E-05,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-4-turbo-preview",
+                       "provider_actual_model_id":  "openai/gpt-4-turbo-preview",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  4096
+                                        },
+                       "estimated_cost_usd":  0.04,
+                       "input_token_usd":  1E-05,
+                       "output_token_usd":  3E-05,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5",
+                       "provider_actual_model_id":  "openai/gpt-5-2025-08-07",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.011250000000000001,
+                       "input_token_usd":  1.25E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.1",
+                       "provider_actual_model_id":  "openai/gpt-5.1-20251113",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.011250000000000001,
+                       "input_token_usd":  1.25E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.1-chat",
+                       "provider_actual_model_id":  "openai/gpt-5.1-chat-20251113",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.011250000000000001,
+                       "input_token_usd":  1.25E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.1-codex",
+                       "provider_actual_model_id":  "openai/gpt-5.1-codex-20251113",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.011250000000000001,
+                       "input_token_usd":  1.25E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.1-codex-max",
+                       "provider_actual_model_id":  "openai/gpt-5.1-codex-max-20251204",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.011250000000000001,
+                       "input_token_usd":  1.25E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.1-codex-mini",
+                       "provider_actual_model_id":  "openai/gpt-5.1-codex-mini-20251113",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.0022500000000000003,
+                       "input_token_usd":  2.5E-07,
+                       "output_token_usd":  2E-06,
+                       "cache_input_token_usd":  2.5E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.2",
+                       "provider_actual_model_id":  "openai/gpt-5.2-20251211",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.01575,
+                       "input_token_usd":  1.75E-06,
+                       "output_token_usd":  1.4E-05,
+                       "cache_input_token_usd":  1.75E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.2-chat",
+                       "provider_actual_model_id":  "openai/gpt-5.2-chat-20251211",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.01575,
+                       "input_token_usd":  1.75E-06,
+                       "output_token_usd":  1.4E-05,
+                       "cache_input_token_usd":  1.75E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.2-codex",
+                       "provider_actual_model_id":  "openai/gpt-5.2-codex-20260114",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.01575,
+                       "input_token_usd":  1.75E-06,
+                       "output_token_usd":  1.4E-05,
+                       "cache_input_token_usd":  1.75E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.2-pro",
+                       "provider_actual_model_id":  "openai/gpt-5.2-pro-20251211",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.18899999999999997,
+                       "input_token_usd":  2.1E-05,
+                       "output_token_usd":  0.000168,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.3-chat",
+                       "provider_actual_model_id":  "openai/gpt-5.3-chat-20260303",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.01575,
+                       "input_token_usd":  1.75E-06,
+                       "output_token_usd":  1.4E-05,
+                       "cache_input_token_usd":  1.75E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.3-codex",
+                       "provider_actual_model_id":  "openai/gpt-5.3-codex-20260224",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.01575,
+                       "input_token_usd":  1.75E-06,
+                       "output_token_usd":  1.4E-05,
+                       "cache_input_token_usd":  1.75E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.4",
+                       "provider_actual_model_id":  "openai/gpt-5.4-20260305",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1050000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.0175,
+                       "input_token_usd":  2.5E-06,
+                       "output_token_usd":  1.5E-05,
+                       "cache_input_token_usd":  2.5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.4-mini",
+                       "provider_actual_model_id":  "openai/gpt-5.4-mini-20260317",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.00525,
+                       "input_token_usd":  7.5E-07,
+                       "output_token_usd":  4.5E-06,
+                       "cache_input_token_usd":  7.5E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.4-nano",
+                       "provider_actual_model_id":  "openai/gpt-5.4-nano-20260317",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.0014500000000000001,
+                       "input_token_usd":  2E-07,
+                       "output_token_usd":  1.25E-06,
+                       "cache_input_token_usd":  2E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.4-pro",
+                       "provider_actual_model_id":  "openai/gpt-5.4-pro-20260305",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1050000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.21000000000000002,
+                       "input_token_usd":  3E-05,
+                       "output_token_usd":  0.00018,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.5",
+                       "provider_actual_model_id":  "openai/gpt-5.5-20260423",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1050000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.035,
+                       "input_token_usd":  5E-06,
+                       "output_token_usd":  3E-05,
+                       "cache_input_token_usd":  5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.5-pro",
+                       "provider_actual_model_id":  "openai/gpt-5.5-pro-20260423",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1050000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.21000000000000002,
+                       "input_token_usd":  3E-05,
+                       "output_token_usd":  0.00018,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.6-luna",
+                       "provider_actual_model_id":  "openai/gpt-5.6-luna-20260709",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1050000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.007,
+                       "input_token_usd":  1E-06,
+                       "output_token_usd":  6E-06,
+                       "cache_input_token_usd":  1E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.6-sol",
+                       "provider_actual_model_id":  "openai/gpt-5.6-sol-20260709",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1050000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.035,
+                       "input_token_usd":  5E-06,
+                       "output_token_usd":  3E-05,
+                       "cache_input_token_usd":  5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5.6-terra",
+                       "provider_actual_model_id":  "openai/gpt-5.6-terra-20260709",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  1050000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.0175,
+                       "input_token_usd":  2.5E-06,
+                       "output_token_usd":  1.5E-05,
+                       "cache_input_token_usd":  2.5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5-chat",
+                       "provider_actual_model_id":  "openai/gpt-5-chat-2025-08-07",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  false,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  128000,
+                                            "max_output_tokens":  16384
+                                        },
+                       "estimated_cost_usd":  0.011250000000000001,
+                       "input_token_usd":  1.25E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5-codex",
+                       "provider_actual_model_id":  "openai/gpt-5-codex",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.011250000000000001,
+                       "input_token_usd":  1.25E-06,
+                       "output_token_usd":  1E-05,
+                       "cache_input_token_usd":  1.25E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5-mini",
+                       "provider_actual_model_id":  "openai/gpt-5-mini-2025-08-07",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.0022500000000000003,
+                       "input_token_usd":  2.5E-07,
+                       "output_token_usd":  2E-06,
+                       "cache_input_token_usd":  2.5E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5-nano",
+                       "provider_actual_model_id":  "openai/gpt-5-nano-2025-08-07",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.00045,
+                       "input_token_usd":  5E-08,
+                       "output_token_usd":  4E-07,
+                       "cache_input_token_usd":  5E-09,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-5-pro",
+                       "provider_actual_model_id":  "openai/gpt-5-pro-2025-10-06",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  400000,
+                                            "max_output_tokens":  128000
+                                        },
+                       "estimated_cost_usd":  0.135,
+                       "input_token_usd":  1.5E-05,
+                       "output_token_usd":  0.00012,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-oss-120b",
+                       "provider_actual_model_id":  "openai/gpt-oss-120b",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  131072,
+                                            "max_output_tokens":  131072
+                                        },
+                       "estimated_cost_usd":  0.000207,
+                       "input_token_usd":  3.7E-08,
+                       "output_token_usd":  1.7E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-oss-20b",
+                       "provider_actual_model_id":  "openai/gpt-oss-20b",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  131072,
+                                            "max_output_tokens":  131072
+                                        },
+                       "estimated_cost_usd":  0.00016,
+                       "input_token_usd":  3E-08,
+                       "output_token_usd":  1.3E-07,
+                       "cache_input_token_usd":  3E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/gpt-oss-safeguard-20b",
+                       "provider_actual_model_id":  "openai/gpt-oss-safeguard-20b",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  131072,
+                                            "max_output_tokens":  65536
+                                        },
+                       "estimated_cost_usd":  0.000375,
+                       "input_token_usd":  7.5E-08,
+                       "output_token_usd":  3E-07,
+                       "cache_input_token_usd":  3.75E-08,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o1",
+                       "provider_actual_model_id":  "openai/o1-2024-12-17",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.075000000000000011,
+                       "input_token_usd":  1.5E-05,
+                       "output_token_usd":  6E-05,
+                       "cache_input_token_usd":  7.5E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o1-pro",
+                       "provider_actual_model_id":  "openai/o1-pro",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  false,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.74999999999999989,
+                       "input_token_usd":  0.00015,
+                       "output_token_usd":  0.0006,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o3",
+                       "provider_actual_model_id":  "openai/o3-2025-04-16",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.0099999999999999985,
+                       "input_token_usd":  2E-06,
+                       "output_token_usd":  8E-06,
+                       "cache_input_token_usd":  5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o3-deep-research",
+                       "provider_actual_model_id":  "openai/o3-deep-research-2025-06-26",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.05,
+                       "input_token_usd":  1E-05,
+                       "output_token_usd":  4E-05,
+                       "cache_input_token_usd":  2.5E-06,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o3-mini",
+                       "provider_actual_model_id":  "openai/o3-mini-2025-01-31",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  false,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.0055,
+                       "input_token_usd":  1.1E-06,
+                       "output_token_usd":  4.4E-06,
+                       "cache_input_token_usd":  5.5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o3-pro",
+                       "provider_actual_model_id":  "openai/o3-pro-2025-06-10",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.1,
+                       "input_token_usd":  2E-05,
+                       "output_token_usd":  8E-05,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o4-mini",
+                       "provider_actual_model_id":  "openai/o4-mini-2025-04-16",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.0055,
+                       "input_token_usd":  1.1E-06,
+                       "output_token_usd":  4.4E-06,
+                       "cache_input_token_usd":  2.75E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   },
+                   {
+                       "id":  "openai/o4-mini-deep-research",
+                       "provider_actual_model_id":  "openai/o4-mini-deep-research-2025-06-26",
+                       "api_types":  [
+                                         "llm"
+                                     ],
+                       "logical_mounts":  [
+                                              "llm.{driver}",
+                                              "llm.{driver}.{model}"
+                                          ],
+                       "capabilities":  {
+                                            "streaming":  true,
+                                            "tool_call":  true,
+                                            "json_schema":  true,
+                                            "web_search":  false,
+                                            "vision":  true,
+                                            "max_context_tokens":  200000,
+                                            "max_output_tokens":  100000
+                                        },
+                       "estimated_cost_usd":  0.0099999999999999985,
+                       "input_token_usd":  2E-06,
+                       "output_token_usd":  8E-06,
+                       "cache_input_token_usd":  5E-07,
+                       "estimated_latency_ms":  1200,
+                       "quality_score":  0.8,
+                       "latency_class":  "normal",
+                       "cost_class":  "medium"
+                   }
+               ],
+    "patterns":  [
+                     {
+                         "pattern":  "*",
+                         "exclude":  true
+                     }
+                 ],
+    "defaults":  {
+                     "api_types":  [
+                                       "llm"
+                                   ],
+                     "logical_mounts":  [
+                                            "llm.{driver}",
+                                            "llm.{driver}.{model}"
+                                        ],
+                     "capabilities":  {
+                                          "streaming":  false,
+                                          "tool_call":  false,
+                                          "json_schema":  false,
+                                          "web_search":  false,
+                                          "vision":  false
+                                      }
+                 },
+    "variants":  [
+
+                 ],
+    "version_rules":  [
+                          {
+                              "family":  "gpt",
+                              "tier":  "standard",
+                              "model_pattern":  "gpt-*",
+                              "exclude_tier_tokens":  [
+                                                          "pro",
+                                                          "mini",
+                                                          "nano",
+                                                          "nono"
+                                                      ],
+                              "version_rank":  {
+                                                   "prefix":  "gpt"
+                                               },
+                              "stability":  {
+                                                "unstable_tokens":  [
+                                                                        "preview",
+                                                                        "experimental",
+                                                                        "beta"
+                                                                    ],
+                                                "current_requires_stable":  true
+                                            },
+                              "current_mount":  "llm.gpt-standard",
+                              "version_mount":  "llm.openai.{model}",
+                              "auto_mounts":  [
+                                                  "llm.gpt",
+                                                  "llm.gpt-standard",
+                                                  "llm.gpt-pro",
+                                                  "llm.gpt-mini",
+                                                  "llm.gpt-nano",
+                                                  "llm",
+                                                  "llm.summarize",
+                                                  "llm.swift",
+                                                  "llm.plan",
+                                                  "llm.reason",
+                                                  "llm.code"
+                                              ],
+                              "exclude_snapshot_date_suffix":  true,
+                              "capabilities":  {
+                                                   "vision":  true
+                                               }
+                          },
+                          {
+                              "family":  "gpt",
+                              "tier":  "pro",
+                              "model_pattern":  "gpt-*",
+                              "tier_tokens":  [
+                                                  "pro"
+                                              ],
+                              "version_rank":  {
+                                                   "prefix":  "gpt"
+                                               },
+                              "stability":  {
+                                                "unstable_tokens":  [
+                                                                        "preview",
+                                                                        "experimental",
+                                                                        "beta"
+                                                                    ],
+                                                "current_requires_stable":  true
+                                            },
+                              "current_mount":  "llm.gpt-pro",
+                              "version_mount":  "llm.openai.{model}",
+                              "auto_mounts":  [
+                                                  "llm.gpt",
+                                                  "llm.gpt-standard",
+                                                  "llm.gpt-pro",
+                                                  "llm.gpt-mini",
+                                                  "llm.gpt-nano",
+                                                  "llm",
+                                                  "llm.summarize",
+                                                  "llm.swift",
+                                                  "llm.plan",
+                                                  "llm.reason",
+                                                  "llm.code"
+                                              ],
+                              "exclude_snapshot_date_suffix":  true
+                          },
+                          {
+                              "family":  "gpt",
+                              "tier":  "mini",
+                              "model_pattern":  "gpt-*",
+                              "tier_tokens":  [
+                                                  "mini"
+                                              ],
+                              "version_rank":  {
+                                                   "prefix":  "gpt"
+                                               },
+                              "stability":  {
+                                                "unstable_tokens":  [
+                                                                        "preview",
+                                                                        "experimental",
+                                                                        "beta"
+                                                                    ],
+                                                "current_requires_stable":  true
+                                            },
+                              "current_mount":  "llm.gpt-mini",
+                              "version_mount":  "llm.openai.{model}",
+                              "auto_mounts":  [
+                                                  "llm.gpt",
+                                                  "llm.gpt-standard",
+                                                  "llm.gpt-pro",
+                                                  "llm.gpt-mini",
+                                                  "llm.gpt-nano",
+                                                  "llm",
+                                                  "llm.summarize",
+                                                  "llm.swift",
+                                                  "llm.plan",
+                                                  "llm.reason",
+                                                  "llm.code"
+                                              ],
+                              "exclude_snapshot_date_suffix":  true
+                          },
+                          {
+                              "family":  "gpt",
+                              "tier":  "nano",
+                              "model_pattern":  "gpt-*",
+                              "tier_tokens":  [
+                                                  "nano",
+                                                  "nono"
+                                              ],
+                              "version_rank":  {
+                                                   "prefix":  "gpt"
+                                               },
+                              "stability":  {
+                                                "unstable_tokens":  [
+                                                                        "preview",
+                                                                        "experimental",
+                                                                        "beta"
+                                                                    ],
+                                                "current_requires_stable":  true
+                                            },
+                              "current_mount":  "llm.gpt-nano",
+                              "version_mount":  "llm.openai.{model}",
+                              "auto_mounts":  [
+                                                  "llm.gpt",
+                                                  "llm.gpt-standard",
+                                                  "llm.gpt-pro",
+                                                  "llm.gpt-mini",
+                                                  "llm.gpt-nano",
+                                                  "llm",
+                                                  "llm.summarize",
+                                                  "llm.swift",
+                                                  "llm.plan",
+                                                  "llm.reason",
+                                                  "llm.code"
+                                              ],
+                              "exclude_snapshot_date_suffix":  true
+                          }
+                      ],
+    "signature":  null
 }

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -2853,6 +2853,7 @@ pub fn provider_model_metadata(
         provider_model_id: provider_model_id.to_string(),
         exact_model: exact_model_name(provider_model_id, provider_instance_name),
         model_driver: model_driver.to_string(),
+        origin_model_id: None,
         provider_actual_model_id: None,
         provider_options: None,
         parameter_scale: None,

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -120,8 +120,6 @@ pub struct DriverModelRule {
     #[serde(default)]
     pub model_driver: Option<String>,
     #[serde(default)]
-    pub provider_actual_model_id: Option<String>,
-    #[serde(default)]
     pub exclude: bool,
     #[serde(default)]
     pub parameter_scale: Option<String>,
@@ -318,7 +316,6 @@ fn resolve_driver_model(
     let mut latency_class = LatencyClass::Normal;
     let mut cost_class = CostClass::Medium;
     let mut model_driver = origin.driver.clone();
-    let mut provider_actual_model_id = None;
     let mut input_token_usd = None;
     let mut output_token_usd = None;
     let mut cache_input_token_usd = None;
@@ -327,7 +324,6 @@ fn resolve_driver_model(
         if let Some(next) = rule.model_driver.as_ref() {
             model_driver = next.clone();
         }
-        provider_actual_model_id = rule.provider_actual_model_id.clone();
         if let Some(next_api_types) = rule.api_types.as_ref() {
             api_types = next_api_types.clone();
         }
@@ -382,7 +378,7 @@ fn resolve_driver_model(
         provider_model_id: provider_model_id.to_string(),
         exact_model: exact_model_name(provider_model_id, provider_instance_name),
         model_driver,
-        provider_actual_model_id,
+        provider_actual_model_id: None,
         provider_options: None,
         parameter_scale,
         api_types,
@@ -1295,7 +1291,7 @@ mod tests {
             None,
         );
 
-        assert_eq!(inventory.models.len(), 1);
+        assert_eq!(inventory.models.len(), 3);
         let openai = inventory
             .models
             .iter()
@@ -1303,10 +1299,8 @@ mod tests {
             .expect("OpenAI model should resolve");
         assert_eq!(openai.model_driver, "openai");
         assert_eq!(openai.exact_model, "openai/gpt-5.5@openrouter-main");
-        assert_eq!(
-            openai.provider_actual_model_id.as_deref(),
-            Some("openai/gpt-5.5-20260423")
-        );
+        assert_eq!(openai.provider_actual_model_id, None);
+        assert!(openai.api_types.contains(&ApiType::Rerank));
         assert_eq!(openai.capabilities.max_context_tokens, Some(1_050_000));
         assert_eq!(openai.capabilities.max_output_tokens, Some(128_000));
         assert_eq!(openai.pricing.input_token_usd, Some(0.000005));
@@ -1324,6 +1318,15 @@ mod tests {
                 .iter()
                 .any(|mount| mount == "llm.openai.gpt-5-5")
         );
+        let reasoning_high = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "openai/gpt-5.5:reasoning-high")
+            .expect("OpenRouter should expand OpenAI reasoning variants");
+        assert_eq!(
+            reasoning_high.provider_actual_model_id.as_deref(),
+            Some("openai/gpt-5.5")
+        );
 
         let official = resolve_driver_inventory(
             "openai-main",
@@ -1339,6 +1342,64 @@ mod tests {
             .logical_mounts
             .iter()
             .any(|mount| mount == "llm.openai.gpt-5-5"));
+    }
+
+    #[test]
+    fn openrouter_patterns_inherit_openai_rules_and_defaults() {
+        let inventory = resolve_driver_inventory(
+            "openrouter-main",
+            ProviderType::CloudApi,
+            "openrouter",
+            &[
+                DriverModelResolveRequest::new("openai/gpt-9", vec![ApiType::Llm]),
+                DriverModelResolveRequest::new("openai/future-native", vec![ApiType::Llm]),
+                DriverModelResolveRequest::new("other/gpt-10", vec![ApiType::Llm]),
+            ],
+            None,
+        );
+
+        assert_eq!(inventory.models.len(), 4);
+        let gpt = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "openai/gpt-9")
+            .expect("prefixed OpenAI pattern should match");
+        assert!(gpt.api_types.contains(&ApiType::Rerank));
+        assert!(gpt.capabilities.tool_call);
+        assert!(gpt.logical_mounts.iter().any(|mount| mount == "rerank"));
+
+        let fallback = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "openai/future-native")
+            .expect("unknown native OpenAI model should use OpenAI defaults");
+        assert_eq!(fallback.api_types, vec![ApiType::Llm]);
+        assert!(!fallback.capabilities.tool_call);
+        assert!(!inventory
+            .models
+            .iter()
+            .any(|model| model.provider_model_id.starts_with("other/gpt-10")));
+    }
+
+    #[test]
+    fn openrouter_deep_research_keeps_required_web_search() {
+        let inventory = resolve_driver_inventory(
+            "openrouter-main",
+            ProviderType::CloudApi,
+            "openrouter",
+            &[DriverModelResolveRequest::new(
+                "openai/o3-deep-research",
+                vec![ApiType::Llm],
+            )],
+            None,
+        );
+        let model = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "openai/o3-deep-research")
+            .expect("deep research model should resolve");
+        assert!(model.capabilities.web_search);
+        assert!(model.logical_mounts.iter().any(|mount| mount == "llm.gpt"));
     }
 
     #[test]

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -211,6 +211,8 @@ pub struct DriverCapabilitiesPatch {
 pub struct DriverModelVariant {
     pub name: String,
     #[serde(default)]
+    pub model_pattern: Option<String>,
+    #[serde(default)]
     pub mount_suffix: Option<String>,
     #[serde(default)]
     pub provider_options: serde_json::Value,
@@ -678,6 +680,13 @@ fn expand_model_variants(
 
     let mut models = vec![model.clone()];
     for variant in variants {
+        if variant
+            .model_pattern
+            .as_deref()
+            .is_some_and(|pattern| !wildcard_matches(pattern, model.provider_model_id.as_str()))
+        {
+            continue;
+        }
         let Some(suffix) = variant.mount_suffix.as_deref() else {
             continue;
         };
@@ -1367,6 +1376,12 @@ mod tests {
         assert!(gpt.api_types.contains(&ApiType::Rerank));
         assert!(gpt.capabilities.tool_call);
         assert!(gpt.logical_mounts.iter().any(|mount| mount == "rerank"));
+
+        let sources = load_driver_metadata_sources("openrouter");
+        let mut other_origin = gpt.clone();
+        other_origin.provider_model_id = "anthropic/claude-future".to_string();
+        other_origin.exact_model = "anthropic/claude-future@openrouter-main".to_string();
+        assert_eq!(expand_model_variants(other_origin, sources.as_slice()).len(), 1);
 
         let fallback = inventory
             .models

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -120,6 +120,8 @@ pub struct DriverModelRule {
     #[serde(default)]
     pub model_driver: Option<String>,
     #[serde(default)]
+    pub provider_actual_model_id: Option<String>,
+    #[serde(default)]
     pub exclude: bool,
     #[serde(default)]
     pub parameter_scale: Option<String>,
@@ -131,6 +133,12 @@ pub struct DriverModelRule {
     pub capabilities: DriverCapabilitiesPatch,
     #[serde(default)]
     pub estimated_cost_usd: Option<f64>,
+    #[serde(default)]
+    pub input_token_usd: Option<f64>,
+    #[serde(default)]
+    pub output_token_usd: Option<f64>,
+    #[serde(default)]
+    pub cache_input_token_usd: Option<f64>,
     #[serde(default)]
     pub estimated_latency_ms: Option<u64>,
     #[serde(default)]
@@ -310,11 +318,16 @@ fn resolve_driver_model(
     let mut latency_class = LatencyClass::Normal;
     let mut cost_class = CostClass::Medium;
     let mut model_driver = origin.driver.clone();
+    let mut provider_actual_model_id = None;
+    let mut input_token_usd = None;
+    let mut output_token_usd = None;
+    let mut cache_input_token_usd = None;
 
     if let Some(rule) = rule {
         if let Some(next) = rule.model_driver.as_ref() {
             model_driver = next.clone();
         }
+        provider_actual_model_id = rule.provider_actual_model_id.clone();
         if let Some(next_api_types) = rule.api_types.as_ref() {
             api_types = next_api_types.clone();
         }
@@ -333,6 +346,9 @@ fn resolve_driver_model(
         if rule.estimated_cost_usd.is_some() {
             estimated_cost_usd = rule.estimated_cost_usd;
         }
+        input_token_usd = rule.input_token_usd;
+        output_token_usd = rule.output_token_usd;
+        cache_input_token_usd = rule.cache_input_token_usd;
         if rule.estimated_latency_ms.is_some() {
             estimated_latency_ms = rule.estimated_latency_ms;
         }
@@ -366,7 +382,7 @@ fn resolve_driver_model(
         provider_model_id: provider_model_id.to_string(),
         exact_model: exact_model_name(provider_model_id, provider_instance_name),
         model_driver,
-        provider_actual_model_id: None,
+        provider_actual_model_id,
         provider_options: None,
         parameter_scale,
         api_types,
@@ -385,8 +401,10 @@ fn resolve_driver_model(
             cost_class,
         },
         pricing: ModelPricing {
+            input_token_usd,
+            output_token_usd,
+            cache_input_token_usd,
             estimated_cost_usd,
-            ..Default::default()
         },
         health: ModelHealth {
             status: HealthStatus::Available,
@@ -1262,6 +1280,10 @@ mod tests {
             DriverModelResolveRequest::new("openai/gpt-5.5", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("anthropic/claude-sonnet-4", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("x-ai/grok-4.5", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/gpt-chat-latest", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/o3-mini-high", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/gpt-5.6-sol-pro", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/gpt-oss-20b:free", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("~x-ai/grok-latest", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("openrouter/auto", vec![ApiType::Llm]),
         ];
@@ -1273,7 +1295,7 @@ mod tests {
             None,
         );
 
-        assert_eq!(inventory.models.len(), 3);
+        assert_eq!(inventory.models.len(), 1);
         let openai = inventory
             .models
             .iter()
@@ -1281,25 +1303,21 @@ mod tests {
             .expect("OpenAI model should resolve");
         assert_eq!(openai.model_driver, "openai");
         assert_eq!(openai.exact_model, "openai/gpt-5.5@openrouter-main");
-        assert!(openai
-            .logical_mounts
-            .iter()
-            .any(|mount| mount == "llm.openai"));
-        assert!(openai
-            .logical_mounts
-            .iter()
-            .any(|mount| mount == "llm.openai.gpt-5-5"));
-
-        let xai = inventory
-            .models
-            .iter()
-            .find(|model| model.provider_model_id == "x-ai/grok-4.5")
-            .expect("xAI model should resolve");
-        assert_eq!(xai.model_driver, "xai");
-        assert!(xai
-            .logical_mounts
-            .iter()
-            .any(|mount| mount == "llm.xai.grok-4-5"));
+        assert_eq!(
+            openai.provider_actual_model_id.as_deref(),
+            Some("openai/gpt-5.5-20260423")
+        );
+        assert_eq!(openai.capabilities.max_context_tokens, Some(1_050_000));
+        assert_eq!(openai.capabilities.max_output_tokens, Some(128_000));
+        assert_eq!(openai.pricing.input_token_usd, Some(0.000005));
+        assert_eq!(openai.pricing.output_token_usd, Some(0.00003));
+        assert_eq!(openai.pricing.cache_input_token_usd, Some(0.0000005));
+        assert!(
+            openai
+                .logical_mounts
+                .iter()
+                .any(|mount| mount == "llm.openai.gpt-5-5")
+        );
 
         let official = resolve_driver_inventory(
             "openai-main",

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -6,11 +6,12 @@ use crate::model_types::{
 };
 use buckyos_kit::get_buckyos_system_etc_dir;
 use log::warn;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-const DRIVER_METADATA_SCHEMA_VERSION: u32 = 1;
+const DRIVER_METADATA_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriverModelResolveRequest {
@@ -49,6 +50,10 @@ pub struct DriverMetadataDocument {
     pub provider_driver: String,
     pub revision: String,
     #[serde(default)]
+    pub origin_provider_aliases: HashMap<String, String>,
+    #[serde(default)]
+    pub origin_mappings: Vec<DriverOriginMapping>,
+    #[serde(default)]
     pub models: Vec<DriverModelRule>,
     #[serde(default)]
     pub patterns: Vec<DriverModelRule>,
@@ -60,6 +65,50 @@ pub struct DriverMetadataDocument {
     pub version_rules: Vec<DriverVersionRule>,
     #[serde(default)]
     pub signature: Option<DriverMetadataSignature>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DriverOriginMapping {
+    #[serde(default)]
+    pub mapping_key: String,
+    #[serde(default)]
+    pub priority: i32,
+    #[serde(default, rename = "match")]
+    pub match_rule: DriverOriginMatch,
+    #[serde(default)]
+    pub transforms: DriverOriginTransforms,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DriverOriginMatch {
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub regex: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DriverOriginTransforms {
+    #[serde(default)]
+    pub driver: Vec<DriverOriginTransform>,
+    #[serde(default)]
+    pub model: Vec<DriverOriginTransform>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DriverOriginTransform {
+    #[serde(default)]
+    pub op: String,
+    #[serde(default)]
+    pub table: Option<String>,
+    #[serde(default)]
+    pub on_missing: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct DriverOriginIdentity {
+    driver: String,
+    model: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -227,6 +276,7 @@ fn resolve_driver_model(
     if provider_model_id.is_empty() {
         return None;
     }
+    let origin = resolve_origin_identity(provider_driver, provider_model_id, sources);
 
     let exact_rule = find_exact_rule(provider_model_id, sources);
     let pattern_rule = if exact_rule.is_none() {
@@ -259,7 +309,7 @@ fn resolve_driver_model(
     let mut quality_score = Some(0.75);
     let mut latency_class = LatencyClass::Normal;
     let mut cost_class = CostClass::Medium;
-    let mut model_driver = provider_driver.to_string();
+    let mut model_driver = origin.driver.clone();
 
     if let Some(rule) = rule {
         if let Some(next) = rule.model_driver.as_ref() {
@@ -271,7 +321,9 @@ fn resolve_driver_model(
         if let Some(next_mounts) = rule.logical_mounts.as_ref() {
             logical_mounts = next_mounts
                 .iter()
-                .map(|mount| expand_mount_template(mount, provider_driver, provider_model_id))
+                .map(|mount| {
+                    expand_mount_template(mount, provider_driver, provider_model_id, &origin)
+                })
                 .collect();
         }
         apply_capabilities_patch(&mut capabilities, &rule.capabilities);
@@ -298,13 +350,13 @@ fn resolve_driver_model(
         logical_mounts = provider_fallback_mounts(request.fallback_logical_mounts.as_slice());
     }
     if logical_mounts.is_empty() {
-        logical_mounts = generic_mounts(provider_driver, provider_model_id, api_types.as_slice());
+        logical_mounts = generic_mounts(&origin, api_types.as_slice());
     }
     if api_types
         .iter()
         .any(|api_type| matches!(api_type, ApiType::Llm))
     {
-        for mount in semantic_llm_family_mounts(provider_model_id) {
+        for mount in semantic_llm_family_mounts(origin.model.as_str()) {
             add_unique(&mut logical_mounts, mount);
         }
     }
@@ -378,10 +430,113 @@ fn parse_driver_metadata(content: &str) -> Result<DriverMetadataDocument, serde_
     serde_json::from_str::<DriverMetadataDocument>(content)
 }
 
+fn resolve_origin_identity(
+    provider_driver: &str,
+    provider_model_id: &str,
+    sources: &[DriverMetadataSource],
+) -> DriverOriginIdentity {
+    let fallback = DriverOriginIdentity {
+        driver: provider_driver.to_string(),
+        model: provider_model_id.to_string(),
+    };
+    let Some(source) = sources.iter().rev().find(|source| {
+        source.document.schema_version == DRIVER_METADATA_SCHEMA_VERSION
+            && !source.document.origin_mappings.is_empty()
+    }) else {
+        return fallback;
+    };
+
+    let mut mappings = source.document.origin_mappings.iter().collect::<Vec<_>>();
+    mappings.sort_by_key(|mapping| mapping.priority);
+    for mapping in mappings {
+        if mapping.match_rule.source != "provider_model_id" {
+            warn!(
+                "aicc.metadata_resolver.skip_origin_mapping source={} mapping={} unsupported_source={}",
+                source.name, mapping.mapping_key, mapping.match_rule.source
+            );
+            continue;
+        }
+        let regex = match Regex::new(mapping.match_rule.regex.as_str()) {
+            Ok(regex) => regex,
+            Err(err) => {
+                warn!(
+                    "aicc.metadata_resolver.skip_origin_mapping source={} mapping={} invalid_regex={}",
+                    source.name, mapping.mapping_key, err
+                );
+                continue;
+            }
+        };
+        let Some(captures) = regex.captures(provider_model_id) else {
+            continue;
+        };
+        let (Some(driver), Some(model)) = (captures.name("driver"), captures.name("model")) else {
+            warn!(
+                "aicc.metadata_resolver.skip_origin_mapping source={} mapping={} missing_named_capture",
+                source.name, mapping.mapping_key
+            );
+            continue;
+        };
+        let Some(driver) = apply_origin_transforms(
+            driver.as_str(),
+            mapping.transforms.driver.as_slice(),
+            &source.document.origin_provider_aliases,
+        ) else {
+            warn!(
+                "aicc.metadata_resolver.skip_origin_mapping source={} mapping={} invalid_driver_transform",
+                source.name, mapping.mapping_key
+            );
+            continue;
+        };
+        let Some(model) = apply_origin_transforms(
+            model.as_str(),
+            mapping.transforms.model.as_slice(),
+            &source.document.origin_provider_aliases,
+        ) else {
+            warn!(
+                "aicc.metadata_resolver.skip_origin_mapping source={} mapping={} invalid_model_transform",
+                source.name, mapping.mapping_key
+            );
+            continue;
+        };
+        if driver.is_empty() || model.is_empty() {
+            continue;
+        }
+        return DriverOriginIdentity { driver, model };
+    }
+    fallback
+}
+
+fn apply_origin_transforms(
+    value: &str,
+    transforms: &[DriverOriginTransform],
+    aliases: &HashMap<String, String>,
+) -> Option<String> {
+    let mut value = value.to_string();
+    for transform in transforms {
+        match transform.op.as_str() {
+            "trim" => value = value.trim().to_string(),
+            "lowercase" => value = value.to_ascii_lowercase(),
+            "alias" => {
+                if transform.table.as_deref() != Some("origin_provider_aliases") {
+                    return None;
+                }
+                if let Some(alias) = aliases.get(value.as_str()) {
+                    value = alias.clone();
+                } else if transform.on_missing.as_deref().unwrap_or("keep") != "keep" {
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+    }
+    Some(value)
+}
+
 fn load_builtin_driver_metadata(provider_driver: &str) -> Option<DriverMetadataDocument> {
     let normalized = normalize_driver(provider_driver);
     let raw = match normalized.as_str() {
         "openai" | "sn-ai-provider" => include_str!("../driver_metadata/openai.json"),
+        "openrouter" => include_str!("../driver_metadata/openrouter.json"),
         "claude" | "anthropic" => include_str!("../driver_metadata/claude.json"),
         "google-gemini" | "gemini" => include_str!("../driver_metadata/gemini.json"),
         "fal" => include_str!("../driver_metadata/fal.json"),
@@ -647,28 +802,24 @@ fn apply_capabilities_patch(capabilities: &mut ModelCapabilities, patch: &Driver
     }
 }
 
-fn generic_mounts(
-    provider_driver: &str,
-    provider_model_id: &str,
-    api_types: &[ApiType],
-) -> Vec<String> {
+fn generic_mounts(origin: &DriverOriginIdentity, api_types: &[ApiType]) -> Vec<String> {
     let mut mounts = Vec::new();
     for api_type in api_types.iter() {
         let base = api_mount_base(api_type);
         add_unique(&mut mounts, base.to_string());
         add_unique(
             &mut mounts,
-            format!("{}.{}", base, logical_mount_segment(provider_driver)),
+            format!("{}.{}", base, logical_mount_segment(origin.driver.as_str())),
         );
         add_unique(
             &mut mounts,
-            format!("{}.{}", base, logical_mount_segment(provider_model_id)),
+            format!("{}.{}", base, logical_mount_segment(origin.model.as_str())),
         );
         if matches!(api_type, ApiType::Llm) {
             add_unique(&mut mounts, "llm".to_string());
             add_unique(
                 &mut mounts,
-                format!("llm.{}", logical_mount_segment(provider_driver)),
+                format!("llm.{}", logical_mount_segment(origin.driver.as_str())),
             );
         }
     }
@@ -797,11 +948,29 @@ fn is_task_role_mount(mount: &str) -> bool {
     })
 }
 
-fn expand_mount_template(template: &str, provider_driver: &str, provider_model_id: &str) -> String {
+fn expand_mount_template(
+    template: &str,
+    provider_driver: &str,
+    provider_model_id: &str,
+    origin: &DriverOriginIdentity,
+) -> String {
     template
-        .replace("{driver}", logical_mount_segment(provider_driver).as_str())
-        .replace("{model}", logical_mount_segment(provider_model_id).as_str())
-        .replace("{provider_model_id}", provider_model_id)
+        .replace(
+            "{provider_driver}",
+            logical_mount_segment(provider_driver).as_str(),
+        )
+        .replace(
+            "{provider_model_id}",
+            logical_mount_segment(provider_model_id).as_str(),
+        )
+        .replace(
+            "{driver}",
+            logical_mount_segment(origin.driver.as_str()).as_str(),
+        )
+        .replace(
+            "{model}",
+            logical_mount_segment(origin.model.as_str()).as_str(),
+        )
 }
 
 fn logical_mount_segment(value: &str) -> String {
@@ -849,7 +1018,7 @@ fn apply_driver_post_rules(
     sources: &[DriverMetadataSource],
 ) {
     for rule in driver_version_rules(sources) {
-        apply_driver_version_rule(provider_driver, models, &rule);
+        apply_driver_version_rule(provider_driver, models, &rule, sources);
     }
 }
 
@@ -869,6 +1038,7 @@ fn apply_driver_version_rule(
     provider_driver: &str,
     models: &mut [ModelMetadata],
     rule: &DriverVersionRule,
+    sources: &[DriverMetadataSource],
 ) {
     use std::cmp::Ordering;
     let mut latest: Option<(usize, DriverModelRank)> = None;
@@ -880,7 +1050,9 @@ fn apply_driver_version_rule(
         {
             continue;
         }
-        let Some(rank) = rank_model_for_version_rule(model.provider_model_id.as_str(), rule) else {
+        let origin =
+            resolve_origin_identity(provider_driver, model.provider_model_id.as_str(), sources);
+        let Some(rank) = rank_model_for_version_rule(origin.model.as_str(), rule) else {
             continue;
         };
         remove_driver_auto_mounts(&mut model.logical_mounts, rule);
@@ -891,6 +1063,7 @@ fn apply_driver_version_rule(
                     version_mount,
                     provider_driver,
                     model.provider_model_id.as_str(),
+                    &origin,
                 ),
             );
         }
@@ -908,6 +1081,8 @@ fn apply_driver_version_rule(
 
     if let Some((index, _)) = latest {
         let model = &mut models[index];
+        let origin =
+            resolve_origin_identity(provider_driver, model.provider_model_id.as_str(), sources);
         if let Some(current_mount) = rule.current_mount.as_deref() {
             add_unique(
                 &mut model.logical_mounts,
@@ -915,6 +1090,7 @@ fn apply_driver_version_rule(
                     current_mount,
                     provider_driver,
                     model.provider_model_id.as_str(),
+                    &origin,
                 ),
             );
         }
@@ -1079,6 +1255,109 @@ fn remove_driver_auto_mounts(mounts: &mut Vec<String>, rule: &DriverVersionRule)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn openrouter_models_resolve_to_origin_identity() {
+        let requests = vec![
+            DriverModelResolveRequest::new("openai/gpt-5.5", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("anthropic/claude-sonnet-4", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("x-ai/grok-4.5", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("~x-ai/grok-latest", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openrouter/auto", vec![ApiType::Llm]),
+        ];
+        let inventory = resolve_driver_inventory(
+            "openrouter-main",
+            ProviderType::CloudApi,
+            "openrouter",
+            requests.as_slice(),
+            None,
+        );
+
+        assert_eq!(inventory.models.len(), 3);
+        let openai = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "openai/gpt-5.5")
+            .expect("OpenAI model should resolve");
+        assert_eq!(openai.model_driver, "openai");
+        assert_eq!(openai.exact_model, "openai/gpt-5.5@openrouter-main");
+        assert!(openai
+            .logical_mounts
+            .iter()
+            .any(|mount| mount == "llm.openai"));
+        assert!(openai
+            .logical_mounts
+            .iter()
+            .any(|mount| mount == "llm.openai.gpt-5-5"));
+
+        let xai = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "x-ai/grok-4.5")
+            .expect("xAI model should resolve");
+        assert_eq!(xai.model_driver, "xai");
+        assert!(xai
+            .logical_mounts
+            .iter()
+            .any(|mount| mount == "llm.xai.grok-4-5"));
+
+        let official = resolve_driver_inventory(
+            "openai-main",
+            ProviderType::CloudApi,
+            "openai",
+            &[DriverModelResolveRequest::new(
+                "gpt-5.5",
+                vec![ApiType::Llm],
+            )],
+            None,
+        );
+        assert!(official.models[0]
+            .logical_mounts
+            .iter()
+            .any(|mount| mount == "llm.openai.gpt-5-5"));
+    }
+
+    #[test]
+    fn origin_mapping_invalid_regex_falls_back_to_channel_identity() {
+        let source = DriverMetadataSource {
+            name: "test".to_string(),
+            document: DriverMetadataDocument {
+                schema_version: DRIVER_METADATA_SCHEMA_VERSION,
+                provider_driver: "aggregator".to_string(),
+                origin_mappings: vec![DriverOriginMapping {
+                    mapping_key: "invalid".to_string(),
+                    priority: 1,
+                    match_rule: DriverOriginMatch {
+                        source: "provider_model_id".to_string(),
+                        regex: "(".to_string(),
+                    },
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        };
+
+        let origin = resolve_origin_identity("aggregator", "vendor/model", &[source]);
+        assert_eq!(origin.driver, "aggregator");
+        assert_eq!(origin.model, "vendor/model");
+    }
+
+    #[test]
+    fn mount_templates_keep_origin_and_channel_names_separate() {
+        let origin = DriverOriginIdentity {
+            driver: "openai".to_string(),
+            model: "gpt-5.5".to_string(),
+        };
+        assert_eq!(
+            expand_mount_template(
+                "llm.{driver}.{model}.{provider_driver}.{provider_model_id}",
+                "openrouter",
+                "openai/gpt-5.5",
+                &origin,
+            ),
+            "llm.openai.gpt-5-5.openrouter.openai-gpt-5-5"
+        );
+    }
 
     #[test]
     fn openai_unknown_fallback_is_conservative() {

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -1290,6 +1290,10 @@ mod tests {
             DriverModelResolveRequest::new("openai/o3-mini-high", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("openai/gpt-5.6-sol-pro", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("openai/gpt-oss-20b:free", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/gpt-5.5:nitro", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/gpt-5.5:floor", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/gpt-5.5:exacto", vec![ApiType::Llm]),
+            DriverModelResolveRequest::new("openai/gpt-9-latest", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("~x-ai/grok-latest", vec![ApiType::Llm]),
             DriverModelResolveRequest::new("openrouter/auto", vec![ApiType::Llm]),
         ];

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -380,6 +380,7 @@ fn resolve_driver_model(
         provider_model_id: provider_model_id.to_string(),
         exact_model: exact_model_name(provider_model_id, provider_instance_name),
         model_driver,
+        origin_model_id: Some(origin.model),
         provider_actual_model_id: None,
         provider_options: None,
         parameter_scale,

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -1070,7 +1070,7 @@ fn apply_driver_version_rule(
         }
         let origin =
             resolve_origin_identity(provider_driver, model.provider_model_id.as_str(), sources);
-        let Some(rank) = rank_model_for_version_rule(origin.model.as_str(), rule) else {
+        let Some(rank) = rank_model_for_version_rule(model.provider_model_id.as_str(), rule) else {
             continue;
         };
         remove_driver_auto_mounts(&mut model.logical_mounts, rule);
@@ -1312,6 +1312,12 @@ mod tests {
         assert_eq!(openai.pricing.input_token_usd, Some(0.000005));
         assert_eq!(openai.pricing.output_token_usd, Some(0.00003));
         assert_eq!(openai.pricing.cache_input_token_usd, Some(0.0000005));
+        assert!(
+            openai
+                .logical_mounts
+                .iter()
+                .any(|mount| mount == "llm.gpt-standard")
+        );
         assert!(
             openai
                 .logical_mounts

--- a/src/frame/aicc/src/model_registry.rs
+++ b/src/frame/aicc/src/model_registry.rs
@@ -458,6 +458,7 @@ mod tests {
             provider_model_id: provider_model_id.to_string(),
             exact_model: format!("{}@{}", provider_model_id, provider),
             model_driver: provider.to_string(),
+            origin_model_id: None,
             provider_actual_model_id: None,
             provider_options: None,
             parameter_scale: None,

--- a/src/frame/aicc/src/model_router.rs
+++ b/src/frame/aicc/src/model_router.rs
@@ -630,6 +630,7 @@ mod tests {
             provider_model_id: model.to_string(),
             exact_model: format!("{}@{}", model, provider),
             model_driver: provider.to_string(),
+            origin_model_id: None,
             provider_actual_model_id: None,
             provider_options: None,
             parameter_scale: None,

--- a/src/frame/aicc/src/model_scheduler.rs
+++ b/src/frame/aicc/src/model_scheduler.rs
@@ -302,6 +302,7 @@ mod tests {
             provider_model_id: exact.to_string(),
             exact_model: format!("{}@{}", exact, provider),
             model_driver: provider.to_string(),
+            origin_model_id: None,
             provider_actual_model_id: None,
             provider_options: None,
             parameter_scale: None,

--- a/src/frame/aicc/src/model_types.rs
+++ b/src/frame/aicc/src/model_types.rs
@@ -579,6 +579,8 @@ pub struct ModelMetadata {
     #[serde(default)]
     pub model_driver: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_actual_model_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_options: Option<serde_json::Value>,
@@ -1430,6 +1432,7 @@ mod tests {
             provider_model_id: "gpt-5.2".to_string(),
             exact_model: "gpt-5.2@openai_primary".to_string(),
             model_driver: "openai".to_string(),
+            origin_model_id: None,
             provider_actual_model_id: None,
             provider_options: None,
             parameter_scale: None,

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -930,10 +930,31 @@ impl OpenAIProvider {
     fn estimate_cost_for_usage(&self, model: &str, usage: &AiUsage) -> Option<AiCost> {
         let input_tokens = usage.input_tokens? as f64;
         let output_tokens = usage.output_tokens? as f64;
-        let (input_per_m, output_per_m) = Self::price_per_1m_tokens(model);
-
-        let amount = ((input_tokens / 1_000_000.0) * input_per_m)
-            + ((output_tokens / 1_000_000.0) * output_per_m);
+        let pricing = self.inventory.read().ok().and_then(|inventory| {
+            inventory.models.iter().find_map(|metadata| {
+                (metadata.provider_model_id == model).then(|| {
+                    (
+                        metadata
+                            .origin_model_id
+                            .clone()
+                            .unwrap_or_else(|| model.to_string()),
+                        metadata.pricing.input_token_usd,
+                        metadata.pricing.output_token_usd,
+                    )
+                })
+            })
+        });
+        let (origin_model_id, input_per_token, output_per_token) =
+            pricing.unwrap_or_else(|| (model.to_string(), None, None));
+        let amount = if let (Some(input_per_token), Some(output_per_token)) =
+            (input_per_token, output_per_token)
+        {
+            (input_tokens * input_per_token) + (output_tokens * output_per_token)
+        } else {
+            let (input_per_m, output_per_m) = Self::price_per_1m_tokens(origin_model_id.as_str());
+            ((input_tokens / 1_000_000.0) * input_per_m)
+                + ((output_tokens / 1_000_000.0) * output_per_m)
+        };
 
         Some(AiCost {
             amount,
@@ -4808,10 +4829,67 @@ data: [DONE]
             .find(|model| model.provider_model_id == "openai/gpt-5.5")
             .expect("base model should resolve");
         assert_eq!(base.provider_actual_model_id, None);
+        assert_eq!(base.origin_model_id.as_deref(), Some("gpt-5.5"));
+        *provider.inventory.write().expect("inventory lock") = inventory.clone();
+        let cost = provider
+            .estimate_cost_for_usage(
+                "openai/gpt-5.5",
+                &AiUsage {
+                    input_tokens: Some(1_000_000),
+                    output_tokens: Some(1_000_000),
+                    total_tokens: Some(2_000_000),
+                },
+            )
+            .expect("OpenRouter usage cost should resolve");
+        assert_eq!(cost.amount, 35.0);
         assert!(inventory.models.iter().any(|model| {
             model.provider_model_id == "openai/gpt-5.5:reasoning-high"
                 && model.provider_actual_model_id.as_deref() == Some("openai/gpt-5.5")
         }));
+    }
+
+    #[test]
+    fn openrouter_cost_fallback_uses_metadata_origin_model_id() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openrouter-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openrouter".to_string(),
+                api_token: "token".to_string(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: default_timeout_ms(),
+            },
+            "token",
+        )
+        .expect("provider should be built");
+
+        let mut inventory = provider
+            .build_inventory_from_remote_value(json!({
+                "data": [{ "id": "openai/gpt-5.4-pro" }]
+            }))
+            .expect("OpenRouter inventory should resolve");
+        let base = inventory
+            .models
+            .iter_mut()
+            .find(|model| model.provider_model_id == "openai/gpt-5.4-pro")
+            .expect("base model should resolve");
+        assert_eq!(base.origin_model_id.as_deref(), Some("gpt-5.4-pro"));
+        base.pricing.input_token_usd = None;
+        base.pricing.output_token_usd = None;
+        *provider.inventory.write().expect("inventory lock") = inventory;
+
+        let cost = provider
+            .estimate_cost_for_usage(
+                "openai/gpt-5.4-pro",
+                &AiUsage {
+                    input_tokens: Some(1_000_000),
+                    output_tokens: Some(1_000_000),
+                    total_tokens: Some(2_000_000),
+                },
+            )
+            .expect("OpenRouter fallback cost should resolve");
+        assert_eq!(cost.amount, 210.0);
     }
 
     #[test]

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -4773,7 +4773,7 @@ data: [DONE]
     }
 
     #[test]
-    fn openrouter_remote_inventory_has_no_openai_default_models() {
+    fn openrouter_remote_inventory_uses_strict_fixed_openai_whitelist() {
         let provider = OpenAIProvider::new(
             OpenAIInstanceConfig {
                 provider_instance_name: "openrouter-main".to_string(),
@@ -4792,16 +4792,21 @@ data: [DONE]
             .build_inventory_from_remote_value(json!({
                 "data": [
                     { "id": "openai/gpt-5.5" },
-                    { "id": "anthropic/claude-sonnet-4" }
+                    { "id": "anthropic/claude-sonnet-4" },
+                    { "id": "openai/gpt-chat-latest" },
+                    { "id": "openai/o3-mini-high" },
+                    { "id": "openai/gpt-5.6-sol-pro" },
+                    { "id": "openai/gpt-oss-20b:free" }
                 ]
             }))
             .expect("OpenRouter inventory should resolve");
 
-        assert_eq!(inventory.models.len(), 2);
-        assert!(inventory
-            .models
-            .iter()
-            .all(|model| model.provider_model_id.contains('/')));
+        assert_eq!(inventory.models.len(), 1);
+        assert_eq!(inventory.models[0].provider_model_id, "openai/gpt-5.5");
+        assert_eq!(
+            inventory.models[0].provider_actual_model_id.as_deref(),
+            Some("openai/gpt-5.5-20260423")
+        );
     }
 
     #[test]

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -89,6 +89,7 @@ const OPENAI_IMAGE_EDIT_OPTION_ALLOWLIST: &[&str] = &[
 pub struct OpenAIInstanceConfig {
     pub provider_instance_name: String,
     pub provider_type: String,
+    pub provider_driver: String,
     pub api_token: String,
     pub base_url: String,
     pub auth_mode: String,
@@ -149,10 +150,14 @@ impl OpenAIProvider {
 
         let provider_type = provider_type_from_settings(cfg.provider_type.as_str());
         let provider_instance_name = cfg.provider_instance_name.clone();
-        let provider_driver = default_provider_driver_for_instance(
-            cfg.provider_instance_name.as_str(),
-            cfg.base_url.as_str(),
-        );
+        let provider_driver = if cfg.provider_driver.trim().is_empty() {
+            default_provider_driver_for_instance(
+                cfg.provider_instance_name.as_str(),
+                cfg.base_url.as_str(),
+            )
+        } else {
+            cfg.provider_driver.trim().to_string()
+        };
         let instance = ProviderInstance {
             provider_instance_name: provider_instance_name.clone(),
             provider_type: provider_type.clone(),
@@ -371,21 +376,26 @@ impl OpenAIProvider {
         provider_type: crate::model_types::ProviderType,
         provider_driver: &str,
     ) -> ProviderInventory {
-        let (models, image_models) = if provider_driver == SN_AI_PROVIDER_DRIVER {
-            (
-                normalize_model_list(parse_csv_list(DEFAULT_SN_AI_PROVIDER_MODELS)),
-                normalize_model_list(parse_csv_list(DEFAULT_SN_AI_PROVIDER_IMAGE_MODELS)),
-            )
-        } else {
-            (
-                normalize_model_list(parse_csv_list(DEFAULT_OPENAI_MODELS)),
-                normalize_model_list(parse_csv_list(DEFAULT_OPENAI_IMAGE_MODELS)),
-            )
-        };
-        let embedding_models =
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS));
-        let asr_models = normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS));
-        let tts_models = normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS));
+        let (models, image_models, embedding_models, asr_models, tts_models) =
+            if provider_driver == "openrouter" {
+                (vec![], vec![], vec![], vec![], vec![])
+            } else if provider_driver == SN_AI_PROVIDER_DRIVER {
+                (
+                    normalize_model_list(parse_csv_list(DEFAULT_SN_AI_PROVIDER_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_SN_AI_PROVIDER_IMAGE_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS)),
+                )
+            } else {
+                (
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_IMAGE_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS)),
+                    normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS)),
+                )
+            };
 
         Self::build_inventory(
             provider_instance_name,
@@ -406,15 +416,24 @@ impl OpenAIProvider {
         image_models: &[String],
         revision: Option<String>,
     ) -> ProviderInventory {
+        let (embedding_models, asr_models, tts_models) = if self.provider_driver == "openrouter" {
+            (vec![], vec![], vec![])
+        } else {
+            (
+                normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS)),
+                normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS)),
+                normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS)),
+            )
+        };
         Self::build_inventory(
             self.instance.provider_instance_name.as_str(),
             self.provider_type.clone(),
             self.provider_driver.as_str(),
             models,
             image_models,
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_EMBEDDING_MODELS)).as_slice(),
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_ASR_MODELS)).as_slice(),
-            normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS)).as_slice(),
+            embedding_models.as_slice(),
+            asr_models.as_slice(),
+            tts_models.as_slice(),
             revision,
         )
     }
@@ -438,7 +457,8 @@ impl OpenAIProvider {
 
         let response = serde_json::from_value::<OpenAIModelsResponse>(body)
             .context("failed to parse openai models response")?;
-        let (llm_models, image_models) = normalize_remote_model_ids(response.data);
+        let (llm_models, image_models) =
+            normalize_remote_model_ids(response.data, self.provider_driver.as_str());
         if llm_models.is_empty() && image_models.is_empty() {
             return Err(anyhow!(
                 "openai inventory refresh returned no supported models"
@@ -3386,6 +3406,8 @@ struct SettingsOpenAIInstanceConfig {
     provider_instance_name: String,
     #[serde(default = "default_provider_type")]
     provider_type: String,
+    #[serde(default)]
+    provider_driver: String,
     #[serde(default, alias = "api_key", alias = "apiKey")]
     api_token: String,
     #[serde(default = "default_base_url")]
@@ -3470,7 +3492,10 @@ fn is_supported_llm_model_name(model: &str) -> bool {
         || normalized.starts_with("o4")
 }
 
-fn normalize_remote_model_ids(entries: Vec<OpenAIModelEntry>) -> (Vec<String>, Vec<String>) {
+fn normalize_remote_model_ids(
+    entries: Vec<OpenAIModelEntry>,
+    provider_driver: &str,
+) -> (Vec<String>, Vec<String>) {
     let mut llm_seen = HashSet::<String>::new();
     let mut image_seen = HashSet::<String>::new();
     let mut llm_models = Vec::new();
@@ -3482,6 +3507,12 @@ fn normalize_remote_model_ids(entries: Vec<OpenAIModelEntry>) -> (Vec<String>, V
             continue;
         }
         let key = model.to_ascii_lowercase();
+        if provider_driver == "openrouter" {
+            if llm_seen.insert(key) {
+                llm_models.push(model.to_string());
+            }
+            continue;
+        }
         if is_text2image_model_name(model) {
             if image_seen.insert(key) {
                 image_models.push(model.to_string());
@@ -3565,6 +3596,7 @@ fn build_openai_instances(settings: &OpenAISettings) -> Result<Vec<OpenAIInstanc
         vec![SettingsOpenAIInstanceConfig {
             provider_instance_name: default_instance_id(),
             provider_type: default_provider_type(),
+            provider_driver: String::new(),
             api_token: settings.api_token.clone(),
             base_url: default_base_url(),
             auth_mode: default_auth_mode(),
@@ -3579,6 +3611,7 @@ fn build_openai_instances(settings: &OpenAISettings) -> Result<Vec<OpenAIInstanc
         instances.push(OpenAIInstanceConfig {
             provider_instance_name: raw_instance.provider_instance_name,
             provider_type: raw_instance.provider_type,
+            provider_driver: raw_instance.provider_driver,
             api_token: if raw_instance.api_token.trim().is_empty() {
                 settings.api_token.clone()
             } else {
@@ -4248,6 +4281,7 @@ data: [DONE]
             instances: vec![SettingsOpenAIInstanceConfig {
                 provider_instance_name: "openai-1".to_string(),
                 provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
                 api_token: String::new(),
                 base_url: default_base_url(),
                 auth_mode: default_auth_mode(),
@@ -4269,6 +4303,7 @@ data: [DONE]
             instances: vec![SettingsOpenAIInstanceConfig {
                 provider_instance_name: "sn-ai-provider-1".to_string(),
                 provider_type: "cloud_api".to_string(),
+                provider_driver: "sn-ai-provider".to_string(),
                 api_token: String::new(),
                 base_url: "https://sn.buckyos.ai/v1".to_string(),
                 auth_mode: RUNTIME_SESSION_AUTH_MODE.to_string(),
@@ -4281,6 +4316,29 @@ data: [DONE]
         assert_eq!(instances[0].auth_mode, RUNTIME_SESSION_AUTH_MODE);
     }
 
+    #[test]
+    fn build_openai_instances_preserves_aggregator_driver() {
+        let settings = OpenAISettings {
+            enabled: true,
+            api_token: "token".to_string(),
+            instances: vec![SettingsOpenAIInstanceConfig {
+                provider_instance_name: "openrouter-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openrouter".to_string(),
+                api_token: String::new(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                auth_mode: default_auth_mode(),
+                timeout_ms: default_timeout_ms(),
+            }],
+        };
+
+        let instances = build_openai_instances(&settings).expect("instances should be built");
+        let provider =
+            OpenAIProvider::new(instances[0].clone(), "token").expect("provider should be built");
+        assert_eq!(provider.instance.provider_driver, "openrouter");
+        assert!(provider.inventory().models.is_empty());
+    }
+
     #[tokio::test]
     async fn stopped_refresh_does_not_send_initial_request() {
         let provider = Arc::new(
@@ -4288,6 +4346,7 @@ data: [DONE]
                 OpenAIInstanceConfig {
                     provider_instance_name: "openai-stopped".to_string(),
                     provider_type: "cloud_api".to_string(),
+                    provider_driver: "openai".to_string(),
                     api_token: "token".to_string(),
                     base_url: "http://127.0.0.1:1".to_string(),
                     auth_mode: "bearer".to_string(),
@@ -4318,6 +4377,7 @@ data: [DONE]
             OpenAIInstanceConfig {
                 provider_instance_name: "openai-drop".to_string(),
                 provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
                 api_token: "token".to_string(),
                 base_url: "http://127.0.0.1:1".to_string(),
                 auth_mode: "bearer".to_string(),
@@ -4368,6 +4428,7 @@ data: [DONE]
             OpenAIInstanceConfig {
                 provider_instance_name: "sn-ai-provider-1".to_string(),
                 provider_type: "cloud_api".to_string(),
+                provider_driver: "sn-ai-provider".to_string(),
                 api_token: "token".to_string(),
                 base_url: "https://sn.buckyos.ai/api/v1/ai/chat/completions".to_string(),
                 auth_mode: "bearer".to_string(),
@@ -4385,6 +4446,7 @@ data: [DONE]
             OpenAIInstanceConfig {
                 provider_instance_name: "openai-primary".to_string(),
                 provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
                 api_token: "token".to_string(),
                 base_url: default_base_url(),
                 auth_mode: "bearer".to_string(),
@@ -4499,6 +4561,7 @@ data: [DONE]
             OpenAIInstanceConfig {
                 provider_instance_name: "openai-primary".to_string(),
                 provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
                 api_token: "token".to_string(),
                 base_url: default_base_url(),
                 auth_mode: "bearer".to_string(),
@@ -4622,20 +4685,23 @@ data: [DONE]
 
     #[test]
     fn remote_model_inventory_filters_supported_model_types() {
-        let (llm_models, image_models) = normalize_remote_model_ids(vec![
-            OpenAIModelEntry {
-                id: "gpt-5.2".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "text-embedding-3-large".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "gpt-image-1".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "gpt-image-2".to_string(),
-            },
-        ]);
+        let (llm_models, image_models) = normalize_remote_model_ids(
+            vec![
+                OpenAIModelEntry {
+                    id: "gpt-5.2".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "text-embedding-3-large".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "gpt-image-1".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "gpt-image-2".to_string(),
+                },
+            ],
+            "openai",
+        );
 
         assert_eq!(llm_models, vec!["gpt-5.2".to_string()]);
         assert_eq!(
@@ -4650,29 +4716,92 @@ data: [DONE]
         // DEFAULT_OPENAI_{ASR,TTS}_MODELS 里登记，再当 LLM 收一遍会让
         // build_inventory 产生重复 exact_model，触发 model_registry
         // SessionConfigInvalid 把整个 refresh 卡死。
-        let (llm_models, image_models) = normalize_remote_model_ids(vec![
-            OpenAIModelEntry {
-                id: "gpt-4o-mini-transcribe".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "gpt-4o-transcribe".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "gpt-4o-mini-tts".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "gpt-4o-audio-preview".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "gpt-4o-realtime-preview".to_string(),
-            },
-            OpenAIModelEntry {
-                id: "gpt-5".to_string(),
-            },
-        ]);
+        let (llm_models, image_models) = normalize_remote_model_ids(
+            vec![
+                OpenAIModelEntry {
+                    id: "gpt-4o-mini-transcribe".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "gpt-4o-transcribe".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "gpt-4o-mini-tts".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "gpt-4o-audio-preview".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "gpt-4o-realtime-preview".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "gpt-5".to_string(),
+                },
+            ],
+            "openai",
+        );
 
         assert_eq!(llm_models, vec!["gpt-5".to_string()]);
         assert!(image_models.is_empty());
+    }
+
+    #[test]
+    fn openrouter_inventory_preserves_provider_native_model_ids() {
+        let (llm_models, image_models) = normalize_remote_model_ids(
+            vec![
+                OpenAIModelEntry {
+                    id: "openai/gpt-5.5".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "anthropic/claude-sonnet-4".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "tencent/hy3:free".to_string(),
+                },
+            ],
+            "openrouter",
+        );
+
+        assert_eq!(
+            llm_models,
+            vec![
+                "openai/gpt-5.5".to_string(),
+                "anthropic/claude-sonnet-4".to_string(),
+                "tencent/hy3:free".to_string(),
+            ]
+        );
+        assert!(image_models.is_empty());
+    }
+
+    #[test]
+    fn openrouter_remote_inventory_has_no_openai_default_models() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openrouter-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openrouter".to_string(),
+                api_token: "token".to_string(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: default_timeout_ms(),
+            },
+            "token",
+        )
+        .expect("provider should be built");
+
+        let inventory = provider
+            .build_inventory_from_remote_value(json!({
+                "data": [
+                    { "id": "openai/gpt-5.5" },
+                    { "id": "anthropic/claude-sonnet-4" }
+                ]
+            }))
+            .expect("OpenRouter inventory should resolve");
+
+        assert_eq!(inventory.models.len(), 2);
+        assert!(inventory
+            .models
+            .iter()
+            .all(|model| model.provider_model_id.contains('/')));
     }
 
     #[test]
@@ -4707,6 +4836,7 @@ data: [DONE]
             OpenAIInstanceConfig {
                 provider_instance_name: "openai-primary".to_string(),
                 provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
                 api_token: "token".to_string(),
                 base_url: default_base_url(),
                 auth_mode: "bearer".to_string(),

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -4801,12 +4801,17 @@ data: [DONE]
             }))
             .expect("OpenRouter inventory should resolve");
 
-        assert_eq!(inventory.models.len(), 1);
-        assert_eq!(inventory.models[0].provider_model_id, "openai/gpt-5.5");
-        assert_eq!(
-            inventory.models[0].provider_actual_model_id.as_deref(),
-            Some("openai/gpt-5.5-20260423")
-        );
+        assert_eq!(inventory.models.len(), 3);
+        let base = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "openai/gpt-5.5")
+            .expect("base model should resolve");
+        assert_eq!(base.provider_actual_model_id, None);
+        assert!(inventory.models.iter().any(|model| {
+            model.provider_model_id == "openai/gpt-5.5:reasoning-high"
+                && model.provider_actual_model_id.as_deref() == Some("openai/gpt-5.5")
+        }));
     }
 
     #[test]

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -4817,7 +4817,15 @@ data: [DONE]
                     { "id": "openai/gpt-chat-latest" },
                     { "id": "openai/o3-mini-high" },
                     { "id": "openai/gpt-5.6-sol-pro" },
-                    { "id": "openai/gpt-oss-20b:free" }
+                    { "id": "openai/gpt-oss-20b:free" },
+                    { "id": "openai/gpt-5.5:free" },
+                    { "id": "openai/gpt-5.5:extended" },
+                    { "id": "openai/gpt-5.5:thinking" },
+                    { "id": "openai/gpt-5.5:nitro" },
+                    { "id": "openai/gpt-5.5:floor" },
+                    { "id": "openai/gpt-5.5:exacto" },
+                    { "id": "openai/gpt-5.5:online" },
+                    { "id": "openai/gpt-9-latest" }
                 ]
             }))
             .expect("OpenRouter inventory should resolve");

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -999,11 +999,32 @@ impl OpenAIProvider {
         // (只留 Text block),tool 信息全丢。
         for msg in &req.payload.messages {
             let role_str = Self::ai_role_to_openai(&msg.role);
-            let content_type = if role_str == "assistant" {
-                "output_text"
-            } else {
-                "input_text"
-            };
+            if role_str == "assistant" {
+                let provider_items = msg
+                    .content
+                    .iter()
+                    .filter_map(|block| match block {
+                        AiContent::ProviderState { provider, value }
+                            if provider.eq_ignore_ascii_case(&self.provider_driver) =>
+                        {
+                            Some(value.clone())
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                if provider_items.is_empty() {
+                    if msg.text_content().trim().is_empty() && msg.tool_calls().is_empty() {
+                        continue;
+                    }
+                    return Err(ProviderError::fatal(format!(
+                        "assistant history is missing Responses output items for provider `{}`",
+                        self.provider_driver
+                    )));
+                }
+                items.extend(provider_items);
+                continue;
+            }
+            let content_type = "input_text";
             let mut pending_text_parts: Vec<Value> = Vec::new();
 
             for block in &msg.content {
@@ -1539,6 +1560,29 @@ impl OpenAIProvider {
             Value::Null => Some(Value::Object(Map::new())),
             other => Some(other),
         }
+    }
+
+    fn message_from_response_body(
+        &self,
+        body: &Value,
+        text: Option<String>,
+        tool_calls: Vec<AiToolCall>,
+    ) -> AiMessage {
+        let mut message = AiResponse::message_from_parts(text, tool_calls, vec![]);
+        if let Some(output_items) = body.get("output").and_then(Value::as_array) {
+            message
+                .content
+                .extend(
+                    output_items
+                        .iter()
+                        .cloned()
+                        .map(|value| AiContent::ProviderState {
+                            provider: self.provider_driver.clone(),
+                            value,
+                        }),
+                );
+        }
+        message
     }
 
     fn extract_text_content(payload: &Value) -> Option<String> {
@@ -2592,6 +2636,16 @@ impl OpenAIProvider {
             );
             return Err(err);
         }
+        if !self.use_chat_completions_endpoint()
+            && body
+                .get("output")
+                .and_then(Value::as_array)
+                .map_or(true, Vec::is_empty)
+        {
+            return Err(ProviderError::fatal(
+                "OpenAI Responses result is missing output items required for history replay",
+            ));
+        }
 
         let usage = body.get("usage").map(|usage| AiUsage {
             input_tokens: usage
@@ -2629,7 +2683,7 @@ impl OpenAIProvider {
         );
 
         let summary = AiResponse {
-            message: AiResponse::message_from_parts(content, tool_choices, vec![]),
+            message: self.message_from_response_body(&body, content, tool_choices),
             usage,
             cost,
             finish_reason: body
@@ -4961,6 +5015,161 @@ data: [DONE]
                 .and_then(|v| v.as_str()),
             Some("data:image/png;base64,aGVsbG8=")
         );
+    }
+
+    #[test]
+    fn responses_history_preserves_and_replays_provider_output_items() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openrouter-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openrouter".to_string(),
+                api_token: "token".to_string(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: default_timeout_ms(),
+            },
+            "token",
+        )
+        .expect("provider should be built");
+        let reasoning_item = json!({
+            "type": "reasoning",
+            "id": "rs_123",
+            "summary": [],
+            "encrypted_content": "opaque",
+        });
+        let message_item = json!({
+            "type": "message",
+            "id": "msg_123",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{
+                "type": "output_text",
+                "text": "hi",
+                "annotations": [{"type": "url_citation", "url": "https://example.com"}],
+            }],
+        });
+        let assistant = provider.message_from_response_body(
+            &json!({"output": [reasoning_item.clone(), message_item.clone()]}),
+            Some("hi".to_string()),
+            vec![],
+        );
+        assert!(assistant.content.iter().all(|content| match content {
+            AiContent::ProviderState { provider, .. } => provider == "openrouter",
+            _ => true,
+        }));
+        let request = AiMethodRequest::new(
+            Capability::Llm,
+            ModelSpec::new("llm.default".to_string(), None),
+            Requirements::default(),
+            AiPayload::new(
+                None,
+                vec![AiMessage::text(AiRole::User, "hello"), assistant],
+                vec![],
+                vec![],
+                None,
+                None,
+            ),
+            None,
+        );
+
+        let messages = provider.build_messages(&request).expect("messages");
+
+        assert_eq!(messages[1], reasoning_item);
+        assert_eq!(messages[2], message_item);
+    }
+
+    #[test]
+    fn responses_history_does_not_replay_foreign_provider_output_items() {
+        let request = AiMethodRequest::new(
+            Capability::Llm,
+            ModelSpec::new("llm.default".to_string(), None),
+            Requirements::default(),
+            AiPayload::new(
+                None,
+                vec![AiMessage::new(
+                    AiRole::Assistant,
+                    vec![
+                        AiContent::text("hi"),
+                        AiContent::ProviderState {
+                            provider: "openai".to_string(),
+                            value: json!({
+                                "type": "message",
+                                "id": "msg_123",
+                                "status": "completed",
+                                "role": "assistant",
+                                "content": [{
+                                    "type": "output_text",
+                                    "text": "hi",
+                                    "annotations": [],
+                                }],
+                            }),
+                        },
+                    ],
+                )],
+                vec![],
+                vec![],
+                None,
+                None,
+            ),
+            None,
+        );
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openrouter-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openrouter".to_string(),
+                api_token: "token".to_string(),
+                base_url: "https://openrouter.ai/api/v1".to_string(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: default_timeout_ms(),
+            },
+            "token",
+        )
+        .expect("provider should be built");
+
+        let err = provider
+            .build_messages(&request)
+            .expect_err("foreign provider state must not be replayed");
+        assert!(err.to_string().contains("provider `openrouter`"));
+    }
+
+    #[test]
+    fn responses_history_rejects_assistant_without_provider_output_items() {
+        let request = AiMethodRequest::new(
+            Capability::Llm,
+            ModelSpec::new("llm.default".to_string(), None),
+            Requirements::default(),
+            AiPayload::new(
+                None,
+                vec![AiMessage::text(AiRole::Assistant, "hi")],
+                vec![],
+                vec![],
+                None,
+                None,
+            ),
+            None,
+        );
+
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openai-main".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
+                api_token: "token".to_string(),
+                base_url: default_base_url(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: default_timeout_ms(),
+            },
+            "token",
+        )
+        .expect("provider should be built");
+        let err = provider
+            .build_messages(&request)
+            .expect_err("assistant history without provider items must fail");
+        assert!(err
+            .to_string()
+            .contains("missing Responses output items for provider `openai`"));
     }
 
     #[test]

--- a/src/frame/aicc/src/sn_ai_provider.rs
+++ b/src/frame/aicc/src/sn_ai_provider.rs
@@ -99,6 +99,7 @@ fn build_sn_ai_provider_instances(
         instances.push(OpenAIInstanceConfig {
             provider_instance_name: raw_instance.provider_instance_name,
             provider_type: raw_instance.provider_type,
+            provider_driver: "sn-ai-provider".to_string(),
             api_token: if raw_instance.api_token.trim().is_empty() {
                 settings.api_token.clone()
             } else {

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -74,7 +74,7 @@ fn claude_provider(base_url: String, timeout_ms: u64) -> ClaudeProvider {
 async fn adapter_openai_01_http_200_success() {
     let base_url = spawn_fake_http_server(vec![MockHttpReply {
         status_code: 200,
-        body: r#"{"id":"r1","status":"completed","output_text":"ok","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}"#.to_string(),
+        body: r#"{"id":"r1","status":"completed","output":[{"type":"message","id":"msg_1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"ok","annotations":[]}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}"#.to_string(),
         content_type: "application/json",
         delay_ms: 0,
     }])

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -14,6 +14,7 @@ fn openai_provider(base_url: String, timeout_ms: u64) -> OpenAIProvider {
         OpenAIInstanceConfig {
             provider_instance_name: "openai-test".to_string(),
             provider_type: "cloud_api".to_string(),
+            provider_driver: "openai".to_string(),
             api_token: "token".to_string(),
             base_url,
             auth_mode: "bearer".to_string(),

--- a/src/frame/llm_context/src/behavior_loop.rs
+++ b/src/frame/llm_context/src/behavior_loop.rs
@@ -77,6 +77,8 @@ pub struct StepRecord {
     /// Raw LLM response text, used verbatim as assistant message content
     /// when this step is rendered back to the LLM.
     pub assistant_text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assistant_message: Option<AiMessage>,
 
     /// "Observation" slot — LLM's reading of the previous action's result.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -143,6 +145,7 @@ impl StepRecord {
         Self {
             meta: StepMeta::default(),
             assistant_text,
+            assistant_message: None,
             observation,
             thought,
             actions: do_actions,
@@ -173,6 +176,7 @@ impl StepRecord {
         Self {
             meta: StepMeta::default(),
             assistant_text: String::new(),
+            assistant_message: None,
             observation: None,
             thought: None,
             actions: Vec::new(),

--- a/src/frame/llm_context/src/context_loop.rs
+++ b/src/frame/llm_context/src/context_loop.rs
@@ -727,6 +727,7 @@ impl LLMContext {
             //    actually dispatch.
             let mut new_step =
                 self.prepare_step(StepRecord::from_result(result), step_started_at_ms);
+            new_step.assistant_message = Some(response.message.clone());
 
             // 3a. Honor `forbid_next_behavior`: a fork sub-ctx must terminate
             //     into its own caller, not jump to a sibling behavior. We

--- a/src/frame/llm_context/src/step_record.rs
+++ b/src/frame/llm_context/src/step_record.rs
@@ -69,10 +69,12 @@ impl XmlStepRenderer {
     }
 
     fn render_full(&self, step: &StepRecord) -> (AiMessage, AiMessage) {
-        let assistant = AiMessage::text(
-            AiRole::Assistant,
-            render_assistant_text_with_action_ids(step),
-        );
+        let assistant = step.assistant_message.clone().unwrap_or_else(|| {
+            AiMessage::text(
+                AiRole::Assistant,
+                render_assistant_text_with_action_ids(step),
+            )
+        });
         let user = step.next_user_message.clone().unwrap_or_else(|| {
             AiMessage::text(
                 AiRole::User,

--- a/src/frame/opendan/src/round_history.rs
+++ b/src/frame/opendan/src/round_history.rs
@@ -1185,6 +1185,12 @@ fn chat_msgonly_message(message: &AiMessage) -> Option<AiMessage> {
         .iter()
         .filter_map(|block| match block {
             AiContent::Text { text } => Some(AiContent::Text { text: text.clone() }),
+            AiContent::ProviderState { provider, value } if message.role == AiRole::Assistant => {
+                Some(AiContent::ProviderState {
+                    provider: provider.clone(),
+                    value: value.clone(),
+                })
+            }
             _ => None,
         })
         .collect();
@@ -1205,8 +1211,8 @@ fn behavior_msgonly_messages(entries: &[Entry]) -> Vec<AiMessage> {
                 }
             }
             EntryPayload::Step { step, .. } => {
-                if let Some(text) = behavior_step_assistant_text(step) {
-                    out.push(AiMessage::text(AiRole::Assistant, text));
+                if let Some(message) = step.assistant_message.clone() {
+                    out.push(message);
                 }
                 if let Some(text) = behavior_step_observation_text(step) {
                     out.push(AiMessage::text(AiRole::Tool, text));
@@ -1421,6 +1427,29 @@ mod tests {
 
     #[tokio::test]
     async fn waiting_tool_round_reopens_and_continues() {
+        fn provider_message(id: &str, text: &str) -> AiMessage {
+            AiMessage::new(
+                AiRole::Assistant,
+                vec![
+                    AiContent::text(text),
+                    AiContent::ProviderState {
+                        provider: "openrouter".to_string(),
+                        value: serde_json::json!({
+                            "type": "message",
+                            "id": id,
+                            "status": "completed",
+                            "role": "assistant",
+                            "content": [{
+                                "type": "output_text",
+                                "text": text,
+                                "annotations": [],
+                            }],
+                        }),
+                    },
+                ],
+            )
+        }
+
         let dir = tempdir().unwrap();
         {
             let mut writer = SessionHistoryWriter::open(dir.path()).await.unwrap();
@@ -1432,6 +1461,10 @@ mod tests {
                 .append_step(
                     StepRecord {
                         assistant_text: "<thought>call tool</thought>".to_string(),
+                        assistant_message: Some(provider_message(
+                            "msg_1",
+                            "<thought>call tool</thought>",
+                        )),
                         thought: Some("call tool".to_string()),
                         ..Default::default()
                     },
@@ -1452,6 +1485,7 @@ mod tests {
             .append_step(
                 StepRecord {
                     assistant_text: "done".to_string(),
+                    assistant_message: Some(provider_message("msg_2", "done")),
                     observation: Some("ok".to_string()),
                     action_results: vec![Observation::Success {
                         call_id: "call-1".to_string(),
@@ -1476,6 +1510,13 @@ mod tests {
             RoundPayload::Full(RoundFullPayload::Behavior { steps }) => {
                 assert_eq!(steps.len(), 2);
                 assert_eq!(steps[1].observation.as_deref(), Some("ok"));
+                assert!(steps[0]
+                    .assistant_message
+                    .as_ref()
+                    .unwrap()
+                    .content
+                    .iter()
+                    .any(|content| matches!(content, AiContent::ProviderState { value, .. } if value["id"] == "msg_1")));
             }
             _ => panic!("expected behavior full payload"),
         }
@@ -1486,6 +1527,10 @@ mod tests {
                 assert_eq!(messages[0].role, AiRole::Assistant);
                 assert_eq!(messages[1].role, AiRole::Assistant);
                 assert_eq!(messages[2].role, AiRole::Tool);
+                assert!(messages[1]
+                    .content
+                    .iter()
+                    .any(|content| matches!(content, AiContent::ProviderState { value, .. } if value["id"] == "msg_2")));
             }
             _ => panic!("expected msgonly payload"),
         }

--- a/src/kernel/buckyos-api/src/aicc_client.rs
+++ b/src/kernel/buckyos-api/src/aicc_client.rs
@@ -822,8 +822,9 @@ pub enum AiContent {
     /// abstracted across providers (OpenAI reasoning item id/encrypted_content,
     /// Claude server_tool_use / web_search_tool_result, etc.).
     ///
-    /// Lowering: only blocks whose `provider` matches the target lowering
-    /// destination are restored to their native item; the rest are dropped.
+    /// `provider` is the stable owner/consumer namespace for the opaque item,
+    /// not the native item's protocol or type name. Each adapter defines the
+    /// provider namespaces it can restore; the rest are dropped.
     ProviderState { provider: String, value: Value },
 }
 


### PR DESCRIPTION
## 背景与意图来源

本 PR 是对 #513 中较大方案的第一阶段拆分，先解决 OpenRouter 一类聚合 Provider 的模型命名和 metadata 归属问题。

- #495 记录了直接问题：OpenRouter 验证时能够发现大量模型，但重新加载后 `provider_driver` 丢失并被当成 OpenAI，最终只剩 OpenAI 默认模型和过滤结果。
- #513 的讨论进一步明确了设计意图：AICC 应保留模型原始作者的物理名称；聚合渠道返回的模型 ID 仍用于实际调用，同时从该 ID 解析原厂 driver/model，让同一物理模型通过不同渠道时进入相同的逻辑模型树。
- 本 PR 按 beta 2.2 breaking change 处理，不增加旧 schema 的兼容分支。

关联：#495、#513。

## 设计意图

将两个此前混在一起的概念分开：

- `provider_driver` / `provider_model_id`：当前调用渠道及其原生模型 ID；
- `origin_driver` / `origin_model_id`：模型原厂及原厂模型 ID，用于 metadata 归属、逻辑挂载和成本元数据选择。

`models`、`patterns`、`variants.model_pattern`、`version_rules.model_pattern` 统一匹配完整的 `provider_model_id`。各 Provider 仍维护各自独立的规则集合，不会在 OpenAI、OpenRouter 之间共享版本候选，也不会跨 GPT、Claude 等模型体系比较版本。

## 更新内容

- 将 driver metadata 升级为 schema v2，新增 `origin_provider_aliases` 和 `origin_mappings`，支持按优先级从 `provider_model_id` 捕获并规范化原厂 driver/model。
- 明确逻辑挂载模板语义：`{driver}` / `{model}` 使用原厂身份，`{provider_driver}` / `{provider_model_id}` 使用当前渠道身份。
- 保留 OpenAI-compatible Provider 配置中的 `provider_driver`，避免 OpenRouter 在保存、重载后退化成 OpenAI。
- 新增 OpenRouter metadata；当前只启用库存中可确认的 OpenAI 原生固定模型，排除动态 alias、`latest`、OpenRouter router 模型和上游 `:variant`。库存明确给出的技术参数优先，否则继承 OpenAI 的 exact/pattern/default 定义。
- OpenRouter 的实际调用继续使用渠道原生 `id`；不依赖逐模型 `provider_actual_model_id` 强制映射。
- 为 metadata variants 增加 `model_pattern`，使派生模型只作用于指定厂商/模型体系；筛掉库存里的派生模型后，仍可由 AICC 对入选原生模型生成自己的 variants。
- 费用估算按原厂 metadata 取值，同时保留聚合渠道对价格字段的覆盖能力。
- 保留 OpenAI Responses API 的 provider-native history item，避免上下文存储、压缩和重放过程中丢失响应协议所需信息。
- 同步更新 driver metadata、AICC 管理和 API 设计文档，并补充解析、过滤、挂载、费用与协议历史相关测试。

## 修复的问题

- 修复聚合 Provider 重载后被错误识别为 OpenAI、库存模型被 OpenAI 过滤规则误删的问题。
- 修复渠道模型名和原厂模型名混用，导致同一物理模型无法挂载到同一逻辑路径的问题。
- 修复 `version_rules` 与其他规则匹配目标不一致的问题，全部统一到完整 `provider_model_id`。
- 修复 variants 在聚合 Provider 内可能跨厂商模型体系错误套用的问题。
- 修复聚合渠道按渠道 driver 而非模型原厂 metadata 估算成本的问题。
- 修复 OpenRouter 动态 alias、免费/参数变体可能被误认成稳定原生模型的问题。
- 修复 Responses API 原生历史在多轮上下文链路中被降级转换、信息丢失的问题。

## 验证

- `cargo test -p aicc`：通过。
- `git diff --check buckyos/beta2.2...feature/aicc-provider-origin-mapping`：通过。

## 风险与后续

- 当前 OpenRouter metadata 只开放 OpenAI 原生固定模型；Claude 等其他厂商应在后续按各自体系补充独立规则和库存校验。
