### PR TITLE
[OpenDAN] 修复容器内大附件无法通过 msg-center 发送

### DIFF
--- a/src/frame/opendan/src/agent_session.rs
+++ b/src/frame/opendan/src/agent_session.rs
@@ -5962,7 +5962,7 @@ impl AgentSession {
             self.agent_name.clone(),
             self.agent_config.toml.runtime.filesystem_policy,
         );
-        let resolver = crate::attachment_resolver::NamedStoreLocalLinkResolver::new(
+        let resolver = crate::attachment_resolver::NamedStoreAttachmentResolver::new(
             workspace_dir,
             self.agent_name.clone(),
         );
@@ -7142,7 +7142,7 @@ impl AgentSession {
             self.agent_name.clone(),
             self.agent_config.toml.runtime.filesystem_policy,
         );
-        let resolver = crate::attachment_resolver::NamedStoreLocalLinkResolver::new(
+        let resolver = crate::attachment_resolver::NamedStoreAttachmentResolver::new(
             workspace_dir,
             self.agent_name.clone(),
         );

--- a/src/frame/opendan/src/attachment_resolver.rs
+++ b/src/frame/opendan/src/attachment_resolver.rs
@@ -3,11 +3,9 @@
 //! egress lane (TG tunnel, MessageHub, …) can upload them like any
 //! externally-sourced attachment.
 //!
-//! Strategy: register large files in **LocalLink** mode — no bytes are
-//! copied, the store just records a content-addressed pointer to the
-//! original path. NamedStore's LocalLink path requires a qcid, and qcid is
-//! unavailable for tiny files, so small files are stored directly in
-//! NamedStore.
+//! Strategy: copy every attachment into NamedStore. The egress consumer may
+//! run in a different container or filesystem namespace, so a LocalLink to
+//! the agent's source path is not portable across the delivery boundary.
 //!
 //! Path-policy enforcement (workspace fence, `..` traversal,
 //! symlink-escape) lives in [`crate::attachment_policy`]; by the time
@@ -23,14 +21,12 @@ use llm_context::LocalFileResolver;
 use ndn_lib::{FileObject, ObjId, StoreMode};
 use ndn_toolkit::{cacl_file_object, CheckMode};
 
-const LOCAL_LINK_MIN_FILE_SIZE: u64 = 3 * 4096;
-
-pub struct NamedStoreLocalLinkResolver {
+pub struct NamedStoreAttachmentResolver {
     workspace_root: Option<PathBuf>,
     agent_id: String,
 }
 
-impl NamedStoreLocalLinkResolver {
+impl NamedStoreAttachmentResolver {
     pub fn new(workspace_root: Option<PathBuf>, agent_id: impl Into<String>) -> Self {
         Self {
             workspace_root,
@@ -40,7 +36,7 @@ impl NamedStoreLocalLinkResolver {
 }
 
 #[async_trait]
-impl LocalFileResolver for NamedStoreLocalLinkResolver {
+impl LocalFileResolver for NamedStoreAttachmentResolver {
     async fn resolve(&self, raw_path: &str) -> Result<ObjId, String> {
         let candidate = std::path::Path::new(raw_path);
         let absolute = if candidate.is_absolute() {
@@ -63,8 +59,6 @@ impl LocalFileResolver for NamedStoreLocalLinkResolver {
                 absolute.display()
             ));
         }
-        let file_size = metadata.len();
-
         let runtime =
             get_buckyos_api_runtime().map_err(|e| format!("buckyos runtime unavailable: {e}"))?;
         let store_mgr = runtime
@@ -72,26 +66,22 @@ impl LocalFileResolver for NamedStoreLocalLinkResolver {
             .await
             .map_err(|e| format!("named_store unavailable: {e}"))?;
 
-        // `cacl_file_object` re-derives per-chunk ChunkLocalInfo from the
-        // actual file. LocalLink requires qcid, which is only defined for
-        // files at least `LOCAL_LINK_MIN_FILE_SIZE` bytes; tiny files are
-        // copied into NamedStore instead of being rejected.
+        // The object must own its payload because downstream message
+        // delivery may run outside this process's filesystem namespace.
         let template = FileObject::default();
-        let store_mode = store_mode_for_attachment_file(&absolute, file_size);
-        let store_mode_label = store_mode_label(&store_mode);
         let (_file_obj, file_obj_id, _file_obj_str) = cacl_file_object(
             Some(&store_mgr),
             &absolute,
             &template,
             true,
             &CheckMode::ByFullHash,
-            store_mode,
+            attachment_store_mode(),
             None,
         )
         .await
         .map_err(|e| {
             format!(
-                "register `{}` into NamedStore ({store_mode_label}) failed: {e}",
+                "register `{}` into NamedStore (StoreInNamedMgr) failed: {e}",
                 absolute.display(),
             )
         })?;
@@ -100,20 +90,8 @@ impl LocalFileResolver for NamedStoreLocalLinkResolver {
     }
 }
 
-fn store_mode_for_attachment_file(path: &std::path::Path, file_size: u64) -> StoreMode {
-    if file_size < LOCAL_LINK_MIN_FILE_SIZE {
-        StoreMode::StoreInNamedMgr
-    } else {
-        StoreMode::LocalFile(path.to_path_buf(), 0..file_size, false)
-    }
-}
-
-fn store_mode_label(mode: &StoreMode) -> &'static str {
-    match mode {
-        StoreMode::LocalFile(_, _, _) => "LocalLink",
-        StoreMode::StoreInNamedMgr => "StoreInNamedMgr",
-        StoreMode::NoStore => "NoStore",
-    }
+fn attachment_store_mode() -> StoreMode {
+    StoreMode::StoreInNamedMgr
 }
 
 #[cfg(test)]
@@ -121,20 +99,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn small_attachment_files_store_inline() {
-        let path = std::path::Path::new("/tmp/small.txt");
+    fn attachment_payload_is_stored_in_named_store() {
         assert!(matches!(
-            store_mode_for_attachment_file(path, LOCAL_LINK_MIN_FILE_SIZE - 1),
+            attachment_store_mode(),
             StoreMode::StoreInNamedMgr
-        ));
-    }
-
-    #[test]
-    fn large_attachment_files_use_local_link() {
-        let path = std::path::Path::new("/tmp/large.bin");
-        assert!(matches!(
-            store_mode_for_attachment_file(path, LOCAL_LINK_MIN_FILE_SIZE),
-            StoreMode::LocalFile(_, _, false)
         ));
     }
 }

--- a/src/frame/opendan/src/lib.rs
+++ b/src/frame/opendan/src/lib.rs
@@ -98,7 +98,7 @@ pub mod attachment_policy;
 
 // §2.2.2 — local-path materialization at egress. Pairs with
 // attachment_policy: once a path is approved, this resolver registers
-// the file with NamedStore in LocalLink mode and surfaces a
+// the file and its payload in NamedStore and surfaces a
 // content-addressed ObjId for the standard RefItem::DataObj lane.
 pub mod attachment_resolver;
 


### PR DESCRIPTION
## 问题

OpenDAN 原先会根据附件大小选择 NamedStore 存储模式：小文件保存到 NamedStore，较大文件则注册为指向原始路径的 `LocalLink`。

Jarvis 生成的文件通常位于 AIOS 容器内，例如 `/tmp/jarvis_art/...`。下游 `msg-center` 运行在不同的文件系统命名空间中，无法读取该容器私有路径，导致附件发送失败，并可能使用户只能看到任务状态而收不到最终结果。

## 修改

- 所有出站附件统一使用 `StoreMode::StoreInNamedMgr`，让 NamedStore 持有实际附件内容。
- 移除基于文件大小选择 `LocalLink` 的逻辑和阈值。
- 将解析器重命名为 `NamedStoreAttachmentResolver`，使名称与实际行为一致。
- 更新模块说明和单元测试，明确附件内容必须保存到 NamedStore。

## 验证

```text
cargo test --offline -p opendan attachment_resolver

test attachment_resolver::tests::attachment_payload_is_stored_in_named_store ... ok
test result: ok. 1 passed; 0 failed
```

测试基于本 PR 提交导出的独立源码快照执行。

## 影响

较大附件不再使用零拷贝的本地链接，会增加 NamedStore 的写入和存储开销，但可以保证附件跨容器、跨文件系统命名空间可靠读取。

Fixes #536
