### PR TITLE
修复 create_worksession 将 task_id=0 当作有效任务的问题

### DIFF
--- a/src/frame/opendan/src/agent.rs
+++ b/src/frame/opendan/src/agent.rs
@@ -1954,6 +1954,7 @@ impl AIAgent {
             auto_start,
             bind_task,
         } = params;
+        let task_id = normalize_task_id(task_id);
         if let Some(task_id) = task_id {
             let Some(client) = self.runtime.task_mgr.as_ref().cloned() else {
                 return Err(anyhow!(
@@ -2440,6 +2441,10 @@ pub struct CreateWorkSessionOutcome {
     pub behavior: String,
     pub auto_started: bool,
     pub task_id: Option<i64>,
+}
+
+fn normalize_task_id(task_id: Option<i64>) -> Option<i64> {
+    task_id.filter(|task_id| *task_id > 0)
 }
 
 struct WorkSessionTaskDefaults {
@@ -2935,6 +2940,14 @@ mod tests {
     use kRPC::{RPCContext, RPCErrors};
     use std::ops::Range;
     use std::sync::atomic::{AtomicI64, Ordering};
+
+    #[test]
+    fn normalize_task_id_omits_non_positive_values() {
+        assert_eq!(normalize_task_id(None), None);
+        assert_eq!(normalize_task_id(Some(-1)), None);
+        assert_eq!(normalize_task_id(Some(0)), None);
+        assert_eq!(normalize_task_id(Some(1)), Some(1));
+    }
 
     #[test]
     fn sanitizes_session_segment() {

--- a/src/frame/opendan/src/worksession_tools.rs
+++ b/src/frame/opendan/src/worksession_tools.rs
@@ -90,6 +90,7 @@ pub struct CreateWorksessionArgs {
     /// Existing TaskManager task to bind. When set, title/objective/workspace
     /// may be derived from the task data.
     #[serde(default)]
+    #[schemars(range(min = 1))]
     pub task_id: Option<i64>,
     /// Reuse an existing workspace by id. Empty / absent ⇒ mint a fresh
     /// workspace bound to the new session.
@@ -1319,6 +1320,22 @@ mod tests {
         .expect("args");
 
         assert!(args.auto_start);
+    }
+
+    #[test]
+    fn create_worksession_task_id_schema_requires_positive_id() {
+        let manager = AgentToolManager::new();
+        register_worksession_tools(&manager, Weak::new(), "ui-session");
+        let spec = manager
+            .get_tool_spec(TOOL_CREATE_WORKSESSION)
+            .expect("create_worksession spec");
+
+        assert_eq!(
+            spec.args_schema
+                .pointer("/properties/task_id/minimum")
+                .and_then(serde_json::Value::as_i64),
+            Some(1)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Jarvis 接到图生图请求后，会先通过 `try_create_worksession` 创建工作会话。普通聊天路径本应省略 `task_id` 并由系统自动创建任务，但模型可能生成 `task_id: 0`。当前实现将它当成已有 TaskManager 任务，调用 `get_task(0)`，最终以 `Task 0 not found` 失败，实际生图流程尚未开始。

## 修改

- 在 `create_worksession` 的工具 Schema 中将 `task_id` 限制为大于等于 1，避免模型生成无效的零值。
- 在 `create_work_session` 业务入口统一过滤非正 `task_id`，按“未指定任务”处理并走自动创建 Task 的正常路径。
- 增加 Schema 约束和非正任务 ID 归一化测试，合法正数任务 ID 的绑定行为保持不变。

## 验证

- `rustfmt --edition 2021 --check src/frame/opendan/src/agent.rs src/frame/opendan/src/worksession_tools.rs`：通过。
- `git diff --check`：通过。
- 两项定向 Cargo 测试在新的临时 target 中进行冷编译，两次均在 5 分钟上限内未完成，第二次停留在 `openssl-sys` 编译阶段，因此尚未实际执行测试用例。

Closes #530