### PR TITLE
修复 Jarvis 文生图附件路径解析失败

### DIFF
--- a/src/frame/llm_context/src/msg_parser.rs
+++ b/src/frame/llm_context/src/msg_parser.rs
@@ -1264,6 +1264,18 @@ mod tests {
     }
 
     #[test]
+    fn attachment_tag_keeps_path_and_display_title_separate() {
+        let tag = parse_attachment_tag(
+            "<attachment path=\"/tmp/wusong_fights_tiger.svg\" title=\"武松打虎.svg\" />",
+        )
+        .unwrap();
+
+        assert_eq!(tag.path.as_deref(), Some("/tmp/wusong_fights_tiger.svg"));
+        assert_eq!(tag.title.as_deref(), Some("武松打虎.svg"));
+        assert_eq!(tag.obj_id, None);
+    }
+
+    #[test]
     fn text_attachment_marker_can_be_preserved_by_option() {
         let msg = AiMessage::text(
             AiRole::Assistant,

--- a/src/rootfs/bin/buckyos_jarvis/behaviors/chat_route.toml
+++ b/src/rootfs/bin/buckyos_jarvis/behaviors/chat_route.toml
@@ -32,7 +32,13 @@ Driver policy for this UI session:
 
 ## Returning Attachments
 
-Use `<attachment>$abs_filepath | $obj_id </attachment>` to send a file or artifact to the user in these cases:
+Use exactly one of these forms to send a file or artifact to the user:
+- Local file: `<attachment path="$abs_filepath" title="$display_name" />`
+- Existing object: `<attachment obj_id="$obj_id" title="$display_name" />`
+
+Do not combine a path and an object ID or use `|` as a separator. Before attaching a local file, create it and verify that the exact path exists.
+
+Send an attachment in these cases:
 - The text file is too long.
 - The file is not a text file.
 - The user explicitly asks for it.


### PR DESCRIPTION
## 问题

Jarvis 的附件返回提示词使用了 `<attachment>$abs_filepath | $obj_id </attachment>`。模型会把 `|` 后的展示名称一起写入附件正文，而消息解析器会将整段正文识别为本地路径，最终因 `stat` 一个不存在的组合路径而拒绝附件。

## 修改

- 将本地文件和已有对象拆分为明确的 `path`、`obj_id` 属性格式。
- 使用 `title` 单独传递展示文件名，禁止使用 `|` 分隔。
- 提示 Jarvis 在返回本地附件前确认精确路径已经创建。
- 增加回归测试，确保附件路径与中文展示名称被分别解析。

## 验证

- `cargo fmt -p llm_context -- --check`
- `cargo test -p llm_context msg_parser`：10 项全部通过。
- `cargo test -p llm_context`：129 项通过；1 项既有 Windows 路径测试 `include_resolves_relative_path_under_roots` 失败，与本次修改无关。
- 实际 Jarvis 会话执行 `/clean` 后，生成的 SVG 附件可以正常打开。

Fixes #531
