### PR TITLE
修正 beta 2.2 AICC 旧 complete 接口示例

### DIFF
--- a/doc/aicc/AICC.md
+++ b/doc/aicc/AICC.md
@@ -22,7 +22,7 @@
 > * AICC **不重新设计**系统已有的：RPC 框架（krpc）、任务生命周期管理（TaskMgr）、事件/日志队列（MsgQueue）。
 > * AICC 只需要：在长任务场景下**生成/关联 task_id**，并将进度与输出写入系统既有的任务事件通道（具体格式/存储/订阅语义以系统组件为准）。
 
-> **breaking change 基线（2026-05-30）**：AICC 对外接口已拆成控制面 / 数据面 / Helper 三层 —— `route.resolve`（逻辑模型名 → 确定精确模型 + provider options + trace）、typed inference（`chat.completions.create` / `images.generate`，只接受 `exact_model`、不隐式 fallback）、`helper.llm_chat` / `helper.text_to_image`（组合层）。本文中描述的 all-in-one `complete` 方法、`ModelSpec.alias` 等是 **legacy / helper 兼容层** 语义，最新协议以 `doc/aicc/aicc_api设计.md` 和 `doc/aicc/aicc_router.md` 为准。
+> **breaking change 基线（2026-05-30）**：AICC 对外接口已拆成控制面 / 数据面 / Helper 三层 —— `route.resolve`（逻辑模型名 → 确定精确模型 + provider options + trace）、typed inference（`chat.completions.create` / `images.generate`，只接受 `exact_model`、不隐式 fallback）、`helper.llm_chat` / `helper.text_to_image`（组合层）。公开 kRPC **没有 `complete` method**；源码中的 `AIComputeCenter::complete()` / `complete_with_method()` 只是内部执行函数，不可作为 RPC method 调用。最新协议以 `doc/aicc/aicc_api设计.md` 和 `doc/aicc/aicc_router.md` 为准。
 
 ---
 
@@ -172,47 +172,16 @@ pub struct ModelSpec {
 
 AICC 对外最核心的方法是控制面 `route.resolve` 与数据面 typed inference（`chat.completions.create` / `images.generate`），外加 `helper.*` 组合层；详见 `doc/aicc/aicc_api设计.md`。`cancel` 仍按下文语义工作。
 
-下面的 `complete` 请求/响应是 **legacy all-in-one** 形态（现以 `helper.llm_chat` 等 helper 方法承载），保留作为语义参考：
+公开调用必须使用以下入口之一：
 
-* `complete`：发起一次 AI 计算（短任务直接返回结果；长任务返回 task_id）
-* `cancel`：best-effort 取消指定 task（是否可取消由系统任务机制与 provider 能力决定）
+* 普通 LLM / 图片调用：`helper.llm_chat` / `helper.text_to_image`
+* 显式两阶段调用：`route.resolve` → `chat.completions.create` / `images.generate`
+* legacy all-in-one：`llm.chat` / `image.txt2img` 等具体能力 method
+* 取消任务：`cancel`
 
-### 4.1 complete 请求/响应（legacy 语义）
+### 4.1 请求/响应
 
-```rust
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CompleteRequest {
-    pub capability: Capability,
-    pub model: ModelSpec,
-    pub requirements: Requirements,
-    pub payload: AiPayload,
-
-    /// 业务侧可传；AICC 默认不做去重，仅可透传给 provider（可选）
-    pub idempotency_key: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CompleteResponse {
-    /// AICC 侧生成或关联的 compute task id
-    pub task_id: String,
-
-    /// 短任务：Succeeded + result != None
-    /// 长任务：Running + result == None
-    pub status: CompleteStatus,
-    pub result: Option<AiResponseSummary>,
-
-    /// 可选：事件通道引用（opaque string）
-    /// 由系统任务/事件组件定义其格式；AICC 仅透传/生成
-    pub event_ref: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum CompleteStatus {
-    Succeeded,
-    Running,
-    Failed, // 启动阶段失败（路由失败/参数不合法/资源不可用等）
-}
-```
+请求与响应结构以 `doc/aicc/aicc_api设计.md` 和 `doc/aicc/maintenance/krpc_aicc_calling_guide.md` 为准。不要发送 `method: "complete"`；该名称只存在于内部执行链路和历史资料中。
 
 **要点**：
 
@@ -262,18 +231,21 @@ pub struct ProviderInstance {
 ```rust
 pub enum ProviderStartResult {
     /// 短任务：直接完成
-    Immediate(AiResponseSummary),
+    Immediate(AiResponse),
 
     /// 长任务：已开始/已提交（后续通过系统任务事件通道输出）
     Started,
+
+    /// 请求已进入内部队列
+    Queued { position: usize },
 }
 
 #[async_trait::async_trait]
 pub trait Provider: Send + Sync {
-    fn instance(&self) -> &ProviderInstance;
+    fn inventory(&self) -> ProviderInventory;
 
     /// 估算成本（供 Router 打分 / 预算/限额策略）
-    fn estimate_cost(&self, req: &CompleteRequest, provider_model: &str) -> CostEstimate;
+    fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput;
 
     /// 核心：启动执行，由 provider 自行判定长/短任务并返回 Started/Immediate
     async fn start(
@@ -387,53 +359,9 @@ pub struct RouteDecision {
 
 ---
 
-## 7. 核心执行流程（AICC 视角伪代码）
+## 7. 核心执行流程（AICC 视角）
 
-下面伪代码刻意避免展开 TaskMgr/MsgQueue 的内部语义，只保留 AICC 的决策与调用边界：
-
-```rust
-pub async fn complete(ctx: InvokeCtx, req: CompleteRequest, state: AppState) -> CompleteResponse {
-    // 1) 轻校验（字段存在性、base64 限制、url 语法等）
-    validate_req(&req)?;
-
-    // 2) 生成/关联 task_id（长短任务都可统一生成，便于观测与追踪）
-    let task_id = gen_task_id();
-
-    // 3) 路由：快照 + 过滤 + 打分 + 得到 decision
-    let snap = state.registry.snapshot(req.capability.clone());
-    let decision = state.router.route(&ctx.tenant_id, &req, &snap, &state.route_cfg, &state.model_catalog)?;
-
-    // 4) 解析资源引用（不在此定义 cyfs 权限细节）
-    let resolved = state.resource_resolver.resolve(&ctx, &req).await?;
-
-    // 5) 构造任务事件 sink（对接系统既有任务事件通道；不在 AICC 定义其细节）
-    let sink = state.task_event_sink_factory.build(&ctx, &task_id);
-
-    // 6) 启动 provider（启动失败才尝试 fallback）
-    let result = start_with_fallback(&ctx, &req, &resolved, &decision, &sink, &state).await;
-
-    match result {
-        Ok(ProviderStartResult::Immediate(r)) => CompleteResponse {
-            task_id,
-            status: CompleteStatus::Succeeded,
-            result: Some(r),
-            event_ref: sink.event_ref(), // 可选
-        },
-        Ok(ProviderStartResult::Started) => CompleteResponse {
-            task_id,
-            status: CompleteStatus::Running,
-            result: None,
-            event_ref: sink.event_ref(), // 可选
-        },
-        Err(_) => CompleteResponse {
-            task_id,
-            status: CompleteStatus::Failed,
-            result: None,
-            event_ref: sink.event_ref(), // 可选
-        }
-    }
-}
-```
+公开 kRPC method 由 `AiccServerHandler::handle_rpc_call` 分发；能力请求进入 `AIComputeCenter::complete_with_method()` 内部执行链路。内部函数名不是公开 method 名，调用方不得据此构造 RPC 请求。
 
 ---
 

--- a/doc/aicc/aicc_api设计.md
+++ b/doc/aicc/aicc_api设计.md
@@ -251,9 +251,23 @@ Response：
 {
   "method": "helper.llm_chat",
   "params": {
-    "model": "llm.plan",
-    "requirements": { "tool_call": true },
-    "messages": [{ "role": "user", "content": [{ "type": "text", "text": "你好" }] }]
+    "capability": "llm",
+    "model": { "alias": "llm.plan" },
+    "requirements": {
+      "tool_call": true,
+      "must_features": [],
+      "max_latency_ms": null,
+      "max_cost_usd": null,
+      "resp_format": "text",
+      "extra": null
+    },
+    "payload": {
+      "input_json": {
+        "messages": [{ "role": "user", "content": [{ "type": "text", "text": "你好" }] }]
+      },
+      "resources": [],
+      "options": {}
+    }
   }
 }
 ```

--- a/doc/aicc/aicc_provider修改.md
+++ b/doc/aicc/aicc_provider修改.md
@@ -1,5 +1,7 @@
 # AICC Provider 修改需求整理
 
+> 本文是 provider 迁移阶段的设计记录，不是公开 kRPC 调用说明。公开接口没有 `complete` method；调用方式以 `aicc_api设计.md` 和 `maintenance/krpc_aicc_calling_guide.md` 为准。
+
 阶段：阶段 2，provider 修改需求整理，review 后再改。  
 范围：只整理 provider 接入层、registry 注册方式、成本估算接口的修改点；本文件不要求直接改代码。
 
@@ -59,8 +61,8 @@
 
 ```rust
 pub trait Provider: Send + Sync {
-    fn instance(&self) -> &ProviderInstance;
-    fn estimate_cost(&self, req: &CompleteRequest, provider_model: &str) -> CostEstimate;
+    fn inventory(&self) -> ProviderInventory;
+    fn estimate_cost(&self, input: &CostEstimateInput) -> CostEstimateOutput;
     async fn start(...);
     async fn cancel(...);
 }
@@ -202,7 +204,7 @@ pub struct ProviderInstance {
 - `AIComputeCenter` 直接持有新版 `ModelRegistry`。
 - 旧 `ModelCatalog` 从运行路径移除，不再生成 legacy alias。
 - provider settings 中的 `alias_map`、`default_model` 如果还需要表达默认模型，应迁移为 global `SessionConfig` 的 logical tree/items，而不是 provider 注册副作用。
-- `CompleteRequest.model.alias` 这类旧字段在本分支可直接迁移为新版 request model 字段；测试同步改，不做兼容解析。
+- `AiMethodRequest.model.alias` 这类 legacy all-in-one 字段在本分支可直接迁移为新版 request model 字段；测试同步改，不做兼容解析。
 
 ### P0. OpenAI 内部 clear 移到 apply_provider_settings 统一管理
 

--- a/doc/aicc/maintenance/krpc_aicc_calling_guide.md
+++ b/doc/aicc/maintenance/krpc_aicc_calling_guide.md
@@ -117,11 +117,25 @@ legacy all-in-one method（兼容保留，不再使用 `complete`）：
 {
   "method": "helper.llm_chat",
   "params": {
-    "model": "llm.plan",
-    "requirements": { "tool_call": true },
-    "messages": [
-      { "role": "user", "content": [{ "type": "text", "text": "请给我写一段发布说明" }] }
-    ]
+    "capability": "llm",
+    "model": { "alias": "llm.plan" },
+    "requirements": {
+      "tool_call": true,
+      "must_features": [],
+      "max_latency_ms": null,
+      "max_cost_usd": null,
+      "resp_format": "text",
+      "extra": null
+    },
+    "payload": {
+      "input_json": {
+        "messages": [
+          { "role": "user", "content": [{ "type": "text", "text": "请给我写一段发布说明" }] }
+        ]
+      },
+      "resources": [],
+      "options": {}
+    }
   },
   "sys": [1001, "<session_token>", "trace-aicc-helper"]
 }

--- a/doc/task_mgr/task_mgr.md
+++ b/doc/task_mgr/task_mgr.md
@@ -454,7 +454,7 @@ workflow/run
     "run_id": "run-...",
     "node_id": "scan",
     "attempt": 2,
-    "executor": "service::aicc.complete",
+    "executor": "service::aicc.llm.chat",
     "prompt": "请检查扫描结果",
     "output_schema": {},
     "subject": {},

--- a/doc/workflow/executor list.md
+++ b/doc/workflow/executor list.md
@@ -50,7 +50,7 @@ FunctionObject / ThunkObject / Node Daemon Runner 是后续阶段的执行基础
 
 `executor` 字段里有两种不同语义：
 
-- **实际 executor 定义**：用 `namespace::name` 表达，例如 `service::aicc.complete`、`http::file-classifier.classify`。这类名字已经能直接定位到一个 adapter 和调用协议。
+- **实际 executor 定义**：用 `namespace::name` 表达，例如 `service::aicc.llm.chat`、`http::file-classifier.classify`。这类名字已经能直接定位到一个 adapter 和调用协议。
 - **语义链接**：用路径表达，例如 `/agent/mia`、`/skill/fs-scanner`、`/tool/image-normalizer`。它们不是最终 executor 定义，而是一个可解析的语义入口。
 
 语义链接必须先通过 executor registry 展开为实际 executor 定义，例如：
@@ -78,7 +78,7 @@ FunctionObject / ThunkObject / Node Daemon Runner 是后续阶段的执行基础
 
 BuckyOS 的标准服务指系统内置、有稳定 RPC schema、整个 Zone 内访问语义一致的服务。命名为 `服务名.方法名`。典型例子：
 
-- `aicc.complete`
+- `aicc.llm.chat`
 - `msg_center.notify_user`
 - `system_config.get` / `system_config.set`
 - `task_manager.create_task`
@@ -86,7 +86,7 @@ BuckyOS 的标准服务指系统内置、有稳定 RPC schema、整个 Zone 内�
 
 ### 一期执行方式
 
-- DSL：`executor: "service::aicc.complete"`
+- DSL：`executor: "service::aicc.llm.chat"`
 - Expr：`Apply`
 - 编排器：识别 `service::` 前缀，直接通过 buckyos-api RPC client 调用对应服务。
 - 输出：RPC response 作为该 Step 的输出回填。
@@ -106,7 +106,7 @@ BuckyOS 的标准服务指系统内置、有稳定 RPC schema、整个 Zone 内�
 🟢 **直执行通道已就位**。`WorkflowOrchestrator::with_executor_registry` 接入
 `ExecutorRegistry`，命中的 `service::` executor 直接由编排器同步调用 adapter，
 跳过 Thunk 投递；缓存与重试 / Human fallback 路径与原有 Thunk 路径行为一致。
-具体 service adapter（buckyos-api RPC 桥接、`aicc.complete` 等）仍待按服务接入。
+具体 service adapter（buckyos-api RPC 桥接、`aicc.llm.chat` 等）仍待按服务接入。
 
 ## 3. AppService / HTTP Executor @ workflow
 

--- a/doc/workflow/wokflow engine.md
+++ b/doc/workflow/wokflow engine.md
@@ -189,7 +189,7 @@ Workflow 的执行结构是一个**有向图（Workflow Graph）**，图中有�
 |------|------|------|
 | `id` | 是 | 节点唯一标识（与 ControlNode 共享命名空间，全局唯一） |
 | `name` | 是 | 人类可读名称 |
-| `executor` | 条件 | 执行者引用。实际 executor 定义使用 `namespace::name`（如 `service::aicc.complete` / `http::file-classifier.classify`）；语义链接使用路径形式（如 `/agent/mia` / `/skill/fs-scanner` / `/tool/image-normalizer`），运行前需通过 registry 展开到实际 executor 定义。`type` 为 `human_required` 时不需要 |
+| `executor` | 条件 | 执行者引用。实际 executor 定义使用 `namespace::name`（如 `service::aicc.llm.chat` / `http::file-classifier.classify`）；语义链接使用路径形式（如 `/agent/mia` / `/skill/fs-scanner` / `/tool/image-normalizer`），运行前需通过 registry 展开到实际 executor 定义。`type` 为 `human_required` 时不需要 |
 | `type` | 是 | 执行类型（见 3.3） |
 | `input` | 否 | 输入数据，可包含 Reference（见 3.6） |
 | `input_schema` | 否 | 输入的 JSON Schema 约束。当提供时，引擎在静态分析阶段校验上游 output_schema 与本 step input_schema 的类型兼容性 |
@@ -634,7 +634,7 @@ Expr Tree 是 DSL JSON 经过静态分析后生成的内部执行表示。它是
 pub struct FunId(pub [u8; 32]);
 
 /// DSL 中的 executor 引用。
-/// Actual 指向实际 executor 定义，如 service::aicc.complete / http::x.y / func::<objid>。
+/// Actual 指向实际 executor 定义，如 service::aicc.llm.chat / http::x.y / func::<objid>。
 /// SemanticPath 是可展开的语义链接，如 /agent/mia / /skill/fs-scanner。
 pub enum ExecutorRef {
     Actual(String),
@@ -1743,7 +1743,7 @@ POST /agent/task
 | **Reference** | 节点间数据传递的只读指针（`${node_id.output.field}`） |
 | **Guard** | 附加在 Node 或 Workflow 上的约束条件 |
 | **Amendment** | Agent 在运行时提交的计划修改请求 |
-| **Executor 定义** | DSL 中 `namespace::name` 形式的实际执行定义，如 `service::aicc.complete`、`http::x.y`、`func::<objid>` |
+| **Executor 定义** | DSL 中 `namespace::name` 形式的实际执行定义，如 `service::aicc.llm.chat`、`http::x.y`、`func::<objid>` |
 | **Executor 语义链接** | DSL 中路径形式的能力引用，如 `/agent/mia`、`/skill/fs-scanner`、`/tool/image-normalizer`，运行前需通过 registry 展开为实际 executor 定义 |
 | **Executor Runtime** | 物理节点上实际执行 ThunkObject 的运行时。接收 ThunkObject，返回 result |
 | **FunId** | FunctionObject 的内容寻址标识。相同 FunctionObject 永远产生相同 FunId |

--- a/doc/workflow/workflow service.md
+++ b/doc/workflow/workflow service.md
@@ -437,7 +437,7 @@ Workflow schedule 是 trigger 真相源，不是业务 executor。它只负责�
 |----|---------|
 | Definition CRUD + 静态分析 | 全量交付 |
 | Run 生命周期 + Step 级 human action | 全量交付 |
-| Executor Registry 接入 `service::` adapter | 全量交付（首批包括 `aicc.complete`、`msg_center.notify_user`、`system_config.*`、`task_manager.create_task`、`kb.*`） |
+| Executor Registry 接入 `service::` adapter | 全量交付（首批包括 `aicc.llm.chat`、`msg_center.notify_user`、`system_config.*`、`task_manager.create_task`、`kb.*`） |
 | `http::` / `appservice::` adapter | 框架就位 + 至少一个示例 endpoint 接入 |
 | `/agent/` / `/skill/` / `/tool/` | 通过 executor registry 展开到 P0 实际 executor，不要求展开到 FunctionObject |
 | `human_confirm` / `human_required` | 全量交付：写到 Step task 的 TaskData，由 TaskMgr UI 渲染交互、Msg Center 经 task_manager 推 URL；workflow 仅负责解释 TaskData 中的 `human_action` |

--- a/product/workflow/BuckyOS Workflow WebUI 产品需求.md
+++ b/product/workflow/BuckyOS Workflow WebUI 产品需求.md
@@ -90,7 +90,7 @@ Workflow WebUI 是 BuckyOS 中面向高级用户的 Workflow Definition 管理�
 | TaskNode（Step） | Workflow Graph 中的执行节点，对应一个 Step。具有 executor、input、output、type（`autonomous` / `human_confirm` / `human_required`）、`output_mode`、`idempotent`、`skippable`、`guards` 等字段。 | DSL §3.2，Expr Tree `Apply` / `Await` |
 | ControlNode | Workflow Graph 中的流转控制节点：`branch`（穷举枚举分支）、`parallel`（并行 + join 策略）、`for_each`（受 `output_mode` 约束的有界迭代）。 | DSL §3.4，Expr Tree `Match` / `Par` / `Map` |
 | Edge | Workflow Graph 中的有向连接。`branch.paths` / `parallel.branches` 是隐式边，不重复声明。 | DSL §3.5 |
-| Executor Reference | 节点的 executor 字段。实际定义形如 `service::aicc.complete` / `http::x.y` / `appservice::z` / `operator::json.pick` / `func::<objid>`；语义链接形如 `/agent/mia` / `/skill/fs-scanner` / `/tool/...`，运行前由 registry 展开。 | DSL §3.2，Service §6.1 |
+| Executor Reference | 节点的 executor 字段。实际定义形如 `service::aicc.llm.chat` / `http::x.y` / `appservice::z` / `operator::json.pick` / `func::<objid>`；语义链接形如 `/agent/mia` / `/skill/fs-scanner` / `/tool/...`，运行前由 registry 展开。 | DSL §3.2，Service §6.1 |
 | Output Mode | `single` / `finite_seekable` / `finite_sequential`，决定下游 for_each 是否可并行/重试粒度。 | DSL §3.2.1 |
 | Guards | 节点或 Workflow 级约束：`budget`（max_tokens / max_cost_usdb / max_duration）、`permissions`、`retry`（max_attempts / backoff / fallback）。 | DSL §3.7 |
 | Human Action | 用户对 Step / Run task 写入的 TaskData，含 `human_action.kind`：`approve` / `modify` / `reject` / `retry` / `skip` / `abort` / `rollback`。**入口在 TaskMgr UI，不在 Workflow WebUI。** | Service §3.3 |

--- a/src/frame/aicc/test_llm.py
+++ b/src/frame/aicc/test_llm.py
@@ -65,66 +65,74 @@ def call_rpc(method: str, params: dict, seq: int = 1) -> dict:
     return rpc_response["result"]
 
 
-def complete_once(prompt: str, must_features: list[str] | None = None, options: dict | None = None) -> dict:
+def llm_chat_once(prompt: str, must_features: list[str] | None = None, options: dict | None = None) -> dict:
+    features = must_features or []
     params = {
-        "capability": "llm_router",
+        "capability": "llm",
         "model": {
             "alias": AICC_MODEL_ALIAS,
         },
         "requirements": {
-            "must_features": must_features or [],
+            "must_features": features,
+            "max_latency_ms": None,
+            "max_cost_usd": None,
+            "resp_format": "json" if "json_output" in features else "text",
+            "extra": None,
         },
         "payload": {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": prompt,
-                }
-            ],
-            "options": options or {"temperature": 0.2, "max_tokens": 96},
+            "input_json": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": prompt}],
+                    }
+                ],
+            },
+            "resources": [],
+            "options": options or {"temperature": 0.2, "max_output_tokens": 96},
         },
         "idempotency_key": f"test-{uuid.uuid4().hex}",
     }
-    return call_rpc("complete", params, seq=int(time.time()))
+    return call_rpc("helper.llm_chat", params, seq=int(time.time()))
+
+
+def response_text(result: dict) -> str | None:
+    response = result.get("result") or {}
+    message = response.get("message") or {}
+    content = message.get("content") or []
+    texts = [block.get("text", "") for block in content if block.get("type") == "text"]
+    text = "\n".join(part for part in texts if part).strip()
+    return text or None
 
 
 class TestAiccOpenAIProvider(unittest.TestCase):
-    def test_complete_basic(self) -> None:
-        result = complete_once("Reply with one short sentence: AICC OpenAI provider is working.")
+    def test_llm_chat_basic(self) -> None:
+        result = llm_chat_once("Reply with one short sentence: AICC OpenAI provider is working.")
 
         self.assertIn("task_id", result, msg=f"missing task_id in result: {result}")
         self.assertIn("status", result, msg=f"missing status in result: {result}")
         self.assertIn(result["status"], ["succeeded", "running"], msg=f"unexpected status: {result}")
 
         if result["status"] == "succeeded":
-            self.assertIsInstance(result.get("result"), dict, msg=f"invalid result payload: {result}")
-            summary = result.get("result") or {}
-            has_text = isinstance(summary.get("text"), str) and len(summary.get("text", "").strip()) > 0
-            has_json = summary.get("json") is not None
-            self.assertTrue(
-                has_text or has_json,
-                msg=f"succeeded response should include text/json summary: {summary}",
-            )
+            self.assertIsNotNone(response_text(result), msg=f"missing response text: {result}")
 
-    def test_complete_json_output(self) -> None:
-        result = complete_once(
+    def test_llm_chat_json_output(self) -> None:
+        result = llm_chat_once(
             prompt='Return JSON only with shape {"ok": true, "source": "aicc"}.',
             must_features=["json_output"],
             options={
                 "temperature": 0,
-                "max_tokens": 80,
+                "max_output_tokens": 80,
                 "response_format": {"type": "json_object"},
             },
         )
 
         self.assertIn(result["status"], ["succeeded", "running"], msg=f"unexpected status: {result}")
         if result["status"] == "succeeded":
-            summary = result.get("result") or {}
-            parsed = summary.get("json")
-            if parsed is None and isinstance(summary.get("text"), str):
-                parsed = json.loads(summary["text"])
-
-            self.assertIsInstance(parsed, dict, msg=f"json_output should return JSON object: {summary}")
+            text = response_text(result)
+            self.assertIsNotNone(text, msg=f"json_output should return text: {result}")
+            parsed = json.loads(text)
+            self.assertIsInstance(parsed, dict, msg=f"json_output should return JSON object: {text}")
             self.assertIn("ok", parsed, msg=f"json result missing 'ok': {parsed}")
 
     def test_cancel_endpoint_reachable(self) -> None:
@@ -139,17 +147,15 @@ class TestAiccOpenAIProvider(unittest.TestCase):
         self.assertIsInstance(cancel_result["accepted"], bool)
 
     def test_input_and_print_output(self) -> None:
-        result = complete_once(
+        result = llm_chat_once(
             prompt=AICC_TEST_INPUT,
-            options={"temperature": 0.2, "max_tokens": 256},
+            options={"temperature": 0.2, "max_output_tokens": 256},
         )
 
         status = result.get("status")
         self.assertIn(status, ["succeeded", "running"], msg=f"unexpected status: {result}")
 
-        summary = result.get("result") or {}
-        output_text = summary.get("text")
-        output_json = summary.get("json")
+        output_text = response_text(result)
 
         print("\n=== AICC Manual Input Test ===")
         print(f"Input: {AICC_TEST_INPUT}")
@@ -157,9 +163,6 @@ class TestAiccOpenAIProvider(unittest.TestCase):
         if isinstance(output_text, str) and output_text.strip():
             print("Output(text):")
             print(output_text.strip())
-        elif output_json is not None:
-            print("Output(json):")
-            print(json.dumps(output_json, ensure_ascii=False, indent=2))
         else:
             print("Output: <none yet, task may still be running>")
 

--- a/src/frame/desktop/src/app/workflow/mock/store.ts
+++ b/src/frame/desktop/src/app/workflow/mock/store.ts
@@ -109,7 +109,7 @@ const kbImportPipeline: WorkflowDefinition = {
         executor: {
           raw: '/agent/aicc',
           resolvedNamespace: 'service',
-          resolvedTarget: 'service::aicc.complete',
+          resolvedTarget: 'service::aicc.llm.chat',
         },
         outputMode: 'single',
         idempotent: true,
@@ -347,7 +347,7 @@ const myImported: WorkflowDefinition = {
         executor: {
           raw: '/agent/normalize',
           resolvedNamespace: 'service',
-          resolvedTarget: 'service::aicc.complete',
+          resolvedTarget: 'service::aicc.llm.chat',
         },
         outputMode: 'single',
         idempotent: true,
@@ -454,7 +454,7 @@ const fileOrganizer: WorkflowDefinition = {
         executor: {
           raw: '/agent/aicc',
           resolvedNamespace: 'service',
-          resolvedTarget: 'service::aicc.complete',
+          resolvedTarget: 'service::aicc.llm.chat',
         },
         outputMode: 'single',
         idempotent: true,
@@ -682,7 +682,7 @@ const seedAmendments: AmendmentSummary[] = [
 
 const seedExecutors: ExecutorEntry[] = [
   {
-    id: 'service::aicc.complete',
+    id: 'service::aicc.llm.chat',
     namespace: 'service',
     description: 'AI completion via aicc service.',
     inputSummary: '{ prompt: string, model?: string }',

--- a/src/kernel/buckyos-api/src/workflow_types.rs
+++ b/src/kernel/buckyos-api/src/workflow_types.rs
@@ -76,7 +76,7 @@ pub enum JoinStrategy {
 /// DSL `executor` 字段的语义分类。
 ///
 /// - `Actual` 表示已经定位到具体执行入口的实际 executor 定义，使用 `namespace::name`
-///   的形式（例如 `service::aicc.complete`、`http::file-classifier.classify`、
+///   的形式（例如 `service::aicc.llm.chat`、`http::file-classifier.classify`、
 ///   `appservice::media-tools.extract_metadata`、`operator::json.pick`、
 ///   `func::<function_object_id>`）。这类引用可以直接交给对应的编排器侧 adapter
 ///   或调度器执行。

--- a/src/kernel/workflow/src/executor_adapter.rs
+++ b/src/kernel/workflow/src/executor_adapter.rs
@@ -152,7 +152,7 @@ mod tests {
     #[tokio::test]
     async fn namespace_adapter_matches_actual_only() {
         let adapter = make_adapter();
-        assert!(adapter.supports(&ExecutorRef::parse("service::aicc.complete").unwrap()));
+        assert!(adapter.supports(&ExecutorRef::parse("service::aicc.llm.chat").unwrap()));
         assert!(!adapter.supports(&ExecutorRef::parse("http::endpoint.x").unwrap()));
         assert!(!adapter.supports(&ExecutorRef::parse("/skill/fs-scanner").unwrap()));
     }
@@ -161,13 +161,13 @@ mod tests {
     async fn registry_returns_first_match() {
         let mut registry = ExecutorRegistry::new();
         registry.register(Arc::new(make_adapter()));
-        let exec = ExecutorRef::parse("service::aicc.complete").unwrap();
+        let exec = ExecutorRef::parse("service::aicc.llm.chat").unwrap();
         let adapter = registry.find(&exec).expect("should find adapter");
         let out = adapter
             .invoke(&exec, &serde_json::json!({"q": 1}))
             .await
             .unwrap();
-        assert_eq!(out["executor"], "service::aicc.complete");
+        assert_eq!(out["executor"], "service::aicc.llm.chat");
         assert_eq!(out["input"]["q"], 1);
     }
 }

--- a/src/kernel/workflow/src/orchestrator.rs
+++ b/src/kernel/workflow/src/orchestrator.rs
@@ -2977,7 +2977,7 @@ mod tests {
                 StepDefinition {
                     id: "fetch".to_string(),
                     name: "Fetch".to_string(),
-                    executor: Some("service::aicc.complete".to_string()),
+                    executor: Some("service::aicc.llm.chat".to_string()),
                     step_type: StepType::Autonomous,
                     input: Some(json!({"prompt": "hello"})),
                     input_schema: None,
@@ -3036,7 +3036,7 @@ mod tests {
                 let executor = executor.clone();
                 let input = input.clone();
                 Box::pin(async move {
-                    if executor.as_str() == "service::aicc.complete" {
+                    if executor.as_str() == "service::aicc.llm.chat" {
                         Ok(json!({ "answer": "ok", "echo": input }))
                     } else {
                         Ok(json!({ "delivered": true, "echo": input }))

--- a/src/kernel/workflow/src/types.rs
+++ b/src/kernel/workflow/src/types.rs
@@ -11,7 +11,7 @@ mod tests {
     #[test]
     fn parse_classifies_actual_namespaces() {
         for raw in [
-            "service::aicc.complete",
+            "service::aicc.llm.chat",
             "http::file-classifier.classify",
             "appservice::media-tools.extract_metadata",
             "operator::json.pick",


### PR DESCRIPTION
关联问题：#553

## 背景

beta 2.2 已移除公开的 AICC `complete` kRPC method，但仓库中仍有旧示例、Workflow 文档和 mock 使用该名称，容易导致开发者调用新版服务时收到 `Unknown method: complete`。

## 修改内容

- 将 Python AICC 示例改为调用 `helper.llm_chat`，并同步当前 `AiMethodRequest` 请求结构和响应解析。
- 在 AICC 文档中明确：`complete()` / `complete_with_method()` 是内部执行函数，不是公开 kRPC method。
- 修正 Helper 请求示例和调用指南。
- 将 Workflow 文档、产品文档、WebUI mock 和测试示例中的 `service::aicc.complete` 更新为已注册的 `service::aicc.llm.chat`。
- 清理公开资料中的旧 `CompleteRequest` / `CompleteResponse` 示例。

## 验证

- `cargo test -p workflow`：46 项通过。
- `cargo test -p buckyos-api aicc_client::tests`：6 项通过。
- Python AICC 示例请求结构与响应解析校验通过。
- `git diff --check` 通过。

未修改 AICC 内部执行函数及其日志名称，也未引入新依赖。
