### PR TITLE
fix(kevent): 修复 Jarvis 容器无法及时接收宿主机事件

### DIFF
--- a/doc/arch/11_env_contract.md
+++ b/doc/arch/11_env_contract.md
@@ -63,6 +63,7 @@ node-daemon 的 `AppLoader` 是 app/agent worker 环境变量的权威注入者�
 | `BUCKYOS_SAFE_MODE` | node-daemon/aios 默认值 | aios entrypoint | `1` 时重置 package 工作副本和 sync metadata；默认 `0`。 |
 | `BUCKYOS_SERVICE_PORT` | node-daemon | agent/service | app/agent 暴露服务端口。agent 未注入时 aios 入口默认 `4060`。 |
 | `BUCKYOS_HOST_GATEWAY` | node-daemon | `buckyos-api` runtime | 容器访问 host 本地服务的 host 名。runtime 会把 app/frame service 的本地 system service URL 解析到该 host。 |
+| `BUCKYOS_KEVENT_DAEMON_ADDR` | node-daemon | `buckyos-api` runtime（App/Agent Worker，包括 OpenDAN） | KEvent daemon bridge endpoint，格式为 `host:port`。node-daemon 默认注入 `host.docker.internal:3183`；未设置时 runtime 回退到 `BUCKYOS_HOST_GATEWAY` 指定的 host 和端口 `3183`。 |
 
 同时注入的内部变量：
 

--- a/doc/arch/kevent/kevent.md
+++ b/doc/arch/kevent/kevent.md
@@ -335,6 +335,8 @@ let kevent_client = BuckyOSRuntime::get_kevent_client().await?;
 
 runtime 按 `runtime_type` 决定通道（容器类型走 bridge，其余走 SHM），并复用同一个进程级单例——每个 client 会带一条 ShmDispatch 线程或一组 TCP 连接，按调用次数新建会按次泄漏线程/连接。
 
+容器由 node-daemon 显式注入 `BUCKYOS_KEVENT_DAEMON_ADDR=host.docker.internal:3183`。runtime 优先使用该完整 endpoint；未注入时才使用 `BUCKYOS_HOST_GATEWAY`（默认 `host.docker.internal`）和 native port `3183` 组合兜底。业务进程不得自行硬编码 Docker 网桥地址。
+
 ```
 EventClient (Full Mode) {
     // 进程内

--- a/src/frame/opendan/src/main.rs
+++ b/src/frame/opendan/src/main.rs
@@ -584,12 +584,20 @@ async fn bootstrap(appid: &str, owner_id: Option<String>) -> Result<Arc<AgentRun
     // ring buffer nobody else was attached to — every global event silently
     // stayed inside the container. This is a hard failure now: without the
     // bridge, agent event subscriptions do not work at all.
-    let kevent_client = Arc::new(api_runtime.get_kevent_client().await.map_err(|err| {
-        anyhow!("opendan.bootstrap: kevent client unavailable: {err:?}")
-    })?);
+    let kevent_client = Arc::new(
+        api_runtime
+            .get_kevent_client()
+            .await
+            .map_err(|err| anyhow!("opendan.bootstrap: kevent client unavailable: {err:?}"))?,
+    );
+    let kevent_backend = kevent_client.transport_kind();
+    let kevent_endpoint = kevent_client
+        .transport_status()
+        .map(|status| status.endpoint)
+        .unwrap_or_else(|| "local".to_string());
 
     info!(
-        "opendan.bootstrap: aicc=ready worklog_db={} msg_center={} task_mgr={} kevent=ready",
+        "opendan.bootstrap: aicc=ready worklog_db={} msg_center={} task_mgr={} kevent_backend={:?} kevent_endpoint={}",
         worklog_db.display(),
         if msg_center.is_some() {
             "ready"
@@ -600,7 +608,9 @@ async fn bootstrap(appid: &str, owner_id: Option<String>) -> Result<Arc<AgentRun
             "ready"
         } else {
             "unavailable"
-        }
+        },
+        kevent_backend,
+        kevent_endpoint
     );
 
     let mut runtime =

--- a/src/kernel/buckyos-api/src/kevent_client.rs
+++ b/src/kernel/buckyos-api/src/kevent_client.rs
@@ -21,6 +21,7 @@ pub const KEVENT_SERVICE_UNIQUE_ID: &str = "kevent";
 pub const KEVENT_SERVICE_NAME: &str = "kevent";
 pub const KEVENT_SERVICE_MAIN_PORT: u16 = 3181;
 pub const KEVENT_SERVICE_NATIVE_PORT: u16 = 3183;
+pub const BUCKYOS_KEVENT_DAEMON_ADDR_ENV: &str = "BUCKYOS_KEVENT_DAEMON_ADDR";
 pub const DEFAULT_READER_CAPACITY: usize = 1024;
 pub const MAX_EVENT_DATA_SIZE_BYTES: usize = 64 * 1024;
 const SHARED_RING_DRAIN_BATCH: usize = 128;

--- a/src/kernel/buckyos-api/src/runtime.rs
+++ b/src/kernel/buckyos-api/src/runtime.rs
@@ -27,7 +27,9 @@ use named_store::NamedDataMgr;
 use crate::aicc_client::*;
 use crate::app_mgr::*;
 use crate::control_panel::*;
-use crate::kevent_client::{KEventClient, KEVENT_SERVICE_NATIVE_PORT};
+use crate::kevent_client::{
+    KEventClient, BUCKYOS_KEVENT_DAEMON_ADDR_ENV, KEVENT_SERVICE_NATIVE_PORT,
+};
 use crate::msg_center_client::*;
 use crate::msg_queue::*;
 use crate::opendan_client::*;
@@ -2016,7 +2018,7 @@ impl BuckyOSRuntime {
     ///
     /// This is the only supported way to obtain one: the transport depends on
     /// where the process runs, and business code has no business knowing about
-    /// `BUCKYOS_HOST_GATEWAY`, ports or ring-buffer paths.
+    /// `BUCKYOS_KEVENT_DAEMON_ADDR`, host gateways or ring-buffer paths.
     ///
     /// * `AppService` / `FrameService` run inside containers, cannot reach the
     ///   host's ring buffer, and therefore talk to node-daemon's native bridge.
@@ -2040,10 +2042,10 @@ impl BuckyOSRuntime {
         let source_node = self.app_id.as_str();
         match self.runtime_type {
             BuckyOSRuntimeType::AppService | BuckyOSRuntimeType::FrameService => {
-                let endpoint = format!(
-                    "{}:{}",
-                    self.resolve_local_service_host(),
-                    KEVENT_SERVICE_NATIVE_PORT
+                let configured_endpoint = env::var(BUCKYOS_KEVENT_DAEMON_ADDR_ENV).ok();
+                let endpoint = resolve_kevent_daemon_endpoint(
+                    configured_endpoint.as_deref(),
+                    &self.resolve_local_service_host(),
                 );
                 info!(
                     "kevent client for {} uses daemon bridge at {}",
@@ -2389,6 +2391,17 @@ fn resolve_container_gateway_host(configured_host: Option<&str>) -> String {
     resolve_host_to_ipv4_literal(host).unwrap_or_else(|| host.to_string())
 }
 
+fn resolve_kevent_daemon_endpoint(
+    configured_endpoint: Option<&str>,
+    fallback_host: &str,
+) -> String {
+    configured_endpoint
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{}:{}", fallback_host, KEVENT_SERVICE_NATIVE_PORT))
+}
+
 fn resolve_host_to_ipv4_literal(host: &str) -> Option<String> {
     let host = host.trim();
     if host.is_empty() {
@@ -2537,6 +2550,18 @@ mod tests {
         assert_eq!(
             resolve_container_gateway_host(Some("localhost")),
             "127.0.0.1"
+        );
+    }
+
+    #[test]
+    fn kevent_daemon_endpoint_prefers_explicit_deployment_value() {
+        assert_eq!(
+            resolve_kevent_daemon_endpoint(Some(" host.docker.internal:43183 "), "127.0.0.1"),
+            "host.docker.internal:43183"
+        );
+        assert_eq!(
+            resolve_kevent_daemon_endpoint(Some("  "), "127.0.0.1"),
+            "127.0.0.1:3183"
         );
     }
 }

--- a/src/kernel/kevent/tests/bridge_recovery_contract.rs
+++ b/src/kernel/kevent/tests/bridge_recovery_contract.rs
@@ -356,9 +356,18 @@ async fn pull_event_paces_normally_while_daemon_is_down() {
         TIMEOUT_MS
     );
 
-    // The transport did keep retrying underneath, with bounded backoff.
+    wait_until(
+        "transport failure to be recorded",
+        Duration::from_secs(6),
+        || {
+            let client = client.clone();
+            async move { client.transport_status().unwrap().total_failures > 0 }
+        },
+    )
+    .await;
+
     let status = client.transport_status().unwrap();
-    assert!(status.consecutive_failures > 0);
+    assert!(status.total_failures > 0);
     assert!(status.last_error.is_some());
 }
 

--- a/src/kernel/node_daemon/src/app_loader.rs
+++ b/src/kernel/node_daemon/src/app_loader.rs
@@ -3,7 +3,8 @@ use crate::service_pkg::new_system_package_env;
 use buckyos_api::{
     get_buckyos_api_runtime, get_full_appid, get_session_token_env_key, AppDoc,
     AppServiceInstanceConfig, AppType, LocalAppInstanceConfig, ServiceInstanceState,
-    ServiceSpecConfig, SubPkgDesc, VERIFY_HUB_TOKEN_EXPIRE_TIME,
+    ServiceSpecConfig, SubPkgDesc, BUCKYOS_KEVENT_DAEMON_ADDR_ENV, KEVENT_SERVICE_NATIVE_PORT,
+    VERIFY_HUB_TOKEN_EXPIRE_TIME,
 };
 use buckyos_kit::{buckyos_get_unix_timestamp, get_buckyos_root_dir};
 use log::{debug, error, info, warn};
@@ -1100,6 +1101,13 @@ impl AppLoader {
         env_vars.insert(
             "BUCKYOS_HOST_GATEWAY".to_string(),
             AGENT_RUNTIME_HOST_GATEWAY.to_string(),
+        );
+        env_vars.insert(
+            BUCKYOS_KEVENT_DAEMON_ADDR_ENV.to_string(),
+            format!(
+                "{}:{}",
+                AGENT_RUNTIME_HOST_GATEWAY, KEVENT_SERVICE_NATIVE_PORT
+            ),
         );
 
         if let Some(media_info) = self.package_media_info(role).await? {
@@ -2381,6 +2389,7 @@ impl AppLoader {
             "BUCKYOS_ZONE_CONFIG".to_string(),
             "BUCKYOS_THIS_DEVICE".to_string(),
             "BUCKYOS_HOST_GATEWAY".to_string(),
+            BUCKYOS_KEVENT_DAEMON_ADDR_ENV.to_string(),
         ];
         if self.media_pkg_id(role).is_some() {
             keys.push("app_media_info".to_string());

--- a/src/kernel/node_daemon/src/test_app_loader.rs
+++ b/src/kernel/node_daemon/src/test_app_loader.rs
@@ -413,6 +413,9 @@ fn appservice_control_commands_match_linux_amd64_docker_runtime() {
     assert!(start.commands[1]
         .args
         .contains(&"BUCKYOS_HOST_GATEWAY=<value>".to_string()));
+    assert!(start.commands[1]
+        .args
+        .contains(&"BUCKYOS_KEVENT_DAEMON_ADDR=<value>".to_string()));
 
     let stop = loader.preview_operation(ControlOperation::Stop).unwrap();
     assert_eq!(stop.runtime, RuntimeType::Docker);
@@ -529,6 +532,9 @@ fn agent_control_commands_match_expected_process_flow_on_linux() {
     assert!(start.commands[1]
         .args
         .contains(&"BUCKYOS_HOST_GATEWAY=<value>".to_string()));
+    assert!(start.commands[1]
+        .args
+        .contains(&"BUCKYOS_KEVENT_DAEMON_ADDR=<value>".to_string()));
     assert!(start.commands[1].args.contains(&"14060:14060".to_string()));
     assert!(start.commands[1]
         .args


### PR DESCRIPTION
## 背景

Jarvis/OpenDAN 运行在 Docker 容器中，无法与宿主机 msg-center/node-daemon 共享同一份 KEvent shared ringbuffer。`beta2.2` 当前已经具备 daemon-backed TCP bridge、reader 自动重注册和断线恢复能力，但容器部署侧仍缺少明确的 KEvent endpoint 契约，启动日志也无法直接确认实际使用的 backend。

关联并修复：[Issue #523](https://github.com/buckyos/buckyos/issues/523)

## 修改内容

- 增加公共环境变量 `BUCKYOS_KEVENT_DAEMON_ADDR`。
- node-daemon 启动 Docker AppService、HostScript 和 Agent worker 时，显式注入 `host.docker.internal:3183`。
- BuckyOS runtime 优先使用完整 endpoint；未注入时继续使用 host gateway 与 native port 组合兜底。
- OpenDAN 启动日志输出实际 KEvent backend 和 endpoint。
- 更新 KEvent 架构文档与 node-daemon loader 测试。
- 修正 Windows 下 daemon 连接失败最长等待 5 秒时，恢复契约测试过早检查统计状态的问题。

本修改按 beta 2.2 breaking change 处理，不增加旧部署方式的兼容分支，也没有引入新依赖。

## 验证

- `cargo test -p buckyos-api`：121 项通过。
- `cargo test -p kevent`：全部通过；包含 daemon 晚启动、重启后重注册、reader 隔离、断线限速等恢复契约。
- `cargo test -p node_daemon test_app_loader`：22 项通过。
- `cargo test -p opendan --bin opendan`：11 项通过。
- `git diff --check buckyos/beta2.2...fix/523-kevent-daemon-bridge`：通过。
- Docker Jarvis 实测：日志确认 `kevent_backend=DaemonBridge`、endpoint 为 `host.docker.internal:3183`；msg-center 事件命中后约 13 ms 拉取到 RequestBox，约 54 ms 启动 UI worker，没有等待下一轮 1 秒 fallback sweep。

## 风险与未验证项

- 未在本工作区执行完整 BuckyOS 安装包构建和 DV 自动化测试。
- OpenDAN lib 全量测试在 Windows 环境存在 14 个与本修改无关的既有 workspace/path/worksession 失败；OpenDAN binary 测试和编译通过。
- `cargo fmt --all -- --check` 会命中 beta2.2 中已有的未格式化文件；本 PR 的 `git diff --check` 通过。

Fixes https://github.com/buckyos/buckyos/issues/523
