### PR TITLE
修复 Jarvis 图像工具交付、AICC 容器路由与 /clean 会话切换

### DIFF
--- a/build_aios
+++ b/build_aios
@@ -27,6 +27,11 @@ SELECTED_ARCHES=()
 PUSH=0
 INSTALL_WORKSPACE_TOOLS=1
 ENTRYPOINT_SOURCE="$ROOT_DIR/publish/aios/entrypoint.sh"
+BUCKYOS_AGENT_TOOLS_SOURCE="$SRC_DIR/tools/buckyos-agent"
+AICC_TOOL_LAUNCHER_SOURCE="$ROOT_DIR/publish/aios/aicc-tool"
+AICC_TOOL_IMPORT_MAP_SOURCE="$ROOT_DIR/publish/aios/aicc-tool.import-map.json"
+BUCKYOS_WEBSDK_REPO="https://github.com/buckyos/buckyos-websdk.git"
+BUCKYOS_WEBSDK_COMMIT="${BUCKYOS_WEBSDK_COMMIT:-6849d3a9edc6e0c6ac54883bdb7bd12531c76aae}"
 REUSE_CARGO_TARGET=0
 CARGO_TARGET_DIR_OVERRIDE="${AIOS_CARGO_TARGET_DIR:-}"
 
@@ -56,6 +61,10 @@ Options:
   --cargo-target-dir <dir>
                   Reuse a specific Cargo target dir; relative paths are resolved from repo root
   -h, --help      Show this help
+
+Env overrides:
+  BUCKYOS_WEBSDK_COMMIT
+                  Pinned buckyos-websdk commit packaged with buckyos-agent tools
 EOF
 }
 
@@ -280,6 +289,51 @@ package_list_to_string() {
   printf '%s' "$*"
 }
 
+prepare_buckyos_agent_package() {
+  local output_dir="$1"
+  local tmp_root="$2"
+  local sdk_dist=""
+  local sdk_checkout="$tmp_root/buckyos-websdk"
+  local fetched_commit
+
+  if [[ ! -f "$BUCKYOS_AGENT_TOOLS_SOURCE/aicc-tool.ts" ]]; then
+    echo "Missing buckyos-agent entrypoint: $BUCKYOS_AGENT_TOOLS_SOURCE/aicc-tool.ts" >&2
+    exit 1
+  fi
+  if [[ ! -f "$AICC_TOOL_LAUNCHER_SOURCE" ]]; then
+    echo "Missing AICC tool launcher: $AICC_TOOL_LAUNCHER_SOURCE" >&2
+    exit 1
+  fi
+  if [[ ! -f "$AICC_TOOL_IMPORT_MAP_SOURCE" ]]; then
+    echo "Missing AICC tool import map: $AICC_TOOL_IMPORT_MAP_SOURCE" >&2
+    exit 1
+  fi
+
+  mkdir -p "$output_dir"
+  cp -R "$BUCKYOS_AGENT_TOOLS_SOURCE/." "$output_dir/"
+  cp "$AICC_TOOL_IMPORT_MAP_SOURCE" "$output_dir/installed-import-map.json"
+
+  log "Fetching buckyos-websdk commit $BUCKYOS_WEBSDK_COMMIT for AICC tools"
+  git init -q "$sdk_checkout"
+  git -C "$sdk_checkout" remote add origin "$BUCKYOS_WEBSDK_REPO"
+  git -C "$sdk_checkout" fetch -q --depth 1 origin "$BUCKYOS_WEBSDK_COMMIT"
+  fetched_commit="$(git -C "$sdk_checkout" rev-parse FETCH_HEAD)"
+  if [[ "$fetched_commit" != "$BUCKYOS_WEBSDK_COMMIT" ]]; then
+    echo "Fetched buckyos-websdk commit $fetched_commit, expected $BUCKYOS_WEBSDK_COMMIT" >&2
+    exit 1
+  fi
+  git -C "$sdk_checkout" checkout -q --detach FETCH_HEAD
+  sdk_dist="$sdk_checkout/dist"
+
+  if [[ ! -f "$sdk_dist/node.mjs" ]]; then
+    echo "buckyos-websdk Node bundle not found in $sdk_dist" >&2
+    exit 1
+  fi
+
+  mkdir -p "$output_dir/vendor/buckyos-websdk"
+  cp -R "$sdk_dist/." "$output_dir/vendor/buckyos-websdk/"
+}
+
 render_dockerfile() {
   local output_path="$1"
   local -a apt_packages=("${RUNTIME_PACKAGES[@]}")
@@ -326,6 +380,26 @@ RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 
 ENV BUCKYOS_ROOT=/opt/buckyos
 WORKDIR /opt/buckyos
+
+# BuckyOS Agent AICC CLI tools. Keep these outside /opt/buckyos/tools because
+# that path is shadowed by the shared ExtTool volume at runtime.
+COPY buckyos-agent /opt/buckyos/bin/opendan/buckyos-agent
+COPY aicc-tool-launcher /usr/local/bin/aicc-tool
+RUN chmod 755 /usr/local/bin/aicc-tool && \
+    for command_path in /opt/buckyos/bin/opendan/buckyos-agent/commands/*.ts; do \
+      command_name="$(basename "$command_path" .ts)"; \
+      ln -sf aicc-tool "/usr/local/bin/$command_name"; \
+    done && \
+    deno check \
+      --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
+      --import-map /opt/buckyos/bin/opendan/buckyos-agent/installed-import-map.json \
+      /opt/buckyos/bin/opendan/buckyos-agent/aicc-tool.ts && \
+    command -v aicc-tool >/dev/null && \
+    command -v gen_image >/dev/null && \
+    command -v edit_image >/dev/null && \
+    aicc-tool --help >/dev/null 2>&1 && \
+    gen_image --help >/dev/null 2>&1 && \
+    edit_image --help >/dev/null 2>&1
 
 # ExtTool Volume mount point — kept empty in the Worker image. The real
 # payload (FreeCAD, pre-warmed uv/deno caches, tool packages) ships in the
@@ -992,6 +1066,7 @@ main() {
   local python_bin
   local cargo_target_dir
   local cargo_target_mode
+  local buckyos_agent_package_dir
   local -a target_arches=()
 
   if [[ ! -f "$PROJECT_CONFIG_PATH" ]]; then
@@ -1008,6 +1083,9 @@ main() {
 
   tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/build_aios.XXXXXX")"
   trap "rm -rf '$tmp_root'" EXIT
+
+  buckyos_agent_package_dir="$tmp_root/buckyos-agent-package"
+  prepare_buckyos_agent_package "$buckyos_agent_package_dir" "$tmp_root"
 
   cargo_target_dir="$(resolve_cargo_target_dir "$tmp_root")"
   mkdir -p "$cargo_target_dir"
@@ -1050,6 +1128,8 @@ main() {
     mkdir -p "$context_dir"
 
     build_runtime_binaries "$arch" "$context_dir" "$cargo_target_dir" "$python_bin"
+    cp -R "$buckyos_agent_package_dir" "$context_dir/buckyos-agent"
+    cp "$AICC_TOOL_LAUNCHER_SOURCE" "$context_dir/aicc-tool-launcher"
     render_dockerfile "$dockerfile_path"
     build_image "$arch" "$context_dir" "$platform" "$dockerfile_path"
   done

--- a/build_aios
+++ b/build_aios
@@ -29,7 +29,6 @@ INSTALL_WORKSPACE_TOOLS=1
 ENTRYPOINT_SOURCE="$ROOT_DIR/publish/aios/entrypoint.sh"
 BUCKYOS_AGENT_TOOLS_SOURCE="$SRC_DIR/tools/buckyos-agent"
 AICC_TOOL_LAUNCHER_SOURCE="$ROOT_DIR/publish/aios/aicc-tool"
-AICC_TOOL_IMPORT_MAP_SOURCE="$ROOT_DIR/publish/aios/aicc-tool.import-map.json"
 BUCKYOS_WEBSDK_REPO="https://github.com/buckyos/buckyos-websdk.git"
 BUCKYOS_WEBSDK_COMMIT="${BUCKYOS_WEBSDK_COMMIT:-6849d3a9edc6e0c6ac54883bdb7bd12531c76aae}"
 REUSE_CARGO_TARGET=0
@@ -292,6 +291,7 @@ package_list_to_string() {
 prepare_buckyos_agent_package() {
   local output_dir="$1"
   local tmp_root="$2"
+  local python_bin="$3"
   local sdk_dist=""
   local sdk_checkout="$tmp_root/buckyos-websdk"
   local fetched_commit
@@ -304,14 +304,8 @@ prepare_buckyos_agent_package() {
     echo "Missing AICC tool launcher: $AICC_TOOL_LAUNCHER_SOURCE" >&2
     exit 1
   fi
-  if [[ ! -f "$AICC_TOOL_IMPORT_MAP_SOURCE" ]]; then
-    echo "Missing AICC tool import map: $AICC_TOOL_IMPORT_MAP_SOURCE" >&2
-    exit 1
-  fi
-
   mkdir -p "$output_dir"
   cp -R "$BUCKYOS_AGENT_TOOLS_SOURCE/." "$output_dir/"
-  cp "$AICC_TOOL_IMPORT_MAP_SOURCE" "$output_dir/installed-import-map.json"
 
   log "Fetching buckyos-websdk commit $BUCKYOS_WEBSDK_COMMIT for AICC tools"
   git init -q "$sdk_checkout"
@@ -332,6 +326,17 @@ prepare_buckyos_agent_package() {
 
   mkdir -p "$output_dir/vendor/buckyos-websdk"
   cp -R "$sdk_dist/." "$output_dir/vendor/buckyos-websdk/"
+
+  "$python_bin" - "$output_dir/deno.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+config_path = Path(sys.argv[1])
+config = json.loads(config_path.read_text(encoding="utf-8"))
+config.setdefault("imports", {})["buckyos"] = "./vendor/buckyos-websdk/node.mjs"
+config_path.write_text(json.dumps(config, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
 }
 
 render_dockerfile() {
@@ -392,8 +397,17 @@ RUN chmod 755 /usr/local/bin/aicc-tool && \
     done && \
     deno check \
       --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
-      --import-map /opt/buckyos/bin/opendan/buckyos-agent/installed-import-map.json \
       /opt/buckyos/bin/opendan/buckyos-agent/aicc-tool.ts && \
+    (cd /opt/buckyos/bin/opendan/buckyos-agent && deno task gen_image --help >/dev/null 2>&1) && \
+    printf '%s\n' \
+      'import { teardown } from "/opt/buckyos/bin/opendan/buckyos-agent/lib/runtime.ts";' \
+      'teardown();' > /tmp/buckyos-agent-compose-smoke.ts && \
+    deno run \
+      --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
+      --allow-env \
+      --allow-read \
+      /tmp/buckyos-agent-compose-smoke.ts && \
+    rm -f /tmp/buckyos-agent-compose-smoke.ts && \
     command -v aicc-tool >/dev/null && \
     command -v gen_image >/dev/null && \
     command -v edit_image >/dev/null && \
@@ -1085,7 +1099,7 @@ main() {
   trap "rm -rf '$tmp_root'" EXIT
 
   buckyos_agent_package_dir="$tmp_root/buckyos-agent-package"
-  prepare_buckyos_agent_package "$buckyos_agent_package_dir" "$tmp_root"
+  prepare_buckyos_agent_package "$buckyos_agent_package_dir" "$tmp_root" "$python_bin"
 
   cargo_target_dir="$(resolve_cargo_target_dir "$tmp_root")"
   mkdir -p "$cargo_target_dir"

--- a/doc/arch/11_env_contract.md
+++ b/doc/arch/11_env_contract.md
@@ -93,6 +93,8 @@ aios entrypoint 派生或兼容变量：
 | 变量 | 来源 | 消费方 | 语义 |
 | --- | --- | --- | --- |
 | `BUCKYOS_APPCLIENT_SESSION_TOKEN` | 外部客户端、AgentTool runner、调试脚本 | `buckyos-api` AppClient runtime、AgentTool | AppClient 调用 kRPC 的 session token。缺失时 AppClient runtime 会尝试从本地 user/device config 和私钥生成 token；AgentTool 需要访问 runtime 时要求该变量存在。 |
+| `BUCKYOS_NODE_GATEWAY_PORT` | 调用方或调试环境可选覆盖；node-daemon/aios 当前不显式注入 | `src/tools/buckyos-agent` | 使用注入的 AppClient session token 时，指定容器访问宿主机 NodeGateway 的端口，默认 `3180`；不适用于外部 Zone 登录模式。若 `BUCKYOS_HOST_GATEWAY` 已包含端口，则以其中的端口为准。 |
+| `BUCKYOS_AICC_TOOL_ROOT` | AIOS launcher 调试环境可选覆盖；node-daemon/aios 不注入 | `/usr/local/bin/aicc-tool` launcher | 覆盖只读 AICC TypeScript 工具安装目录，默认 `/opt/buckyos/bin/opendan/buckyos-agent`。仅用于镜像测试或非标准安装布局，不是 Agent 业务配置。 |
 | `OPENDAN_AGENT_ROOT` | AgentTool runner | AgentTool runtime context | Agent RootFS 根目录。新的 AgentTool 最小契约之一。 |
 | `OPENDAN_SESSION_ID` | AgentTool runner | AgentTool runtime context | 当前 agent session id。 |
 | `OPENDAN_TRACE_ID` | AgentTool runner | AgentTool runtime context | 可选 trace id。 |

--- a/publish/aios/Dockerfile
+++ b/publish/aios/Dockerfile
@@ -50,6 +50,26 @@ RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 ENV BUCKYOS_ROOT=/opt/buckyos
 WORKDIR /opt/buckyos
 
+# BuckyOS Agent AICC CLI tools. Keep these outside /opt/buckyos/tools because
+# that path is shadowed by the shared ExtTool volume at runtime.
+COPY buckyos-agent /opt/buckyos/bin/opendan/buckyos-agent
+COPY aicc-tool-launcher /usr/local/bin/aicc-tool
+RUN chmod 755 /usr/local/bin/aicc-tool && \
+    for command_path in /opt/buckyos/bin/opendan/buckyos-agent/commands/*.ts; do \
+      command_name="$(basename "$command_path" .ts)"; \
+      ln -sf aicc-tool "/usr/local/bin/$command_name"; \
+    done && \
+    deno check \
+      --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
+      --import-map /opt/buckyos/bin/opendan/buckyos-agent/installed-import-map.json \
+      /opt/buckyos/bin/opendan/buckyos-agent/aicc-tool.ts && \
+    command -v aicc-tool >/dev/null && \
+    command -v gen_image >/dev/null && \
+    command -v edit_image >/dev/null && \
+    aicc-tool --help >/dev/null 2>&1 && \
+    gen_image --help >/dev/null 2>&1 && \
+    edit_image --help >/dev/null 2>&1
+
 # ExtTool Volume mount point — kept empty in the Worker image. Real payload
 # ships in the separate paios/exttool image and lands in the buckyos-exttool
 # named volume, which node_daemon mounts here read-only at run time.

--- a/publish/aios/Dockerfile
+++ b/publish/aios/Dockerfile
@@ -61,8 +61,17 @@ RUN chmod 755 /usr/local/bin/aicc-tool && \
     done && \
     deno check \
       --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
-      --import-map /opt/buckyos/bin/opendan/buckyos-agent/installed-import-map.json \
       /opt/buckyos/bin/opendan/buckyos-agent/aicc-tool.ts && \
+    (cd /opt/buckyos/bin/opendan/buckyos-agent && deno task gen_image --help >/dev/null 2>&1) && \
+    printf '%s\n' \
+      'import { teardown } from "/opt/buckyos/bin/opendan/buckyos-agent/lib/runtime.ts";' \
+      'teardown();' > /tmp/buckyos-agent-compose-smoke.ts && \
+    deno run \
+      --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
+      --allow-env \
+      --allow-read \
+      /tmp/buckyos-agent-compose-smoke.ts && \
+    rm -f /tmp/buckyos-agent-compose-smoke.ts && \
     command -v aicc-tool >/dev/null && \
     command -v gen_image >/dev/null && \
     command -v edit_image >/dev/null && \

--- a/publish/aios/aicc-tool
+++ b/publish/aios/aicc-tool
@@ -7,7 +7,6 @@ launcher="$(basename "$0")"
 if [ "$launcher" = "aicc-tool" ]; then
   exec deno run \
     --config "$tool_root/deno.json" \
-    --import-map "$tool_root/installed-import-map.json" \
     --allow-net \
     --allow-read \
     --allow-write \
@@ -18,7 +17,6 @@ fi
 
 exec deno run \
   --config "$tool_root/deno.json" \
-  --import-map "$tool_root/installed-import-map.json" \
   --allow-net \
   --allow-read \
   --allow-write \

--- a/publish/aios/aicc-tool
+++ b/publish/aios/aicc-tool
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set -eu
+
+tool_root="${BUCKYOS_AICC_TOOL_ROOT:-/opt/buckyos/bin/opendan/buckyos-agent}"
+launcher="$(basename "$0")"
+
+if [ "$launcher" = "aicc-tool" ]; then
+  exec deno run \
+    --config "$tool_root/deno.json" \
+    --import-map "$tool_root/installed-import-map.json" \
+    --allow-net \
+    --allow-read \
+    --allow-write \
+    --allow-env \
+    --unsafely-ignore-certificate-errors \
+    "$tool_root/aicc-tool.ts" "$@"
+fi
+
+exec deno run \
+  --config "$tool_root/deno.json" \
+  --import-map "$tool_root/installed-import-map.json" \
+  --allow-net \
+  --allow-read \
+  --allow-write \
+  --allow-env \
+  --unsafely-ignore-certificate-errors \
+  "$tool_root/aicc-tool.ts" "$launcher" "$@"

--- a/publish/aios/aicc-tool.import-map.json
+++ b/publish/aios/aicc-tool.import-map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "buckyos": "./vendor/buckyos-websdk/node.mjs"
+  }
+}

--- a/publish/aios/aicc-tool.import-map.json
+++ b/publish/aios/aicc-tool.import-map.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "buckyos": "./vendor/buckyos-websdk/node.mjs"
-  }
-}

--- a/src/frame/opendan/src/agent.rs
+++ b/src/frame/opendan/src/agent.rs
@@ -37,7 +37,7 @@ use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::time::{sleep, Duration};
 
 use crate::agent_bash::{build_session_tools, SessionBinLayout, SessionToolsBuild};
-use crate::agent_config::AgentConfig;
+use crate::agent_config::{AgentConfig, SessionIdStrategy};
 use crate::agent_session::{AgentSession, AgentSessionBuild, SessionReply};
 use crate::agent_task_executor::TASK_TYPE_AGENT_DELEGATE;
 use crate::ai_runtime::AgentRuntime;
@@ -130,8 +130,8 @@ pub enum Inbound {
         /// pending queue and as the ack handle back to msg-center. Locally
         /// injected items use a synthetic `local-...` id.
         record_id: String,
-        /// Originating tunnel / DID host name. Drives the
-        /// `tunnel_to_ui_session` lookup when `session_id` is `None`.
+        /// Originating tunnel / DID host name. Drives the active
+        /// `tunnel_to_ui_session` binding for per-peer UI sessions.
         from: String,
         /// Full DID of the sender, used as the reply target when the
         /// session emits an assistant message. `None` for locally-injected
@@ -148,7 +148,8 @@ pub enum Inbound {
         /// (`MsgObject.to`), which carries its own routing, so this is no longer
         /// forwarded to `post_send`.
         tunnel_did: Option<String>,
-        /// Optional explicit target. `None` ⇒ resolve via `from`.
+        /// Optional upstream target. Used when no active per-peer UI tunnel
+        /// binding exists; `/new`, `/switch`, and `/clean` bindings take priority.
         session_id: Option<String>,
         /// Group DID for group messages. `None` for one-to-one chat.
         group_id: Option<String>,
@@ -1243,6 +1244,29 @@ impl AIAgent {
             .compute(cfg.session_id_strategy, &input)
     }
 
+    async fn resolve_msg_session_id(
+        self: &Arc<Self>,
+        from: &str,
+        use_tunnel_binding: bool,
+        explicit_session_id: Option<String>,
+        evaluated_session_id: Option<String>,
+    ) -> Result<String> {
+        if use_tunnel_binding {
+            if let Some(session_id) = self.tunnel_to_ui_session.lock().await.get(from).cloned() {
+                return Ok(session_id);
+            }
+        }
+
+        if let Some(session_id) = explicit_session_id.or(evaluated_session_id) {
+            if use_tunnel_binding {
+                self.bind_tunnel_to_session(from, &session_id).await;
+            }
+            return Ok(session_id);
+        }
+
+        self.clone().resolve_ui_session(from).await
+    }
+
     async fn dispatch_inbound(self: Arc<Self>, item: Inbound) -> Result<()> {
         match item {
             Inbound::Msg {
@@ -1267,9 +1291,11 @@ impl AIAgent {
                     .session_class(&class)
                     .map(|c| c.kind)
                     .unwrap_or(SessionKind::Ui);
-                let resolved_id = if let Some(sid) = session_id {
-                    sid
-                } else {
+                let use_tunnel_binding = self.config.session_class(&class).is_some_and(|cfg| {
+                    matches!(kind, SessionKind::Ui)
+                        && matches!(cfg.session_id_strategy, SessionIdStrategy::PerPeer)
+                });
+                let evaluated_session_id = if session_id.is_none() {
                     // Build a tiny shim Inbound so the evaluator can read
                     // from/from_did without re-borrowing the moved fields.
                     let probe = Inbound::Msg {
@@ -1283,22 +1309,18 @@ impl AIAgent {
                         text: String::new(),
                         ai_message: ai_message.clone(),
                     };
-                    match self.evaluate_session_id(&class, &probe) {
-                        Some(id) => {
-                            // For UI-style classes we keep the tunnel binding
-                            // so /switch and follow-up messages route to the
-                            // same session.
-                            if matches!(kind, SessionKind::Ui) {
-                                self.tunnel_to_ui_session
-                                    .lock()
-                                    .await
-                                    .insert(from.clone(), id.clone());
-                            }
-                            id
-                        }
-                        None => self.clone().resolve_ui_session(&from).await?,
-                    }
+                    self.evaluate_session_id(&class, &probe)
+                } else {
+                    None
                 };
+                let resolved_id = self
+                    .resolve_msg_session_id(
+                        &from,
+                        use_tunnel_binding,
+                        session_id,
+                        evaluated_session_id,
+                    )
+                    .await?;
                 if !self.session_accepts_pending(&resolved_id).await? {
                     warn!(
                         "opendan.agent[{}]: reject msg record_id={} for ended session {}",
@@ -3608,6 +3630,68 @@ runner_id = "agent"
         assert!(msg.contains("followup_routing.target_worksession_id"));
         assert!(msg.contains("title `Old task`"));
         assert!(msg.contains("workspace `old-workspace`"));
+    }
+
+    #[tokio::test]
+    async fn explicit_ui_session_initializes_missing_tunnel_binding() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let agent = test_agent(dir.path().to_path_buf());
+
+        let resolved = agent
+            .resolve_msg_session_id("did:dev:alice", true, Some("tg-explicit".to_string()), None)
+            .await
+            .expect("resolve explicit session");
+
+        assert_eq!(resolved, "tg-explicit");
+        assert_eq!(
+            agent
+                .resolve_session_for_command("did:dev:alice")
+                .await
+                .expect("tunnel binding"),
+            "tg-explicit"
+        );
+    }
+
+    #[tokio::test]
+    async fn ui_command_bindings_override_stale_explicit_session_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let agent = test_agent(dir.path().to_path_buf());
+        let from = "did:dev:alice";
+
+        agent.bind_tunnel_to_session(from, "ui-new").await;
+        assert_eq!(
+            agent
+                .resolve_msg_session_id(from, true, Some("tg-stale".to_string()), None)
+                .await
+                .expect("route after new"),
+            "ui-new"
+        );
+        assert_eq!(
+            agent
+                .resolve_msg_session_id(from, true, None, Some("ui-derived".to_string()))
+                .await
+                .expect("route derived session after new"),
+            "ui-new"
+        );
+
+        agent.bind_tunnel_to_session(from, "ui-switched").await;
+        assert_eq!(
+            agent
+                .resolve_msg_session_id(from, true, Some("tg-stale".to_string()), None)
+                .await
+                .expect("route after switch"),
+            "ui-switched"
+        );
+
+        agent.unbind_tunnel_if_session(from, "ui-switched").await;
+        agent.bind_tunnel_to_session(from, "ui-clean").await;
+        assert_eq!(
+            agent
+                .resolve_msg_session_id(from, true, Some("tg-stale".to_string()), None)
+                .await
+                .expect("route after clean"),
+            "ui-clean"
+        );
     }
 
     #[tokio::test]

--- a/src/frame/opendan/src/behavior_cfg.rs
+++ b/src/frame/opendan/src/behavior_cfg.rs
@@ -614,16 +614,34 @@ mod tests {
     fn jarvis_work_behaviors_define_runtime_prompt_hooks() {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../rootfs/bin/buckyos_jarvis/behaviors");
-        let image_cli_prompt = std::fs::read_to_string(root.join("aicc_image_cli.inc")).unwrap();
+        let media_cli_prompt = std::fs::read_to_string(root.join("aicc_image_cli.inc")).unwrap();
         for required in [
-            "edit_image",
             "gen_image",
+            "edit_image",
+            "inpaint_image",
+            "upscale_image",
+            "remove_bg",
+            "ocr_image",
+            "caption_image",
+            "detect_image",
+            "segment_image",
+            "text_to_speech",
+            "speech_to_text",
+            "gen_music",
+            "enhance_audio",
+            "gen_video",
+            "img2video",
+            "video2video",
+            "extend_video",
+            "upscale_video",
+            "ai_provider",
+            "ai_quota",
             "named_object:<obj_id>",
             "<attachment path=",
         ] {
             assert!(
-                image_cli_prompt.contains(required),
-                "AICC image CLI prompt must document `{required}`"
+                media_cli_prompt.contains(required),
+                "AICC media CLI prompt must document `{required}`"
             );
         }
         for name in ["chat_route", "plan", "do"] {

--- a/src/frame/opendan/src/behavior_cfg.rs
+++ b/src/frame/opendan/src/behavior_cfg.rs
@@ -626,7 +626,7 @@ mod tests {
                 "AICC image CLI prompt must document `{required}`"
             );
         }
-        for name in ["plan", "do"] {
+        for name in ["chat_route", "plan", "do"] {
             let path = root.join(format!("{name}.toml"));
             let cfg = BehaviorCfg::load_from_file(&path).unwrap();
             assert!(
@@ -636,6 +636,10 @@ mod tests {
                 "{} must include the AICC image CLI prompt",
                 path.display()
             );
+        }
+        for name in ["plan", "do"] {
+            let path = root.join(format!("{name}.toml"));
+            let cfg = BehaviorCfg::load_from_file(&path).unwrap();
             assert!(
                 cfg.prompt
                     .on_behavior_switch

--- a/src/frame/opendan/src/behavior_cfg.rs
+++ b/src/frame/opendan/src/behavior_cfg.rs
@@ -614,9 +614,28 @@ mod tests {
     fn jarvis_work_behaviors_define_runtime_prompt_hooks() {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../rootfs/bin/buckyos_jarvis/behaviors");
+        let image_cli_prompt = std::fs::read_to_string(root.join("aicc_image_cli.inc")).unwrap();
+        for required in [
+            "edit_image",
+            "gen_image",
+            "named_object:<obj_id>",
+            "<attachment path=",
+        ] {
+            assert!(
+                image_cli_prompt.contains(required),
+                "AICC image CLI prompt must document `{required}`"
+            );
+        }
         for name in ["plan", "do"] {
             let path = root.join(format!("{name}.toml"));
             let cfg = BehaviorCfg::load_from_file(&path).unwrap();
+            assert!(
+                cfg.prompt
+                    .on_init
+                    .contains("__INCLUDE(./aicc_image_cli.inc)__"),
+                "{} must include the AICC image CLI prompt",
+                path.display()
+            );
             assert!(
                 cfg.prompt
                     .on_behavior_switch

--- a/src/rootfs/bin/buckyos_jarvis/behaviors/aicc_image_cli.inc
+++ b/src/rootfs/bin/buckyos_jarvis/behaviors/aicc_image_cli.inc
@@ -24,6 +24,17 @@ gen_image 'A precise product photo of a matte black desk lamp.' './desk-lamp.png
 
 Use `<command> --help` when non-default options are needed.
 
+### Reading and extending the tools
+
+- The read-only installed TypeScript sources are under `/opt/buckyos/bin/opendan/buckyos-agent/`.
+- Inspect `commands/*.ts` for complete AICC call examples and reuse helpers from `lib/*.ts` when a built-in command does not cover the task.
+- Write derived scripts only to the Agent or current Session `tools/` directory. Never modify the installed system copy.
+- Run a derived script with the installed configuration so the vendored SDK resolves correctly:
+
+```bash
+deno run --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json --allow-net --allow-read --allow-write --allow-env --unsafely-ignore-certificate-errors './tools/my-aicc-tool.ts'
+```
+
 ### Completion and failure
 
 - Treat the command as successful only when its `AgentToolResult` reports success and the output file exists.

--- a/src/rootfs/bin/buckyos_jarvis/behaviors/aicc_image_cli.inc
+++ b/src/rootfs/bin/buckyos_jarvis/behaviors/aicc_image_cli.inc
@@ -1,0 +1,31 @@
+## AICC Image CLI
+
+The AIOS runtime provides image commands on `PATH`. Use them through `exec_bash` for image tasks.
+
+### Tool selection
+
+- To modify, restyle, or add something to an existing image, you MUST use `edit_image` as the first choice.
+- To create a new image from text, you MUST use `gen_image` as the first choice.
+- Use `inpaint_image` when the user supplies a mask, `upscale_image` for resolution enhancement, and `remove_bg` for background removal.
+- Do not replace an applicable AICC image command with hand-written SVG, ImageMagick drawing, or Python compositing merely because those utilities are available.
+
+### Inputs and invocation
+
+- Run `command -v <command>` once if availability is uncertain. Do not repeatedly probe an available command.
+- For a message attachment whose source type is `named_object`, pass `named_object:<obj_id>` as the input image.
+- For a URL attachment, pass its URL. A local file path and a `data:` URL are also accepted.
+- Write results to the current workspace when one is available; otherwise use a session-local output path.
+- Quote the edit instruction as one argument. Typical invocations are:
+
+```bash
+edit_image 'named_object:<obj_id>' 'Add a large bumblebee to the center of the flower.' './flower-with-bumblebee.png'
+gen_image 'A precise product photo of a matte black desk lamp.' './desk-lamp.png'
+```
+
+Use `<command> --help` when non-default options are needed.
+
+### Completion and failure
+
+- Treat the command as successful only when its `AgentToolResult` reports success and the output file exists.
+- Return every requested image with `<attachment path="..." title="..." />`; mentioning a path in prose is not delivery.
+- If the selected AICC command is missing or fails, inspect and report its structured error. Use a fallback only when the AICC capability is unavailable or the command cannot perform the requested operation, and state that fallback explicitly.

--- a/src/rootfs/bin/buckyos_jarvis/behaviors/aicc_image_cli.inc
+++ b/src/rootfs/bin/buckyos_jarvis/behaviors/aicc_image_cli.inc
@@ -1,13 +1,15 @@
-## AICC Image CLI
+## AICC Media CLI
 
-The AIOS runtime provides image commands on `PATH`. Use them through `exec_bash` for image tasks.
+The AIOS runtime provides image, vision, audio, video, and AICC diagnostic commands on `PATH`. Use the matching command through `exec_bash` instead of merely describing how the task could be done.
 
 ### Tool selection
 
-- To modify, restyle, or add something to an existing image, you MUST use `edit_image` as the first choice.
-- To create a new image from text, you MUST use `gen_image` as the first choice.
-- Use `inpaint_image` when the user supplies a mask, `upscale_image` for resolution enhancement, and `remove_bg` for background removal.
-- Do not replace an applicable AICC image command with hand-written SVG, ImageMagick drawing, or Python compositing merely because those utilities are available.
+- Image generation and editing: `gen_image` creates an image from text; `edit_image` modifies or restyles an existing image; `inpaint_image` edits a masked region; `upscale_image` increases resolution; `remove_bg` removes the background.
+- Image understanding: `ocr_image` extracts document text; `caption_image` describes an image; `detect_image` returns detected objects as JSON; `segment_image` returns segmentation data as JSON.
+- Audio: `text_to_speech` synthesizes speech; `speech_to_text` transcribes audio; `gen_music` creates music from a prompt; `enhance_audio` cleans or enhances existing audio.
+- Video: `gen_video` creates video from text; `img2video` animates an image; `video2video` transforms an existing video; `extend_video` continues a video; `upscale_video` increases video resolution.
+- AICC diagnostics: `ai_provider list` lists configured providers; `ai_provider health` checks provider health; `ai_quota` queries quota, optionally filtered by capability or method. Use these for explicit status/quota requests or to diagnose an AICC availability failure, not as a substitute for the requested media command.
+- For an applicable media request, the matching AICC command MUST be the first choice. Do not replace it with hand-written SVG, ImageMagick drawing, Python compositing, or a prose-only instruction merely because those alternatives are available.
 
 ### Inputs and invocation
 
@@ -20,6 +22,9 @@ The AIOS runtime provides image commands on `PATH`. Use them through `exec_bash`
 ```bash
 edit_image 'named_object:<obj_id>' 'Add a large bumblebee to the center of the flower.' './flower-with-bumblebee.png'
 gen_image 'A precise product photo of a matte black desk lamp.' './desk-lamp.png'
+ocr_image 'named_object:<obj_id>' './recognized-text.txt'
+text_to_speech 'Welcome to BuckyOS.' './welcome.wav'
+img2video 'named_object:<obj_id>' 'Slow camera push-in with natural motion.' './animated.mp4'
 ```
 
 Use `<command> --help` when non-default options are needed.
@@ -37,6 +42,6 @@ deno run --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json --allow-net -
 
 ### Completion and failure
 
-- Treat the command as successful only when its `AgentToolResult` reports success and the output file exists.
-- Return every requested image with `<attachment path="..." title="..." />`; mentioning a path in prose is not delivery.
+- Treat the command as successful only when its `AgentToolResult` reports success and every expected output file exists.
+- Return every requested image, audio, video, text file, or JSON artifact with `<attachment path="..." title="..." />`; mentioning a path in prose is not delivery. Inline a short text/JSON result as well when that is more useful to the user.
 - If the selected AICC command is missing or fails, inspect and report its structured error. Use a fallback only when the AICC capability is unavailable or the command cannot perform the requested operation, and state that fallback explicitly.

--- a/src/rootfs/bin/buckyos_jarvis/behaviors/chat_route.toml
+++ b/src/rootfs/bin/buckyos_jarvis/behaviors/chat_route.toml
@@ -83,6 +83,7 @@ Prefer `read` when reading files.
 - Read a note when relevant: `agent-notebook read [--bookid notebook_id] --title $title`
 - Create or update a notebook before writing unrelated durable information: `agent-notebook create-notebook --bookid notebook_id [--kind normal|project|agent] [--title <title>] [--description <description>]`
 
+__INCLUDE(./aicc_image_cli.inc)__
 
 <</skills>>
 """

--- a/src/rootfs/bin/buckyos_jarvis/behaviors/do.toml
+++ b/src/rootfs/bin/buckyos_jarvis/behaviors/do.toml
@@ -82,6 +82,8 @@ __INCLUDE(./step_record_rule.inc)__
 
 Read global state only when it can change execution. Do not dump large state into the report; include only the facts needed to explain the result.
 
+__INCLUDE(./aicc_image_cli.inc)__
+
 <</SKILLS>>
 
 """

--- a/src/rootfs/bin/buckyos_jarvis/behaviors/plan.toml
+++ b/src/rootfs/bin/buckyos_jarvis/behaviors/plan.toml
@@ -79,6 +79,8 @@ __INCLUDE(./step_record_rule.inc)__
 
 Read global state only when it can change the plan. Do not repeat large state dumps in todos; copy only the facts needed for DO mode.
 
+__INCLUDE(./aicc_image_cli.inc)__
+
 <</SKILLS>>
 
 <<RESULT_PROTOCOL>>

--- a/src/tools/buckyos-agent/lib/runtime.ts
+++ b/src/tools/buckyos-agent/lib/runtime.ts
@@ -2,6 +2,7 @@
 // but tailored for the CLI: env-var-driven, single-shot login.
 
 import { buckyos, parseSessionTokenClaims, RuntimeType } from "buckyos";
+import { resolveRuntimeConnection } from "./runtime_config.ts";
 
 export interface AiccRuntime {
   // deno-lint-ignore no-explicit-any
@@ -13,11 +14,6 @@ export interface AiccRuntime {
 }
 
 let cached: AiccRuntime | null = null;
-
-function envOr(name: string, fallback: string): string {
-  const v = Deno.env.get(name);
-  return typeof v === "string" && v.trim() ? v.trim() : fallback;
-}
 
 function envOpt(name: string): string | undefined {
   const v = Deno.env.get(name);
@@ -31,8 +27,8 @@ function sleep(ms: number): Promise<void> {
 export async function initRuntime(): Promise<AiccRuntime> {
   if (cached) return cached;
 
-  const appId = envOr("BUCKYOS_APP_ID", envOr("BUCKYOS_TEST_APP_ID", "buckyos-agent"));
-  const zoneHost = envOr("BUCKYOS_ZONE_HOST", envOr("BUCKYOS_TEST_ZONE_HOST", "test.buckyos.io"));
+  const connection = resolveRuntimeConnection(Deno.env.toObject());
+  const { appId, ownerUserId, zoneHost } = connection;
   const homeDir = Deno.env.get("HOME") ?? "";
   const privateKeySearchPaths = [
     envOpt("BUCKYOS_APP_CLIENT_DIR"),
@@ -46,16 +42,19 @@ export async function initRuntime(): Promise<AiccRuntime> {
   // deno-lint-ignore no-explicit-any
   await (buckyos as any).initBuckyOS(appId, {
     appId,
-    ownerUserId: "devtest",
+    ownerUserId,
     runtimeType: RuntimeType.AppClient,
     zoneHost,
-    defaultProtocol: "https://",
+    defaultProtocol: connection.defaultProtocol,
+    sessionToken: connection.sessionToken,
     privateKeySearchPaths,
     autoRenew: false,
   });
 
-  // Local JWT signature uses a not-before timestamp ~1s in the future.
-  await sleep(1100);
+  if (!connection.usesInjectedSession) {
+    // Local JWT signature uses a not-before timestamp ~1s in the future.
+    await sleep(1100);
+  }
   // deno-lint-ignore no-explicit-any
   const account = await (buckyos as any).login();
   if (!account?.session_token) {
@@ -65,11 +64,11 @@ export async function initRuntime(): Promise<AiccRuntime> {
     (parseSessionTokenClaims(account.session_token) as Record<string, unknown> | null) ?? null;
 
   const userId = account.user_id ?? (claims?.sub as string | undefined) ??
-    (claims?.userid as string | undefined) ?? "devtest";
+    (claims?.userid as string | undefined) ?? ownerUserId;
   // deno-lint-ignore no-explicit-any
-  const ownerUserId = (buckyos as any).getBuckyOSConfig?.()?.ownerUserId ?? userId;
+  const runtimeOwnerUserId = (buckyos as any).getBuckyOSConfig?.()?.ownerUserId ?? ownerUserId;
 
-  cached = { buckyos, userId, ownerUserId, zoneHost, appId };
+  cached = { buckyos, userId, ownerUserId: runtimeOwnerUserId, zoneHost, appId };
   return cached;
 }
 

--- a/src/tools/buckyos-agent/lib/runtime_config.ts
+++ b/src/tools/buckyos-agent/lib/runtime_config.ts
@@ -1,0 +1,54 @@
+export interface RuntimeEnvironment {
+  [name: string]: string | undefined;
+}
+
+export interface RuntimeConnectionConfig {
+  appId: string;
+  ownerUserId: string;
+  zoneHost: string;
+  defaultProtocol: "http://" | "https://";
+  sessionToken?: string;
+  usesInjectedSession: boolean;
+}
+
+function value(env: RuntimeEnvironment, name: string): string | undefined {
+  const raw = env[name];
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+function hostWithPort(host: string, port: string): string {
+  if (/:\d+$/.test(host)) return host;
+  return `${host}:${port}`;
+}
+
+export function resolveRuntimeConnection(
+  env: RuntimeEnvironment,
+): RuntimeConnectionConfig {
+  const appId = value(env, "BUCKYOS_APP_ID") ??
+    value(env, "BUCKYOS_TEST_APP_ID") ?? "buckyos-agent";
+  const ownerUserId = value(env, "BUCKYOS_OWNER_USER_ID") ?? "devtest";
+  const sessionToken = value(env, "BUCKYOS_APPCLIENT_SESSION_TOKEN");
+
+  if (sessionToken) {
+    const gatewayHost = value(env, "BUCKYOS_HOST_GATEWAY") ??
+      "host.docker.internal";
+    const gatewayPort = value(env, "BUCKYOS_NODE_GATEWAY_PORT") ?? "3180";
+    return {
+      appId,
+      ownerUserId,
+      zoneHost: hostWithPort(gatewayHost, gatewayPort),
+      defaultProtocol: "http://",
+      sessionToken,
+      usesInjectedSession: true,
+    };
+  }
+
+  return {
+    appId,
+    ownerUserId,
+    zoneHost: value(env, "BUCKYOS_ZONE_HOST") ??
+      value(env, "BUCKYOS_TEST_ZONE_HOST") ?? "test.buckyos.io",
+    defaultProtocol: "https://",
+    usesInjectedSession: false,
+  };
+}

--- a/src/tools/buckyos-agent/lib/runtime_config_test.ts
+++ b/src/tools/buckyos-agent/lib/runtime_config_test.ts
@@ -1,0 +1,55 @@
+import { resolveRuntimeConnection } from "./runtime_config.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+Deno.test("injected AppClient session uses the internal node gateway", () => {
+  assertEquals(
+    resolveRuntimeConnection({
+      BUCKYOS_APP_ID: "jarvis",
+      BUCKYOS_OWNER_USER_ID: "alice",
+      BUCKYOS_APPCLIENT_SESSION_TOKEN: "session-token",
+      BUCKYOS_HOST_GATEWAY: "172.17.0.1",
+    }),
+    {
+      appId: "jarvis",
+      ownerUserId: "alice",
+      zoneHost: "172.17.0.1:3180",
+      defaultProtocol: "http://",
+      sessionToken: "session-token",
+      usesInjectedSession: true,
+    },
+  );
+});
+
+Deno.test(
+  "injected AppClient session does not duplicate an explicit gateway port",
+  () => {
+    const config = resolveRuntimeConnection({
+      BUCKYOS_APPCLIENT_SESSION_TOKEN: "session-token",
+      BUCKYOS_HOST_GATEWAY: "host.docker.internal:43180",
+    });
+    assertEquals(config.zoneHost, "host.docker.internal:43180");
+  },
+);
+
+Deno.test("standalone mode keeps the external zone and local signing flow", () => {
+  assertEquals(
+    resolveRuntimeConnection({
+      BUCKYOS_TEST_APP_ID: "local-tool",
+      BUCKYOS_TEST_ZONE_HOST: "test.example.com",
+    }),
+    {
+      appId: "local-tool",
+      ownerUserId: "devtest",
+      zoneHost: "test.example.com",
+      defaultProtocol: "https://",
+      usesInjectedSession: false,
+    },
+  );
+});

--- a/src/tools/buckyos-agent/readme.md
+++ b/src/tools/buckyos-agent/readme.md
@@ -69,6 +69,25 @@ ln -s aicc-tool gen_image
 gen_image "prompt" out.png
 ```
 
+AIOS 镜像中的只读安装目录是 `/opt/buckyos/bin/opendan/buckyos-agent/`。安装态
+`deno.json` 已指向镜像内 vendored SDK，因此可以直接运行 task：
+
+```bash
+cd /opt/buckyos/bin/opendan/buckyos-agent
+deno task gen_image --help
+```
+
+Agent 组合新工具时，可以读取该目录下的 `commands/*.ts` 和 `lib/*.ts`，但应把派生
+脚本写入 Agent 或当前 Session 自己的 `tools/` 目录，不要修改只读安装副本。运行派生
+脚本时显式复用安装态配置：
+
+```bash
+deno run --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
+  --allow-net --allow-read --allow-write --allow-env \
+  --unsafely-ignore-certificate-errors \
+  ./tools/my-aicc-tool.ts
+```
+
 ### 命令清单
 
 `gen_image` / `edit_image` / `inpaint_image` / `upscale_image` / `remove_bg`
@@ -103,6 +122,7 @@ CLI 始终将 `AgentToolResult` JSON 写到 stdout（与 `src/frame/agent_tool` 
 - `BUCKYOS_APPCLIENT_SESSION_TOKEN`：OpenDAN 注入的 AppClient session token；设置后启用容器内访问方式
 - `BUCKYOS_HOST_GATEWAY`：容器访问宿主机的地址（默认 `host.docker.internal`）
 - `BUCKYOS_NODE_GATEWAY_PORT`：NodeGateway 端口（默认 `3180`）
+- `BUCKYOS_AICC_TOOL_ROOT`：仅供 AIOS launcher 调试覆盖安装目录（默认 `/opt/buckyos/bin/opendan/buckyos-agent`）
 - `BUCKYOS_OWNER_USER_ID`：当前 Zone owner 用户 ID（默认 `devtest`）
 - `BUCKYOS_ZONE_HOST`（默认 `test.buckyos.io`，兼容 `BUCKYOS_TEST_ZONE_HOST`）
 - `BUCKYOS_APP_CLIENT_DIR` / `BUCKYOS_TEST_APP_CLIENT_DIR`：额外私钥搜索目录

--- a/src/tools/buckyos-agent/readme.md
+++ b/src/tools/buckyos-agent/readme.md
@@ -97,9 +97,13 @@ CLI 始终将 `AgentToolResult` JSON 写到 stdout（与 `src/frame/agent_tool` 
 
 ### 环境变量
 
-继承 `test/aicc_test` 的 BuckyOS 接入方式，所以本地需要私钥（默认搜索路径 `~/.buckyos`、`/opt/buckyos/etc` 等）。
+在 OpenDAN 中，工具使用运行时注入的受限 AppClient session token，并通过宿主机 NodeGateway 访问系统服务。本地独立运行时仍需私钥（默认搜索路径 `~/.buckyos`、`/opt/buckyos/etc` 等）。
 
 - `BUCKYOS_APP_ID`（默认 `buckyos-agent`，兼容 `BUCKYOS_TEST_APP_ID`）
+- `BUCKYOS_APPCLIENT_SESSION_TOKEN`：OpenDAN 注入的 AppClient session token；设置后启用容器内访问方式
+- `BUCKYOS_HOST_GATEWAY`：容器访问宿主机的地址（默认 `host.docker.internal`）
+- `BUCKYOS_NODE_GATEWAY_PORT`：NodeGateway 端口（默认 `3180`）
+- `BUCKYOS_OWNER_USER_ID`：当前 Zone owner 用户 ID（默认 `devtest`）
 - `BUCKYOS_ZONE_HOST`（默认 `test.buckyos.io`，兼容 `BUCKYOS_TEST_ZONE_HOST`）
 - `BUCKYOS_APP_CLIENT_DIR` / `BUCKYOS_TEST_APP_CLIENT_DIR`：额外私钥搜索目录
 - `AICC_DEFAULT_PROFILE`：`balanced|cheap|fast|quality`（默认 `balanced`）


### PR DESCRIPTION
## 概要

本 PR 合并修复 Jarvis 图片编辑链路中连续暴露的三个问题：图像 CLI 未进入运行镜像、容器内 CLI 错误连接外部 Zone，以及 `/clean` 后显式 `session_id` 继续恢复旧会话。

## 异常现象

### 1. Jarvis 无法发现或选择 `edit_image`

仓库已经实现 `edit_image`、`gen_image`、`inpaint_image` 等 AICC 图像 CLI，但 AIOS 构建产物没有安装对应源码、启动器和依赖缓存。Jarvis 运行环境中无法找到这些命令，只能临时尝试 SVG、ImageMagick 或 Python 合成，最终没有调用 AICC `image.img2img`。

### 2. 工具可见后仍无法连接 AICC

将 CLI 暴露到 PATH 后，`edit_image` 在容器内返回：

```text
RPC call failed: fetch failed
method: image.img2img
```

同期 AICC 日志没有收到请求，说明失败发生在客户端连接阶段。

### 3. `/clean` 返回成功，但后续消息仍进入旧会话

Telegram/msg-center 后续消息携带旧的显式 `session_id`。OpenDAN 普通消息路由优先采用该字段，绕过 `/clean` 新建的 tunnel→UI session 绑定，导致旧 snapshot 和旧 system prompt 被继续恢复，新建的 `ui-*` 会话成为孤立会话。

## 原因

- AIOS 镜像只交付 OpenDAN/Rust Agent Tool，没有交付 `src/tools/buckyos-agent` 图像 CLI。
- `buckyos-agent` CLI 固定采用 `RuntimeType.AppClient` 和外部 Zone HTTPS 地址，没有识别 OpenDAN 注入的受限 session token，也没有通过宿主机 NodeGateway 访问 AICC。
- UI 消息路由没有在 tunnel 已有有效绑定时覆盖隧道传入的旧显式 `session_id`。
- Jarvis 的 chat/plan/do 提示中缺少明确的 AICC 图像 CLI 使用规则，模型即使能看到 shell，也不一定优先选择 `edit_image`。

## 解决方案

### AIOS 图像 CLI 交付

- 在 AIOS 构建中安装并缓存 `buckyos-agent` 图像工具。
- 在运行镜像中提供稳定的 `aicc-tool` 启动器和各图像命令入口。
- 增加镜像构建期 smoke check，验证命令入口和帮助信息可用。
- 补充 Jarvis chat/plan/do 的 AICC Image CLI 指引，要求图片编辑优先使用 `edit_image`，成功后按附件格式返回结果。

### 容器内 AICC 路由

- 将运行时连接模式提取为可测试配置。
- 检测到 `BUCKYOS_APPCLIENT_SESSION_TOKEN` 时，使用注入的受限 token。
- 通过 `http://<BUCKYOS_HOST_GATEWAY>:3180` 访问 NodeGateway，不再错误绕行外部 Zone。
- 使用 `BUCKYOS_OWNER_USER_ID`，同时保留本地独立运行时的 HTTPS 和私钥认证流程。
- 增加内部网关、显式端口及本地模式测试。

### `/clean` 会话路由

- 对 UI 隧道消息统一解析 tunnel 绑定。
- 当 tunnel 已绑定有效 UI session 时，不再让旧的显式 `session_id` 覆盖该绑定。
- 保留无 tunnel 绑定场景下的显式 session 行为。
- 增加显式 `session_id`、绑定切换和绑定缺失的回归覆盖。

## 验证结果

实机日志已确认：

- `/clean` 后新消息进入新建的 `ui-*` 会话。
- 新 UI 会话的最终 prompt 包含 AICC Image CLI 指引。
- Jarvis 能发现并直接执行 `/usr/local/bin/edit_image`。
- AICC 收到 `method=image.img2img`，路由到图像模型并成功生成 PNG。

图片附件跨容器投递属于 #536，token 过期/刷新恢复属于 #516，均不在本 PR 的三项修复范围内。

## 关联 Issue

Closes #537
Closes #540
Closes #541