### PR TITLE
fix: 修复 Jarvis service instance 状态上报被 RBAC 拒绝

### DIFF
--- a/src/kernel/buckyos-api/src/rbac_config.rs
+++ b/src/kernel/buckyos-api/src/rbac_config.rs
@@ -107,6 +107,7 @@ p, agent, obj://config/users/{user}/agents/{agent}/settings,read|write,allow
 p, agent, obj://config/users/{user}/agents/{agent}/spec,read,allow
 p, agent, obj://config/users/{user}/agents/{agent}/info,read|write,allow
 p, agent, obj://config/services/{service}/info,read,allow
+p, agent, obj://config/services/{agent}/instances/{node},write,allow
 
 p, admin,obj://config/boot/*, read,allow
 p, admin,obj://config/system/*,read,allow
@@ -118,6 +119,7 @@ p, admin,obj://config/users/{admin}/apps/{app}/{key},read|write,allow
 p, admin,obj://config/users/{admin}/agents/{agent}/{key},read|write,allow
 p, admin,obj://config/services/aicc/settings,read|write,allow
 p, admin,obj://config/services/msg-center/settings,read|write,allow
+p, admin,obj://config/services/{service}/instances/{node},write,allow
 p, admin,obj://config/services/*,read,allow
 
 p, users,obj://config/boot/*, read,allow
@@ -128,6 +130,7 @@ p, users,obj://config/users/{users}/profile,read|write,allow
 p, users,obj://config/users/{users}/apps/{app}/{key},read|write,allow
 p, users,obj://config/users/{users}/agents/{agent}/{key},read|write,allow
 p, users,obj://config/services/{service}/info,read,allow
+p, users,obj://config/services/{service}/instances/{node},write,allow
 
 g, node-daemon, kernel
 g, scheduler, kernel
@@ -507,6 +510,59 @@ g, bob, users
                 "alice",
                 "control-panel",
                 "obj://config/services/msg-center/settings",
+                "write",
+                None,
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_can_report_own_service_instance() {
+        let _guard = TEST_LOCK.lock().await;
+
+        let config = build_current_rbac_config(Some(
+            "g, alice, admin\ng, bob, users\ng, buckyos_jarvis, agent",
+        ));
+        rbac::create_enforcer(&config.model, &config.policy)
+            .await
+            .unwrap();
+
+        assert!(
+            rbac::enforce(
+                "alice",
+                "buckyos_jarvis",
+                "obj://config/services/buckyos_jarvis/instances/ood1",
+                "write",
+                None,
+            )
+            .await
+        );
+        assert!(
+            rbac::enforce(
+                "bob",
+                "buckyos_jarvis",
+                "obj://config/services/buckyos_jarvis/instances/ood1",
+                "write",
+                None,
+            )
+            .await
+        );
+        assert!(
+            !rbac::enforce(
+                "alice",
+                "buckyos_jarvis",
+                "obj://config/services/other-agent/instances/ood1",
+                "write",
+                None,
+            )
+            .await
+        );
+        assert!(
+            !rbac::enforce(
+                "alice",
+                "buckyos_jarvis",
+                "obj://config/services/buckyos_jarvis/settings",
                 "write",
                 None,
             )


### PR DESCRIPTION
## 原因

Jarvis/OpenDAN runtime 会定期向 system-config 写入 `services/buckyos_jarvis/instances/{node}`，但 system-config 的 RBAC 会同时校验用户身份和 app 身份。默认策略中，`agent` app 角色以及 admin/普通用户角色都缺少该实例状态路径的写权限，因此 Jarvis 虽能正常处理消息，后台状态上报仍会持续被拒绝。

## 修复

- 允许 `agent` 角色写入自身 `services/{agent}/instances/{node}` 路径。
- 为 admin 和普通用户补充 service instance 状态路径的用户侧写权限。
- 继续依靠用户与 app 双重校验限制权限：agent 不能写入其他 service，也不能借此修改 service settings。
- 增加正向和越权场景的 RBAC 回归测试。

## 验证

- `cargo test -p buckyos-api`：121 项全部通过。
- `rustfmt --edition 2021 --check kernel/buckyos-api/src/rbac_config.rs`：通过。

Fixes #525