### PR TITLE
refactor(aicc): 聚合模型价格元数据

### DIFF
--- a/doc/aicc/aicc-models-mgr.md
+++ b/doc/aicc/aicc-models-mgr.md
@@ -643,7 +643,7 @@ llm.reason 不随意 fallback
 
 Scheduler 不只看目录权重，还看候选的运行属性：
 
-- `estimated_cost_usd` 或动态成本估算；
+- `pricing.estimated_cost` 或动态成本估算；
 - `p95_latency_ms` 或 latency class；
 - `error_rate_5m`；
 - `quality_score`；
@@ -676,10 +676,12 @@ Scheduler 再在剩余候选中按 profile 打分。
 用户可以通过 provider 侧价格配置或 override 影响：
 
 ```text
-estimated_cost_usd
-input_token_usd
-output_token_usd
-cache_input_token_usd
+pricing:
+  currency: USD
+  estimated_cost: 0.01
+  input_token: 0.000001
+  output_token: 0.000002
+  cache_input_token: 0.0000005
 ```
 
 这适合表达“同一个模型，哪个 provider 更便宜就优先用哪个”。

--- a/doc/aicc/aicc_router.md
+++ b/doc/aicc/aicc_router.md
@@ -433,9 +433,10 @@ models:
       latency_class: normal
       cost_class: high
     pricing:
-      input_token_usd: 0.0000000
-      output_token_usd: 0.0000000
-      cache_input_token_usd: 0.0000000
+      currency: USD
+      input_token: 0.0000000
+      output_token: 0.0000000
+      cache_input_token: 0.0000000
     health:
       status: available
       p95_latency_ms: 3000

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -34,7 +34,7 @@ provider's complete mapping list.
 ```json
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "openai",
   "revision_seq": 1,
@@ -52,7 +52,7 @@ provider's complete mapping list.
 Fields:
 
  - `format`: fixed to `buckyos.aicc.provider-driver-metadata`.
- - `schema_version`: incompatible schema major, currently `2`.
+ - `schema_version`: incompatible schema major, currently `3`.
  - `schema_revision`: additive schema revision, currently `0`.
  - `provider_driver`: driver id such as `openai`, `openrouter`, `claude`,
   `google-gemini`, `fal`, or `minimax`.
@@ -96,9 +96,10 @@ Rules support these fields:
   The first pair identifies the physical origin; the second pair identifies the
   current delivery channel.
 - `capabilities`: partial capability patch: `streaming`, `tool_call`, `json_schema`, `web_search`, `vision`, `max_context_tokens`, `max_output_tokens`.
-- `input_token_usd`, `output_token_usd`, `cache_input_token_usd`: optional
-  provider token prices in USD per token.
-- `estimated_cost_usd`, `estimated_latency_ms`: default scheduler estimates.
+- `pricing`: optional monetary data object. `currency` identifies the ISO 4217
+  currency; `input_token`, `output_token`, and `cache_input_token` are optional
+  per-token prices; `estimated_cost` is the default scheduler cost estimate.
+- `estimated_latency_ms`: default scheduler latency estimate.
 - `quality_score`, `latency_class`, `cost_class`: routing attributes.
 
 All exact ids and wildcard patterns, including

--- a/doc/aicc/driver_metadata_update_protocol.md
+++ b/doc/aicc/driver_metadata_update_protocol.md
@@ -83,7 +83,7 @@ PathObject 的签名、host、path 和 `exp` 由 NDN SDK 验证，AICC 不另设
     {
       "provider_driver": "openai",
       "path": "v1/providers/openai-18.json",
-      "schema_version": 2,
+      "schema_version": 3,
       "revision_seq": 18,
       "obj_id": "<FileObject ObjId>"
     }
@@ -108,7 +108,7 @@ PathObject 的签名、host、path 和 `exp` 由 NDN SDK 验证，AICC 不另设
 ```json
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "openai",
   "revision_seq": 18,

--- a/src/frame/aicc/driver_metadata/claude.json
+++ b/src/frame/aicc/driver_metadata/claude.json
@@ -1,6 +1,6 @@
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "claude",
   "revision_seq": 1,
@@ -20,7 +20,10 @@
         "max_context_tokens": 200000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1800,
       "latency_class": "normal",
       "cost_class": "low"
@@ -48,7 +51,10 @@
         "max_context_tokens": 200000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1800
     },
     {
@@ -74,7 +80,10 @@
         "max_context_tokens": 200000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1800
     },
     {
@@ -100,7 +109,10 @@
         "max_context_tokens": 200000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1800
     },
     {
@@ -126,7 +138,10 @@
         "max_context_tokens": 200000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1800
     },
     {
@@ -152,7 +167,10 @@
         "max_context_tokens": 200000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1800
     },
     {
@@ -177,7 +195,10 @@
         "max_context_tokens": 200000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1800
     }
   ],
@@ -191,7 +212,10 @@
       "web_search": false,
       "vision": false
     },
-    "estimated_cost_usd": 0.01,
+    "pricing": {
+      "currency": "USD",
+      "estimated_cost": 0.01
+    },
     "estimated_latency_ms": 1800
   },
   "variants": [

--- a/src/frame/aicc/driver_metadata/fal.json
+++ b/src/frame/aicc/driver_metadata/fal.json
@@ -1,6 +1,6 @@
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "fal",
   "revision_seq": 1,
@@ -11,7 +11,10 @@
       "model_driver": "real-esrgan",
       "api_types": ["image.upscale"],
       "logical_mounts": ["image.upscale", "image.upscale.fal", "image.upscale.fal-ai.esrgan"],
-      "estimated_cost_usd": 0.05,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.05
+      },
       "estimated_latency_ms": 8000
     },
     {
@@ -19,7 +22,10 @@
       "model_driver": "rembg",
       "api_types": ["image.bg_remove"],
       "logical_mounts": ["image.bg_remove", "image.bg_remove.fal", "image.bg_remove.fal-ai.imageutils.rembg"],
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 4000
     },
     {
@@ -27,7 +33,10 @@
       "model_driver": "deepfilternet",
       "api_types": ["audio.enhance"],
       "logical_mounts": ["audio.enhance", "audio.enhance.fal", "audio.enhance.fal-ai.deepfilternet3"],
-      "estimated_cost_usd": 0.02,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.02
+      },
       "estimated_latency_ms": 20000
     },
     {
@@ -35,7 +44,10 @@
       "model_driver": "real-esrgan",
       "api_types": ["video.upscale"],
       "logical_mounts": ["video.upscale", "video.upscale.fal", "video.upscale.fal-ai.video-upscaler"],
-      "estimated_cost_usd": 0.5,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.5
+      },
       "estimated_latency_ms": 120000
     }
   ],

--- a/src/frame/aicc/driver_metadata/gemini.json
+++ b/src/frame/aicc/driver_metadata/gemini.json
@@ -1,6 +1,6 @@
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "google-gemini",
   "revision_seq": 1,
@@ -19,21 +19,30 @@
         "embedding.multimodal.gemini",
         "embedding.multimodal.{model}"
       ],
-      "estimated_cost_usd": 0.0001,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0001
+      },
       "estimated_latency_ms": 800
     },
     {
       "id": "gemini-2.5-flash-preview-tts",
       "api_types": ["audio.tts"],
       "logical_mounts": ["audio.tts", "audio.tts.google", "audio.tts.gemini", "audio.tts.{model}"],
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 3000
     },
     {
       "id": "lyria-002",
       "api_types": ["audio.music"],
       "logical_mounts": ["audio.music", "audio.music.google", "audio.music.gemini", "audio.music.{model}"],
-      "estimated_cost_usd": 0.1,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.1
+      },
       "estimated_latency_ms": 60000
     },
     {
@@ -45,7 +54,10 @@
         "video.txt2video.gemini",
         "video.txt2video.{model}"
       ],
-      "estimated_cost_usd": 0.5,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.5
+      },
       "estimated_latency_ms": 120000
     }
   ],
@@ -63,21 +75,30 @@
         "embedding.multimodal.gemini",
         "embedding.multimodal.{model}"
       ],
-      "estimated_cost_usd": 0.0001,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0001
+      },
       "estimated_latency_ms": 800
     },
     {
       "pattern": "*tts*",
       "api_types": ["audio.tts"],
       "logical_mounts": ["audio.tts", "audio.tts.google", "audio.tts.gemini", "audio.tts.{model}"],
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 3000
     },
     {
       "pattern": "lyria-*",
       "api_types": ["audio.music"],
       "logical_mounts": ["audio.music", "audio.music.google", "audio.music.gemini", "audio.music.{model}"],
-      "estimated_cost_usd": 0.1,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.1
+      },
       "estimated_latency_ms": 60000
     },
     {
@@ -89,7 +110,10 @@
         "video.txt2video.gemini",
         "video.txt2video.{model}"
       ],
-      "estimated_cost_usd": 0.5,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.5
+      },
       "estimated_latency_ms": 120000
     },
     {
@@ -104,7 +128,10 @@
         "image.img2img.gemini",
         "image.img2img.{model}"
       ],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 6000
     },
     {
@@ -119,7 +146,10 @@
         "image.img2img.gemini",
         "image.img2img.{model}"
       ],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 6000
     },
     {
@@ -134,7 +164,10 @@
         "image.img2img.gemini",
         "image.img2img.{model}"
       ],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 6000
     },
     {
@@ -171,7 +204,10 @@
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1400
     },
     {
@@ -208,7 +244,10 @@
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1400
     },
     {
@@ -245,7 +284,10 @@
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1400
     },
     {
@@ -282,7 +324,10 @@
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1400
     },
     {
@@ -319,7 +364,10 @@
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1400
     },
     {
@@ -355,7 +403,10 @@
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1400
     }
   ],
@@ -369,7 +420,10 @@
       "web_search": false,
       "vision": false
     },
-    "estimated_cost_usd": 0.01,
+    "pricing": {
+      "currency": "USD",
+      "estimated_cost": 0.01
+    },
     "estimated_latency_ms": 1400
   },
   "variants": [],

--- a/src/frame/aicc/driver_metadata/minimax.json
+++ b/src/frame/aicc/driver_metadata/minimax.json
@@ -1,6 +1,6 @@
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "minimax",
   "revision_seq": 1,
@@ -20,7 +20,10 @@
         "max_context_tokens": 100000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1400
     }
   ],
@@ -34,7 +37,10 @@
       "web_search": false,
       "vision": false
     },
-    "estimated_cost_usd": 0.01,
+    "pricing": {
+      "currency": "USD",
+      "estimated_cost": 0.01
+    },
     "estimated_latency_ms": 1400
   },
   "variants": [

--- a/src/frame/aicc/driver_metadata/openai.json
+++ b/src/frame/aicc/driver_metadata/openai.json
@@ -1,6 +1,6 @@
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "openai",
   "revision_seq": 1,
@@ -20,7 +20,10 @@
         "image.inpaint.{driver}",
         "image.inpaint.{model}"
       ],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 5000,
       "quality_score": 0.9
     },
@@ -28,56 +31,80 @@
       "id": "dall-e-3",
       "api_types": ["image.txt2img"],
       "logical_mounts": ["image.txt2img.{driver}", "image.txt2img.dalle", "image.txt2img.{model}"],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 5000
     },
     {
       "id": "dall-e-2",
       "api_types": ["image.txt2img"],
       "logical_mounts": ["image.txt2img.{driver}", "image.txt2img.dalle", "image.txt2img.{model}"],
-      "estimated_cost_usd": 0.02,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.02
+      },
       "estimated_latency_ms": 5000
     },
     {
       "id": "text-embedding-3-large",
       "api_types": ["embedding.text"],
       "logical_mounts": ["embedding.text", "embedding.text.{driver}", "embedding.text.{model}"],
-      "estimated_cost_usd": 0.0001,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0001
+      },
       "estimated_latency_ms": 800
     },
     {
       "id": "text-embedding-3-small",
       "api_types": ["embedding.text"],
       "logical_mounts": ["embedding.text", "embedding.text.{driver}", "embedding.text.{model}"],
-      "estimated_cost_usd": 0.0001,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0001
+      },
       "estimated_latency_ms": 800
     },
     {
       "id": "whisper-1",
       "api_types": ["audio.asr"],
       "logical_mounts": ["audio.asr", "audio.asr.{driver}", "audio.asr.{model}"],
-      "estimated_cost_usd": 0.006,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.006
+      },
       "estimated_latency_ms": 5000
     },
     {
       "id": "gpt-4o-mini-transcribe",
       "api_types": ["audio.asr"],
       "logical_mounts": ["audio.asr", "audio.asr.{driver}", "audio.asr.{model}"],
-      "estimated_cost_usd": 0.006,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.006
+      },
       "estimated_latency_ms": 5000
     },
     {
       "id": "tts-1",
       "api_types": ["audio.tts"],
       "logical_mounts": ["audio.tts", "audio.tts.{driver}", "audio.tts.{model}"],
-      "estimated_cost_usd": 0.015,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.015
+      },
       "estimated_latency_ms": 3000
     },
     {
       "id": "gpt-4o-mini-tts",
       "api_types": ["audio.tts"],
       "logical_mounts": ["audio.tts", "audio.tts.{driver}", "audio.tts.{model}"],
-      "estimated_cost_usd": 0.015,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.015
+      },
       "estimated_latency_ms": 3000
     }
   ],
@@ -86,14 +113,20 @@
       "pattern": "*transcribe*",
       "api_types": ["audio.asr"],
       "logical_mounts": ["audio.asr", "audio.asr.{driver}", "audio.asr.{model}"],
-      "estimated_cost_usd": 0.006,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.006
+      },
       "estimated_latency_ms": 5000
     },
     {
       "pattern": "*-tts*",
       "api_types": ["audio.tts"],
       "logical_mounts": ["audio.tts", "audio.tts.{driver}", "audio.tts.{model}"],
-      "estimated_cost_usd": 0.015,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.015
+      },
       "estimated_latency_ms": 3000
     },
     {
@@ -108,7 +141,10 @@
       "pattern": "dall-e-*",
       "api_types": ["image.txt2img"],
       "logical_mounts": ["image.txt2img.{driver}", "image.txt2img.dalle", "image.txt2img.{model}"],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 5000
     },
     {
@@ -125,7 +161,10 @@
         "image.inpaint.{driver}",
         "image.inpaint.{model}"
       ],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 5000,
       "quality_score": 0.9
     },
@@ -133,7 +172,10 @@
       "pattern": "text-embedding-*",
       "api_types": ["embedding.text"],
       "logical_mounts": ["embedding.text", "embedding.text.{driver}", "embedding.text.{model}"],
-      "estimated_cost_usd": 0.0001,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0001
+      },
       "estimated_latency_ms": 800
     },
     {
@@ -154,7 +196,10 @@
         "max_context_tokens": 128000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -173,7 +218,10 @@
         "max_context_tokens": 128000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -187,7 +235,10 @@
         "max_context_tokens": 128000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1200
     }
   ],
@@ -201,7 +252,10 @@
       "web_search": false,
       "vision": false
     },
-    "estimated_cost_usd": 0.01,
+    "pricing": {
+      "currency": "USD",
+      "estimated_cost": 0.01
+    },
     "estimated_latency_ms": 1200
   },
   "variants": [

--- a/src/frame/aicc/driver_metadata/openrouter.json
+++ b/src/frame/aicc/driver_metadata/openrouter.json
@@ -1,6 +1,6 @@
 {
   "format": "buckyos.aicc.provider-driver-metadata",
-  "schema_version": 2,
+  "schema_version": 3,
   "schema_revision": 0,
   "provider_driver": "openrouter",
   "revision_seq": 1,
@@ -61,9 +61,12 @@
         "max_output_tokens": 4096,
         "vision": false
       },
-      "estimated_cost_usd": 0.002,
-      "input_token_usd": 5e-7,
-      "output_token_usd": 0.0000015,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.002,
+        "input_token": 5e-7,
+        "output_token": 0.0000015
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -91,9 +94,12 @@
         "max_output_tokens": 4096,
         "vision": false
       },
-      "estimated_cost_usd": 0.003,
-      "input_token_usd": 0.000001,
-      "output_token_usd": 0.000002,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.003,
+        "input_token": 0.000001,
+        "output_token": 0.000002
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -121,9 +127,12 @@
         "max_output_tokens": 4096,
         "vision": false
       },
-      "estimated_cost_usd": 0.007,
-      "input_token_usd": 0.000003,
-      "output_token_usd": 0.000004,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.007,
+        "input_token": 0.000003,
+        "output_token": 0.000004
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -151,9 +160,12 @@
         "max_output_tokens": 4096,
         "vision": false
       },
-      "estimated_cost_usd": 0.0035,
-      "input_token_usd": 0.0000015,
-      "output_token_usd": 0.000002,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0035,
+        "input_token": 0.0000015,
+        "output_token": 0.000002
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -181,9 +193,12 @@
         "max_output_tokens": 4096,
         "vision": false
       },
-      "estimated_cost_usd": 0.09000000000000001,
-      "input_token_usd": 0.00003,
-      "output_token_usd": 0.00006,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.09000000000000001,
+        "input_token": 0.00003,
+        "output_token": 0.00006
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -211,10 +226,13 @@
         "max_output_tokens": 32768,
         "vision": true
       },
-      "estimated_cost_usd": 0.009999999999999998,
-      "input_token_usd": 0.000002,
-      "output_token_usd": 0.000008,
-      "cache_input_token_usd": 5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.009999999999999998,
+        "input_token": 0.000002,
+        "output_token": 0.000008,
+        "cache_input_token": 5e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -242,10 +260,13 @@
         "max_output_tokens": 32768,
         "vision": true
       },
-      "estimated_cost_usd": 0.002,
-      "input_token_usd": 4e-7,
-      "output_token_usd": 0.0000016,
-      "cache_input_token_usd": 1e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.002,
+        "input_token": 4e-7,
+        "output_token": 0.0000016,
+        "cache_input_token": 1e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -273,10 +294,13 @@
         "max_output_tokens": 32768,
         "vision": true
       },
-      "estimated_cost_usd": 0.0005,
-      "input_token_usd": 1e-7,
-      "output_token_usd": 4e-7,
-      "cache_input_token_usd": 2.5e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0005,
+        "input_token": 1e-7,
+        "output_token": 4e-7,
+        "cache_input_token": 2.5e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -304,10 +328,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.0125,
-      "input_token_usd": 0.0000025,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 0.00000125,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0125,
+        "input_token": 0.0000025,
+        "output_token": 0.00001,
+        "cache_input_token": 0.00000125
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -335,9 +362,12 @@
         "max_output_tokens": 4096,
         "vision": true
       },
-      "estimated_cost_usd": 0.02,
-      "input_token_usd": 0.000005,
-      "output_token_usd": 0.000015,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.02,
+        "input_token": 0.000005,
+        "output_token": 0.000015
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -365,10 +395,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.0125,
-      "input_token_usd": 0.0000025,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 0.00000125,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0125,
+        "input_token": 0.0000025,
+        "output_token": 0.00001,
+        "cache_input_token": 0.00000125
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -396,10 +429,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.0125,
-      "input_token_usd": 0.0000025,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 0.00000125,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0125,
+        "input_token": 0.0000025,
+        "output_token": 0.00001,
+        "cache_input_token": 0.00000125
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -427,10 +463,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.00075,
-      "input_token_usd": 1.5e-7,
-      "output_token_usd": 6e-7,
-      "cache_input_token_usd": 7.5e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.00075,
+        "input_token": 1.5e-7,
+        "output_token": 6e-7,
+        "cache_input_token": 7.5e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -458,10 +497,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.00075,
-      "input_token_usd": 1.5e-7,
-      "output_token_usd": 6e-7,
-      "cache_input_token_usd": 7.5e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.00075,
+        "input_token": 1.5e-7,
+        "output_token": 6e-7,
+        "cache_input_token": 7.5e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -489,9 +531,12 @@
         "max_output_tokens": 16384,
         "vision": false
       },
-      "estimated_cost_usd": 0.00075,
-      "input_token_usd": 1.5e-7,
-      "output_token_usd": 6e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.00075,
+        "input_token": 1.5e-7,
+        "output_token": 6e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -519,9 +564,12 @@
         "max_output_tokens": 16384,
         "vision": false
       },
-      "estimated_cost_usd": 0.0125,
-      "input_token_usd": 0.0000025,
-      "output_token_usd": 0.00001,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0125,
+        "input_token": 0.0000025,
+        "output_token": 0.00001
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -549,9 +597,12 @@
         "max_output_tokens": 4096,
         "vision": true
       },
-      "estimated_cost_usd": 0.04,
-      "input_token_usd": 0.00001,
-      "output_token_usd": 0.00003,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04,
+        "input_token": 0.00001,
+        "output_token": 0.00003
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -579,9 +630,12 @@
         "max_output_tokens": 4096,
         "vision": false
       },
-      "estimated_cost_usd": 0.04,
-      "input_token_usd": 0.00001,
-      "output_token_usd": 0.00003,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04,
+        "input_token": 0.00001,
+        "output_token": 0.00003
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -609,10 +663,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.011250000000000001,
-      "input_token_usd": 0.00000125,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 1.25e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.011250000000000001,
+        "input_token": 0.00000125,
+        "output_token": 0.00001,
+        "cache_input_token": 1.25e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -640,10 +697,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.011250000000000001,
-      "input_token_usd": 0.00000125,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 1.25e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.011250000000000001,
+        "input_token": 0.00000125,
+        "output_token": 0.00001,
+        "cache_input_token": 1.25e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -671,10 +731,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.011250000000000001,
-      "input_token_usd": 0.00000125,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 1.25e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.011250000000000001,
+        "input_token": 0.00000125,
+        "output_token": 0.00001,
+        "cache_input_token": 1.25e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -702,10 +765,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.011250000000000001,
-      "input_token_usd": 0.00000125,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 1.25e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.011250000000000001,
+        "input_token": 0.00000125,
+        "output_token": 0.00001,
+        "cache_input_token": 1.25e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -733,10 +799,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.011250000000000001,
-      "input_token_usd": 0.00000125,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 1.25e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.011250000000000001,
+        "input_token": 0.00000125,
+        "output_token": 0.00001,
+        "cache_input_token": 1.25e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -764,10 +833,13 @@
         "max_output_tokens": 100000,
         "vision": true
       },
-      "estimated_cost_usd": 0.0022500000000000003,
-      "input_token_usd": 2.5e-7,
-      "output_token_usd": 0.000002,
-      "cache_input_token_usd": 2.5e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0022500000000000003,
+        "input_token": 2.5e-7,
+        "output_token": 0.000002,
+        "cache_input_token": 2.5e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -795,10 +867,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.01575,
-      "input_token_usd": 0.00000175,
-      "output_token_usd": 0.000014,
-      "cache_input_token_usd": 1.75e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01575,
+        "input_token": 0.00000175,
+        "output_token": 0.000014,
+        "cache_input_token": 1.75e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -826,10 +901,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.01575,
-      "input_token_usd": 0.00000175,
-      "output_token_usd": 0.000014,
-      "cache_input_token_usd": 1.75e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01575,
+        "input_token": 0.00000175,
+        "output_token": 0.000014,
+        "cache_input_token": 1.75e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -857,10 +935,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.01575,
-      "input_token_usd": 0.00000175,
-      "output_token_usd": 0.000014,
-      "cache_input_token_usd": 1.75e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01575,
+        "input_token": 0.00000175,
+        "output_token": 0.000014,
+        "cache_input_token": 1.75e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -888,9 +969,12 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.18899999999999997,
-      "input_token_usd": 0.000021,
-      "output_token_usd": 0.000168,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.18899999999999997,
+        "input_token": 0.000021,
+        "output_token": 0.000168
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -918,10 +1002,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.01575,
-      "input_token_usd": 0.00000175,
-      "output_token_usd": 0.000014,
-      "cache_input_token_usd": 1.75e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01575,
+        "input_token": 0.00000175,
+        "output_token": 0.000014,
+        "cache_input_token": 1.75e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -949,10 +1036,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.01575,
-      "input_token_usd": 0.00000175,
-      "output_token_usd": 0.000014,
-      "cache_input_token_usd": 1.75e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01575,
+        "input_token": 0.00000175,
+        "output_token": 0.000014,
+        "cache_input_token": 1.75e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -980,10 +1070,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.0175,
-      "input_token_usd": 0.0000025,
-      "output_token_usd": 0.000015,
-      "cache_input_token_usd": 2.5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0175,
+        "input_token": 0.0000025,
+        "output_token": 0.000015,
+        "cache_input_token": 2.5e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1011,10 +1104,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.00525,
-      "input_token_usd": 7.5e-7,
-      "output_token_usd": 0.0000045,
-      "cache_input_token_usd": 7.5e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.00525,
+        "input_token": 7.5e-7,
+        "output_token": 0.0000045,
+        "cache_input_token": 7.5e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1042,10 +1138,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.0014500000000000001,
-      "input_token_usd": 2e-7,
-      "output_token_usd": 0.00000125,
-      "cache_input_token_usd": 2e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0014500000000000001,
+        "input_token": 2e-7,
+        "output_token": 0.00000125,
+        "cache_input_token": 2e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1073,9 +1172,12 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.21000000000000002,
-      "input_token_usd": 0.00003,
-      "output_token_usd": 0.00018,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.21000000000000002,
+        "input_token": 0.00003,
+        "output_token": 0.00018
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1103,10 +1205,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.035,
-      "input_token_usd": 0.000005,
-      "output_token_usd": 0.00003,
-      "cache_input_token_usd": 5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.035,
+        "input_token": 0.000005,
+        "output_token": 0.00003,
+        "cache_input_token": 5e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1134,9 +1239,12 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.21000000000000002,
-      "input_token_usd": 0.00003,
-      "output_token_usd": 0.00018,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.21000000000000002,
+        "input_token": 0.00003,
+        "output_token": 0.00018
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1164,10 +1272,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.007,
-      "input_token_usd": 0.000001,
-      "output_token_usd": 0.000006,
-      "cache_input_token_usd": 1e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.007,
+        "input_token": 0.000001,
+        "output_token": 0.000006,
+        "cache_input_token": 1e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1195,10 +1306,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.035,
-      "input_token_usd": 0.000005,
-      "output_token_usd": 0.00003,
-      "cache_input_token_usd": 5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.035,
+        "input_token": 0.000005,
+        "output_token": 0.00003,
+        "cache_input_token": 5e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1226,10 +1340,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.0175,
-      "input_token_usd": 0.0000025,
-      "output_token_usd": 0.000015,
-      "cache_input_token_usd": 2.5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0175,
+        "input_token": 0.0000025,
+        "output_token": 0.000015,
+        "cache_input_token": 2.5e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1257,10 +1374,13 @@
         "max_output_tokens": 16384,
         "vision": true
       },
-      "estimated_cost_usd": 0.011250000000000001,
-      "input_token_usd": 0.00000125,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 1.25e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.011250000000000001,
+        "input_token": 0.00000125,
+        "output_token": 0.00001,
+        "cache_input_token": 1.25e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1288,10 +1408,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.011250000000000001,
-      "input_token_usd": 0.00000125,
-      "output_token_usd": 0.00001,
-      "cache_input_token_usd": 1.25e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.011250000000000001,
+        "input_token": 0.00000125,
+        "output_token": 0.00001,
+        "cache_input_token": 1.25e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1319,10 +1442,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.0022500000000000003,
-      "input_token_usd": 2.5e-7,
-      "output_token_usd": 0.000002,
-      "cache_input_token_usd": 2.5e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0022500000000000003,
+        "input_token": 2.5e-7,
+        "output_token": 0.000002,
+        "cache_input_token": 2.5e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1350,10 +1476,13 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.00045,
-      "input_token_usd": 5e-8,
-      "output_token_usd": 4e-7,
-      "cache_input_token_usd": 5e-9,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.00045,
+        "input_token": 5e-8,
+        "output_token": 4e-7,
+        "cache_input_token": 5e-9
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1381,9 +1510,12 @@
         "max_output_tokens": 128000,
         "vision": true
       },
-      "estimated_cost_usd": 0.135,
-      "input_token_usd": 0.000015,
-      "output_token_usd": 0.00012,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.135,
+        "input_token": 0.000015,
+        "output_token": 0.00012
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1411,9 +1543,12 @@
         "max_output_tokens": 131072,
         "vision": false
       },
-      "estimated_cost_usd": 0.000207,
-      "input_token_usd": 3.7e-8,
-      "output_token_usd": 1.7e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.000207,
+        "input_token": 3.7e-8,
+        "output_token": 1.7e-7
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1441,10 +1576,13 @@
         "max_output_tokens": 131072,
         "vision": false
       },
-      "estimated_cost_usd": 0.00016,
-      "input_token_usd": 3e-8,
-      "output_token_usd": 1.3e-7,
-      "cache_input_token_usd": 3e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.00016,
+        "input_token": 3e-8,
+        "output_token": 1.3e-7,
+        "cache_input_token": 3e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1472,10 +1610,13 @@
         "max_output_tokens": 65536,
         "vision": false
       },
-      "estimated_cost_usd": 0.000375,
-      "input_token_usd": 7.5e-8,
-      "output_token_usd": 3e-7,
-      "cache_input_token_usd": 3.75e-8,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.000375,
+        "input_token": 7.5e-8,
+        "output_token": 3e-7,
+        "cache_input_token": 3.75e-8
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1500,10 +1641,13 @@
         "web_search": false,
         "vision": true
       },
-      "estimated_cost_usd": 0.07500000000000001,
-      "input_token_usd": 0.000015,
-      "output_token_usd": 0.00006,
-      "cache_input_token_usd": 0.0000075,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.07500000000000001,
+        "input_token": 0.000015,
+        "output_token": 0.00006,
+        "cache_input_token": 0.0000075
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1525,9 +1669,12 @@
         "web_search": false,
         "vision": true
       },
-      "estimated_cost_usd": 0.7499999999999999,
-      "input_token_usd": 0.00015,
-      "output_token_usd": 0.0006,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.7499999999999999,
+        "input_token": 0.00015,
+        "output_token": 0.0006
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1549,10 +1696,13 @@
         "web_search": false,
         "vision": true
       },
-      "estimated_cost_usd": 0.009999999999999998,
-      "input_token_usd": 0.000002,
-      "output_token_usd": 0.000008,
-      "cache_input_token_usd": 5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.009999999999999998,
+        "input_token": 0.000002,
+        "output_token": 0.000008,
+        "cache_input_token": 5e-7
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1574,10 +1724,13 @@
         "web_search": true,
         "vision": true
       },
-      "estimated_cost_usd": 0.05,
-      "input_token_usd": 0.00001,
-      "output_token_usd": 0.00004,
-      "cache_input_token_usd": 0.0000025,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.05,
+        "input_token": 0.00001,
+        "output_token": 0.00004,
+        "cache_input_token": 0.0000025
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1599,10 +1752,13 @@
         "web_search": false,
         "vision": false
       },
-      "estimated_cost_usd": 0.0055,
-      "input_token_usd": 0.0000011,
-      "output_token_usd": 0.0000044,
-      "cache_input_token_usd": 5.5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0055,
+        "input_token": 0.0000011,
+        "output_token": 0.0000044,
+        "cache_input_token": 5.5e-7
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1624,9 +1780,12 @@
         "web_search": false,
         "vision": true
       },
-      "estimated_cost_usd": 0.1,
-      "input_token_usd": 0.00002,
-      "output_token_usd": 0.00008,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.1,
+        "input_token": 0.00002,
+        "output_token": 0.00008
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1648,10 +1807,13 @@
         "web_search": false,
         "vision": true
       },
-      "estimated_cost_usd": 0.0055,
-      "input_token_usd": 0.0000011,
-      "output_token_usd": 0.0000044,
-      "cache_input_token_usd": 2.75e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0055,
+        "input_token": 0.0000011,
+        "output_token": 0.0000044,
+        "cache_input_token": 2.75e-7
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1673,10 +1835,13 @@
         "web_search": true,
         "vision": true
       },
-      "estimated_cost_usd": 0.009999999999999998,
-      "input_token_usd": 0.000002,
-      "output_token_usd": 0.000008,
-      "cache_input_token_usd": 5e-7,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.009999999999999998,
+        "input_token": 0.000002,
+        "output_token": 0.000008,
+        "cache_input_token": 5e-7
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1747,7 +1912,10 @@
         "audio.asr.{driver}",
         "audio.asr.{model}"
       ],
-      "estimated_cost_usd": 0.006,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.006
+      },
       "estimated_latency_ms": 5000
     },
     {
@@ -1760,7 +1928,10 @@
         "audio.tts.{driver}",
         "audio.tts.{model}"
       ],
-      "estimated_cost_usd": 0.015,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.015
+      },
       "estimated_latency_ms": 3000
     },
     {
@@ -1781,7 +1952,10 @@
         "image.txt2img.dalle",
         "image.txt2img.{model}"
       ],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 5000
     },
     {
@@ -1802,7 +1976,10 @@
         "image.inpaint.{driver}",
         "image.inpaint.{model}"
       ],
-      "estimated_cost_usd": 0.04,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.04
+      },
       "estimated_latency_ms": 5000,
       "quality_score": 0.9
     },
@@ -1816,7 +1993,10 @@
         "embedding.text.{driver}",
         "embedding.text.{model}"
       ],
-      "estimated_cost_usd": 0.0001,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.0001
+      },
       "estimated_latency_ms": 800
     },
     {
@@ -1840,7 +2020,10 @@
         "max_context_tokens": 128000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1200,
       "quality_score": 0.9,
       "latency_class": "normal",
@@ -1864,7 +2047,10 @@
         "max_context_tokens": 128000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1884,7 +2070,10 @@
         "max_context_tokens": 128000,
         "max_output_tokens": 8192
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1903,7 +2092,10 @@
         "web_search": false,
         "vision": false
       },
-      "estimated_cost_usd": 0.01,
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.01
+      },
       "estimated_latency_ms": 1200
     },
     {
@@ -1926,7 +2118,10 @@
       "web_search": false,
       "vision": false
     },
-    "estimated_cost_usd": 0.01,
+    "pricing": {
+      "currency": "USD",
+      "estimated_cost": 0.01
+    },
     "estimated_latency_ms": 1200
   },
   "variants": [

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -2912,7 +2912,7 @@ pub fn provider_model_metadata(
             cost_class: CostClass::Unknown,
         },
         pricing: ModelPricing {
-            estimated_cost_usd,
+            estimated_cost: estimated_cost_usd,
             ..Default::default()
         },
         health: ModelHealth {
@@ -3756,7 +3756,7 @@ impl AIComputeCenter {
                     estimate.estimated_cost_usd,
                 )
                 .unwrap_or(estimate.estimated_cost_usd);
-            candidate.metadata.pricing.estimated_cost_usd = Some(effective_cost.max(0.0));
+            candidate.metadata.pricing.estimated_cost = Some(effective_cost.max(0.0));
             candidate.dynamic_cost_estimate = Some(CostEstimateOutput {
                 estimated_cost_usd: effective_cost.max(0.0),
                 pricing_mode: estimate.pricing_mode,
@@ -3786,7 +3786,7 @@ impl AIComputeCenter {
                     .dynamic_cost_estimate
                     .as_ref()
                     .map(|estimate| estimate.estimated_cost_usd)
-                    .or(candidate.metadata.pricing.estimated_cost_usd);
+                    .or(candidate.metadata.pricing.estimated_cost);
                 if cost.map(|value| value > max_cost).unwrap_or(false) {
                     return false;
                 }

--- a/src/frame/aicc/src/claude.rs
+++ b/src/frame/aicc/src/claude.rs
@@ -443,7 +443,7 @@ impl ClaudeProvider {
                 };
                 Some(
                     DriverModelResolveRequest::new(provider_model_id, fallback_api_types)
-                        .with_cost(model.pricing.estimated_cost_usd)
+                        .with_cost(model.pricing.estimated_cost)
                         .with_latency(model.health.p50_latency_ms.or(model.health.p95_latency_ms)),
                 )
             })
@@ -481,17 +481,18 @@ impl ClaudeProvider {
     }
 
     fn merge_remote_pricing(normalized: &mut ModelMetadata, remote: &ModelMetadata) {
-        if remote.pricing.input_token_usd.is_some() {
-            normalized.pricing.input_token_usd = remote.pricing.input_token_usd;
+        normalized.pricing.currency = remote.pricing.currency.clone();
+        if remote.pricing.input_token.is_some() {
+            normalized.pricing.input_token = remote.pricing.input_token;
         }
-        if remote.pricing.output_token_usd.is_some() {
-            normalized.pricing.output_token_usd = remote.pricing.output_token_usd;
+        if remote.pricing.output_token.is_some() {
+            normalized.pricing.output_token = remote.pricing.output_token;
         }
-        if remote.pricing.cache_input_token_usd.is_some() {
-            normalized.pricing.cache_input_token_usd = remote.pricing.cache_input_token_usd;
+        if remote.pricing.cache_input_token.is_some() {
+            normalized.pricing.cache_input_token = remote.pricing.cache_input_token;
         }
-        if remote.pricing.estimated_cost_usd.is_some() {
-            normalized.pricing.estimated_cost_usd = remote.pricing.estimated_cost_usd;
+        if remote.pricing.estimated_cost.is_some() {
+            normalized.pricing.estimated_cost = remote.pricing.estimated_cost;
         }
     }
 

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-const DRIVER_METADATA_SCHEMA_VERSION: u32 = 2;
+const DRIVER_METADATA_SCHEMA_VERSION: u32 = 3;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriverModelResolveRequest {
@@ -142,13 +142,7 @@ pub struct DriverModelRule {
     #[serde(default)]
     pub capabilities: DriverCapabilitiesPatch,
     #[serde(default)]
-    pub estimated_cost_usd: Option<f64>,
-    #[serde(default)]
-    pub input_token_usd: Option<f64>,
-    #[serde(default)]
-    pub output_token_usd: Option<f64>,
-    #[serde(default)]
-    pub cache_input_token_usd: Option<f64>,
+    pub pricing: Option<ModelPricing>,
     #[serde(default)]
     pub estimated_latency_ms: Option<u64>,
     #[serde(default)]
@@ -365,16 +359,15 @@ fn resolve_driver_model(
 
     let mut capabilities = conservative_capabilities();
     let mut parameter_scale = None;
-    let mut estimated_cost_usd = request.fallback_estimated_cost_usd;
+    let mut pricing = ModelPricing {
+        estimated_cost: request.fallback_estimated_cost_usd,
+        ..Default::default()
+    };
     let mut estimated_latency_ms = request.fallback_estimated_latency_ms;
     let mut quality_score = Some(0.75);
     let mut latency_class = LatencyClass::Normal;
     let mut cost_class = CostClass::Medium;
     let mut model_driver = origin.driver.clone();
-    let mut input_token_usd = None;
-    let mut output_token_usd = None;
-    let mut cache_input_token_usd = None;
-
     if let Some(rule) = rule {
         if let Some(next) = rule.model_driver.as_ref() {
             model_driver = next.clone();
@@ -394,12 +387,15 @@ fn resolve_driver_model(
         if rule.parameter_scale.is_some() {
             parameter_scale = rule.parameter_scale.clone();
         }
-        if rule.estimated_cost_usd.is_some() {
-            estimated_cost_usd = rule.estimated_cost_usd;
+        if let Some(rule_pricing) = rule.pricing.as_ref() {
+            pricing.currency.clone_from(&rule_pricing.currency);
+            if rule_pricing.estimated_cost.is_some() {
+                pricing.estimated_cost = rule_pricing.estimated_cost;
+            }
+            pricing.input_token = rule_pricing.input_token;
+            pricing.output_token = rule_pricing.output_token;
+            pricing.cache_input_token = rule_pricing.cache_input_token;
         }
-        input_token_usd = rule.input_token_usd;
-        output_token_usd = rule.output_token_usd;
-        cache_input_token_usd = rule.cache_input_token_usd;
         if rule.estimated_latency_ms.is_some() {
             estimated_latency_ms = rule.estimated_latency_ms;
         }
@@ -452,12 +448,7 @@ fn resolve_driver_model(
             latency_class,
             cost_class,
         },
-        pricing: ModelPricing {
-            input_token_usd,
-            output_token_usd,
-            cache_input_token_usd,
-            estimated_cost_usd,
-        },
+        pricing,
         health: ModelHealth {
             status: HealthStatus::Available,
             p95_latency_ms: estimated_latency_ms,
@@ -740,14 +731,32 @@ fn validate_driver_model_rule(rule: &DriverModelRule, location: &str) -> Result<
     if let Some(mounts) = rule.logical_mounts.as_ref() {
         validate_string_list(mounts.as_slice(), &format!("{}.logical_mounts", location))?;
     }
-    validate_non_negative_number(rule.estimated_cost_usd, "estimated_cost_usd", location)?;
-    validate_non_negative_number(rule.input_token_usd, "input_token_usd", location)?;
-    validate_non_negative_number(rule.output_token_usd, "output_token_usd", location)?;
-    validate_non_negative_number(
-        rule.cache_input_token_usd,
-        "cache_input_token_usd",
-        location,
-    )?;
+    if let Some(pricing) = rule.pricing.as_ref() {
+        let pricing_location = format!("{}.pricing", location);
+        if pricing.currency.trim().is_empty() {
+            return Err(format!("{}.currency cannot be empty", pricing_location));
+        }
+        validate_non_negative_number(
+            pricing.estimated_cost,
+            "estimated_cost",
+            pricing_location.as_str(),
+        )?;
+        validate_non_negative_number(
+            pricing.input_token,
+            "input_token",
+            pricing_location.as_str(),
+        )?;
+        validate_non_negative_number(
+            pricing.output_token,
+            "output_token",
+            pricing_location.as_str(),
+        )?;
+        validate_non_negative_number(
+            pricing.cache_input_token,
+            "cache_input_token",
+            pricing_location.as_str(),
+        )?;
+    }
     if rule
         .quality_score
         .is_some_and(|value| !value.is_finite() || !(0.0..=1.0).contains(&value))
@@ -986,7 +995,7 @@ fn find_default_rule(sources: &[DriverMetadataSource]) -> Option<&DriverModelRul
         if source.document.defaults.api_types.is_some()
             || source.document.defaults.logical_mounts.is_some()
             || source.document.defaults.capabilities.has_any()
-            || source.document.defaults.estimated_cost_usd.is_some()
+            || source.document.defaults.pricing.is_some()
             || source.document.defaults.estimated_latency_ms.is_some()
         {
             return Some(&source.document.defaults);
@@ -1637,7 +1646,7 @@ mod tests {
     fn override_metadata_rejects_schema_and_provider_identity_mismatch() {
         let valid = serde_json::json!({
             "format": "buckyos.aicc.provider-driver-metadata",
-            "schema_version": 2,
+            "schema_version": DRIVER_METADATA_SCHEMA_VERSION,
             "schema_revision": 0,
             "provider_driver": "openai",
             "revision_seq": 1,
@@ -1671,7 +1680,7 @@ mod tests {
     fn origin_mapping_validation_is_fail_closed() {
         let valid = serde_json::json!({
             "format": "buckyos.aicc.provider-driver-metadata",
-            "schema_version": 2,
+            "schema_version": DRIVER_METADATA_SCHEMA_VERSION,
             "schema_revision": 0,
             "provider_driver": "aggregator",
             "revision_seq": 1,
@@ -1766,9 +1775,10 @@ mod tests {
         assert!(openai.api_types.contains(&ApiType::Rerank));
         assert_eq!(openai.capabilities.max_context_tokens, Some(1_050_000));
         assert_eq!(openai.capabilities.max_output_tokens, Some(128_000));
-        assert_eq!(openai.pricing.input_token_usd, Some(0.000005));
-        assert_eq!(openai.pricing.output_token_usd, Some(0.00003));
-        assert_eq!(openai.pricing.cache_input_token_usd, Some(0.0000005));
+        assert_eq!(openai.pricing.currency, "USD");
+        assert_eq!(openai.pricing.input_token, Some(0.000005));
+        assert_eq!(openai.pricing.output_token, Some(0.00003));
+        assert_eq!(openai.pricing.cache_input_token, Some(0.0000005));
         assert!(openai
             .logical_mounts
             .iter()

--- a/src/frame/aicc/src/metadata_updater.rs
+++ b/src/frame/aicc/src/metadata_updater.rs
@@ -23,7 +23,7 @@ const INDEX_FORMAT: &str = "buckyos.aicc.driver-metadata-index";
 const MANIFEST_FORMAT: &str = "buckyos.aicc.driver-metadata-manifest";
 const ACTIVATION_FORMAT: &str = "buckyos.aicc.driver-metadata-activation";
 const PROTOCOL_VERSION: u32 = 1;
-const METADATA_SCHEMA_VERSION: u32 = 2;
+const METADATA_SCHEMA_VERSION: u32 = 3;
 const MAX_INDEX_BYTES: u64 = 256 * 1024;
 const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
 const MAX_METADATA_BYTES: u64 = 64 * 1024 * 1024;
@@ -1756,7 +1756,7 @@ mod tests {
         DriverMetadataManifestFile {
             provider_driver: driver.to_string(),
             path: format!("v1/providers/{}-{}.json", driver, revision),
-            schema_version: 2,
+            schema_version: METADATA_SCHEMA_VERSION,
             revision_seq: revision,
             obj_id: obj_id.to_string(),
         }
@@ -1777,7 +1777,7 @@ mod tests {
     fn document(driver: &str, revision: u64) -> DriverMetadataDocument {
         DriverMetadataDocument {
             format: "buckyos.aicc.provider-driver-metadata".to_string(),
-            schema_version: 2,
+            schema_version: METADATA_SCHEMA_VERSION,
             schema_revision: 0,
             provider_driver: driver.to_string(),
             revision_seq: revision,
@@ -2107,7 +2107,7 @@ mod tests {
         let entry = file("openai", 1, &object_id);
         let duplicate_rules = serde_json::json!({
             "format": "buckyos.aicc.provider-driver-metadata",
-            "schema_version": 2,
+            "schema_version": METADATA_SCHEMA_VERSION,
             "schema_revision": 0,
             "provider_driver": "openai",
             "revision_seq": 1,
@@ -2155,10 +2155,34 @@ mod tests {
         invalid_cost["variants"] = serde_json::json!([]);
         invalid_cost["models"] = serde_json::json!([{
             "id": "gpt-test",
-            "input_token_usd": -0.01
+            "pricing": {
+                "currency": "USD",
+                "input_token": -0.01
+            }
         }]);
         assert!(validate_metadata_bytes(
             serde_json::to_vec(&invalid_cost).unwrap().as_slice(),
+            &entry,
+        )
+        .is_err());
+
+        let mut missing_currency = invalid_cost.clone();
+        missing_currency["models"][0]["pricing"] = serde_json::json!({
+            "input_token": 0.01
+        });
+        assert!(validate_metadata_bytes(
+            serde_json::to_vec(&missing_currency).unwrap().as_slice(),
+            &entry,
+        )
+        .is_err());
+
+        let mut legacy_flat_pricing = invalid_cost.clone();
+        legacy_flat_pricing["models"] = serde_json::json!([{
+            "id": "gpt-test",
+            "input_token_usd": 0.01
+        }]);
+        assert!(validate_metadata_bytes(
+            serde_json::to_vec(&legacy_flat_pricing).unwrap().as_slice(),
             &entry,
         )
         .is_err());

--- a/src/frame/aicc/src/model_router.rs
+++ b/src/frame/aicc/src/model_router.rs
@@ -437,7 +437,7 @@ impl<'a> ModelRouter<'a> {
                     if candidate
                         .metadata
                         .pricing
-                        .estimated_cost_usd
+                        .estimated_cost
                         .map(|cost| cost > max_cost)
                         .unwrap_or(false)
                     {
@@ -652,7 +652,7 @@ mod tests {
                 ..Default::default()
             },
             pricing: ModelPricing {
-                estimated_cost_usd: Some(0.01),
+                estimated_cost: Some(0.01),
                 ..Default::default()
             },
             health: ModelHealth {

--- a/src/frame/aicc/src/model_scheduler.rs
+++ b/src/frame/aicc/src/model_scheduler.rs
@@ -169,7 +169,7 @@ fn cost_value(candidate: &ModelCandidate) -> f64 {
     candidate
         .metadata
         .pricing
-        .estimated_cost_usd
+        .estimated_cost
         .unwrap_or_else(|| match candidate.metadata.attributes.cost_class {
             crate::model_types::CostClass::Low => 0.1,
             crate::model_types::CostClass::Medium => 0.5,
@@ -317,7 +317,7 @@ mod tests {
                 ..Default::default()
             },
             pricing: ModelPricing {
-                estimated_cost_usd: Some(cost),
+                estimated_cost: Some(cost),
                 ..Default::default()
             },
             health: ModelHealth {

--- a/src/frame/aicc/src/model_types.rs
+++ b/src/frame/aicc/src/model_types.rs
@@ -528,16 +528,18 @@ impl Default for ModelAttributes {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelPricing {
+    pub currency: String,
     #[serde(default)]
-    pub input_token_usd: Option<f64>,
+    pub input_token: Option<f64>,
     #[serde(default)]
-    pub output_token_usd: Option<f64>,
+    pub output_token: Option<f64>,
     #[serde(default)]
-    pub cache_input_token_usd: Option<f64>,
+    pub cache_input_token: Option<f64>,
     #[serde(default)]
-    pub estimated_cost_usd: Option<f64>,
+    pub estimated_cost: Option<f64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1207,50 +1209,66 @@ pub struct SessionOverlayTrace {
     pub selected_from_overlay: bool,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RoutePricingSnapshot {
+    pub currency: String,
     #[serde(default)]
-    pub input_token_usd: Option<f64>,
+    pub input_token: Option<f64>,
     #[serde(default)]
-    pub output_token_usd: Option<f64>,
+    pub output_token: Option<f64>,
     #[serde(default)]
-    pub cache_input_token_usd: Option<f64>,
+    pub cache_input_token: Option<f64>,
     #[serde(default)]
-    pub estimated_cost_usd: Option<f64>,
+    pub estimated_cost: Option<f64>,
+}
+
+impl Default for ModelPricing {
+    fn default() -> Self {
+        Self {
+            currency: "USD".to_string(),
+            input_token: None,
+            output_token: None,
+            cache_input_token: None,
+            estimated_cost: None,
+        }
+    }
 }
 
 impl RoutePricingSnapshot {
     pub fn from_candidate(candidate: &ModelCandidate) -> Option<Self> {
         Self::from_values(
-            candidate.metadata.pricing.input_token_usd,
-            candidate.metadata.pricing.output_token_usd,
-            candidate.metadata.pricing.cache_input_token_usd,
+            candidate.metadata.pricing.currency.clone(),
+            candidate.metadata.pricing.input_token,
+            candidate.metadata.pricing.output_token,
+            candidate.metadata.pricing.cache_input_token,
             candidate
                 .dynamic_cost_estimate
                 .as_ref()
                 .map(|estimate| estimate.estimated_cost_usd)
-                .or(candidate.metadata.pricing.estimated_cost_usd),
+                .or(candidate.metadata.pricing.estimated_cost),
         )
     }
 
     fn from_values(
-        input_token_usd: Option<f64>,
-        output_token_usd: Option<f64>,
-        cache_input_token_usd: Option<f64>,
-        estimated_cost_usd: Option<f64>,
+        currency: String,
+        input_token: Option<f64>,
+        output_token: Option<f64>,
+        cache_input_token: Option<f64>,
+        estimated_cost: Option<f64>,
     ) -> Option<Self> {
-        if input_token_usd.is_none()
-            && output_token_usd.is_none()
-            && cache_input_token_usd.is_none()
-            && estimated_cost_usd.is_none()
+        if input_token.is_none()
+            && output_token.is_none()
+            && cache_input_token.is_none()
+            && estimated_cost.is_none()
         {
             return None;
         }
         Some(Self {
-            input_token_usd,
-            output_token_usd,
-            cache_input_token_usd,
-            estimated_cost_usd,
+            currency,
+            input_token,
+            output_token,
+            cache_input_token,
+            estimated_cost,
         })
     }
 }

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -938,28 +938,32 @@ impl OpenAIProvider {
                             .origin_model_id
                             .clone()
                             .unwrap_or_else(|| model.to_string()),
-                        metadata.pricing.input_token_usd,
-                        metadata.pricing.output_token_usd,
+                        metadata.pricing.currency.clone(),
+                        metadata.pricing.input_token,
+                        metadata.pricing.output_token,
                     )
                 })
             })
         });
-        let (origin_model_id, input_per_token, output_per_token) =
-            pricing.unwrap_or_else(|| (model.to_string(), None, None));
-        let amount = if let (Some(input_per_token), Some(output_per_token)) =
+        let (origin_model_id, currency, input_per_token, output_per_token) =
+            pricing.unwrap_or_else(|| (model.to_string(), "USD".to_string(), None, None));
+        let (amount, currency) = if let (Some(input_per_token), Some(output_per_token)) =
             (input_per_token, output_per_token)
         {
-            (input_tokens * input_per_token) + (output_tokens * output_per_token)
+            (
+                (input_tokens * input_per_token) + (output_tokens * output_per_token),
+                currency,
+            )
         } else {
             let (input_per_m, output_per_m) = Self::price_per_1m_tokens(origin_model_id.as_str());
-            ((input_tokens / 1_000_000.0) * input_per_m)
-                + ((output_tokens / 1_000_000.0) * output_per_m)
+            (
+                ((input_tokens / 1_000_000.0) * input_per_m)
+                    + ((output_tokens / 1_000_000.0) * output_per_m),
+                "USD".to_string(),
+            )
         };
 
-        Some(AiCost {
-            amount,
-            currency: "USD".to_string(),
-        })
+        Some(AiCost { amount, currency })
     }
 
     /// 把 `AiRole` 映射成 OpenAI Responses API 接受的 role 字符串。
@@ -3384,7 +3388,7 @@ fn remote_model_resolve_request(model: &ModelMetadata) -> Option<DriverModelReso
     }
     Some(
         DriverModelResolveRequest::new(provider_model_id, api_types)
-            .with_cost(model.pricing.estimated_cost_usd)
+            .with_cost(model.pricing.estimated_cost)
             .with_latency(model.health.p50_latency_ms.or(model.health.p95_latency_ms)),
     )
 }
@@ -3399,17 +3403,18 @@ fn remote_provider_model_id(model: &ModelMetadata) -> Option<String> {
 }
 
 fn merge_remote_dynamic_metadata(model: &mut ModelMetadata, remote_model: &ModelMetadata) {
-    if remote_model.pricing.input_token_usd.is_some() {
-        model.pricing.input_token_usd = remote_model.pricing.input_token_usd;
+    model.pricing.currency = remote_model.pricing.currency.clone();
+    if remote_model.pricing.input_token.is_some() {
+        model.pricing.input_token = remote_model.pricing.input_token;
     }
-    if remote_model.pricing.output_token_usd.is_some() {
-        model.pricing.output_token_usd = remote_model.pricing.output_token_usd;
+    if remote_model.pricing.output_token.is_some() {
+        model.pricing.output_token = remote_model.pricing.output_token;
     }
-    if remote_model.pricing.cache_input_token_usd.is_some() {
-        model.pricing.cache_input_token_usd = remote_model.pricing.cache_input_token_usd;
+    if remote_model.pricing.cache_input_token.is_some() {
+        model.pricing.cache_input_token = remote_model.pricing.cache_input_token;
     }
-    if remote_model.pricing.estimated_cost_usd.is_some() {
-        model.pricing.estimated_cost_usd = remote_model.pricing.estimated_cost_usd;
+    if remote_model.pricing.estimated_cost.is_some() {
+        model.pricing.estimated_cost = remote_model.pricing.estimated_cost;
     }
     if remote_model.health.p50_latency_ms.is_some() {
         model.health.p50_latency_ms = remote_model.health.p50_latency_ms;
@@ -4937,8 +4942,8 @@ data: [DONE]
             .find(|model| model.provider_model_id == "openai/gpt-5.4-pro")
             .expect("base model should resolve");
         assert_eq!(base.origin_model_id.as_deref(), Some("gpt-5.4-pro"));
-        base.pricing.input_token_usd = None;
-        base.pricing.output_token_usd = None;
+        base.pricing.input_token = None;
+        base.pricing.output_token = None;
         *provider.inventory.write().expect("inventory lock") = inventory;
 
         let cost = provider


### PR DESCRIPTION
## 变更说明

- 将 AICC 模型的金额相关参数统一聚合到 `ModelPricing` / metadata 的 `pricing` 对象中。
- 价格字段移除 `_usd` 后缀，改为 `estimated_cost`、`input_token`、`output_token`、`cache_input_token`。
- 新增必填的独立 `currency` 字段；当前内置 metadata 均明确使用 `USD`。
- 将 driver metadata schema 从 v2 提升到 v3，并迁移 OpenAI、OpenRouter、Claude、Gemini、MiniMax、Fal 的内置 JSON。
- 联动 metadata 解析与校验、模型路由与调度、Provider 动态价格合并、路由快照和 OpenAI 计费币种传递。
- 同步更新 metadata schema、云更新协议和 AICC 模型相关文档。
- 未引入新依赖。

## 兼容性

这是 beta 2.2 的 breaking change，不保留旧顶层价格字段兼容逻辑。schema v2 或仍使用 `*_usd` 顶层字段的 metadata 会被严格拒绝。

## 验证

- `cargo fmt -p aicc -- --check`
- `cargo check -p aicc --all-targets`
- `cargo test -p aicc`
- 校验 6 份内置 metadata JSON：schema 均为 v3，115 个 `pricing` 对象均包含非空币种
- `git diff --check`

## 未验证项

- 未执行 `uv run buckyos-build.py -s aicc`：当前 Windows 环境未安装 `uv`。