### PR TITLE
fix(aicc): 对齐 Gemini 实际能力与驱动实现

### DIFF
--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -43,6 +43,7 @@ provider's complete mapping list.
   "origin_mappings": [],
   "models": [],
   "patterns": [],
+  "capability_overrides": [],
   "defaults": {},
   "variants": [],
   "signature": null
@@ -64,6 +65,11 @@ Fields:
   `driver` and `model` from the provider-native model id.
 - `models`: exact rules keyed by `id`.
 - `patterns`: wildcard rules keyed by `pattern`; `*` is the only wildcard.
+- `capability_overrides`: ordered capability-only patches selected by model
+  `pattern` and, optionally, `api_types`. All matching rules are applied after
+  the model's exact/pattern/default rule. Documents are applied from lower to
+  higher source priority, and rules within a document are applied in array
+  order, so later patches take precedence.
 - `defaults`: default rule when no exact or pattern rule matches.
 - `variants`: optional provider option variants. The resolver expands each
   matching base model into additional AICC exact models whose provider model id
@@ -95,7 +101,7 @@ Rules support these fields:
   `{provider_driver}`, and `{provider_model_id}` are expanded by the resolver.
   The first pair identifies the physical origin; the second pair identifies the
   current delivery channel.
-- `capabilities`: partial capability patch: `streaming`, `tool_call`, `json_schema`, `web_search`, `web_search_with_tool_call`, `vision`, `max_context_tokens`, `max_output_tokens`. `web_search_with_tool_call` is only needed when a model's support for combining provider-hosted search with custom function calling differs from its individual `web_search` and `tool_call` capabilities; when omitted it defaults to the conjunction of those individual capabilities.
+- `capabilities`: partial capability patch: `streaming`, `tool_call`, `json_schema`, `web_search`, `vision`, `max_context_tokens`, `max_output_tokens`, `unsupported_feature_combinations`. Each entry in `unsupported_feature_combinations` is a set of two or more otherwise-supported features that cannot be used in the same request, for example `[["tool_calling", "web_search"]]`. Supported feature names are `streaming`, `tool_calling`, `json_output`, `web_search`, and `vision`.
 - `pricing`: optional monetary data object. `currency` identifies the ISO 4217
   currency; `input_token`, `output_token`, and `cache_input_token` are optional
   per-token prices; `estimated_cost` is the default scheduler cost estimate.

--- a/doc/aicc/driver_metadata_schema.md
+++ b/doc/aicc/driver_metadata_schema.md
@@ -95,7 +95,7 @@ Rules support these fields:
   `{provider_driver}`, and `{provider_model_id}` are expanded by the resolver.
   The first pair identifies the physical origin; the second pair identifies the
   current delivery channel.
-- `capabilities`: partial capability patch: `streaming`, `tool_call`, `json_schema`, `web_search`, `vision`, `max_context_tokens`, `max_output_tokens`.
+- `capabilities`: partial capability patch: `streaming`, `tool_call`, `json_schema`, `web_search`, `web_search_with_tool_call`, `vision`, `max_context_tokens`, `max_output_tokens`. `web_search_with_tool_call` is only needed when a model's support for combining provider-hosted search with custom function calling differs from its individual `web_search` and `tool_call` capabilities; when omitted it defaults to the conjunction of those individual capabilities.
 - `pricing`: optional monetary data object. `currency` identifies the ISO 4217
   currency; `input_token`, `output_token`, and `cache_input_token` are optional
   per-token prices; `estimated_cost` is the default scheduler cost estimate.

--- a/src/frame/aicc/driver_metadata/gemini.json
+++ b/src/frame/aicc/driver_metadata/gemini.json
@@ -1,7 +1,7 @@
 {
   "format": "buckyos.aicc.provider-driver-metadata",
   "schema_version": 3,
-  "schema_revision": 0,
+  "schema_revision": 1,
   "provider_driver": "google-gemini",
   "revision_seq": 1,
   "required_features": [],
@@ -416,6 +416,15 @@
         "estimated_cost": 0.01
       },
       "estimated_latency_ms": 1400
+    }
+  ],
+  "capability_overrides": [
+    {
+      "pattern": "gemini-2.*",
+      "api_types": ["llm"],
+      "capabilities": {
+        "unsupported_feature_combinations": [["tool_calling", "web_search"]]
+      }
     }
   ],
   "defaults": {

--- a/src/frame/aicc/driver_metadata/gemini.json
+++ b/src/frame/aicc/driver_metadata/gemini.json
@@ -207,7 +207,7 @@
         "streaming": true,
         "tool_call": true,
         "json_schema": true,
-        "web_search": false,
+        "web_search": true,
         "vision": true,
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
@@ -247,7 +247,7 @@
         "streaming": true,
         "tool_call": true,
         "json_schema": true,
-        "web_search": false,
+        "web_search": true,
         "vision": true,
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192
@@ -367,7 +367,7 @@
         "streaming": true,
         "tool_call": true,
         "json_schema": true,
-        "web_search": false,
+        "web_search": true,
         "vision": true,
         "max_context_tokens": 1048576,
         "max_output_tokens": 8192

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -2968,6 +2968,7 @@ pub fn provider_model_metadata(
             web_search: features
                 .iter()
                 .any(|item| item == buckyos_api::features::WEB_SEARCH),
+            web_search_with_tool_call: None,
             vision: features
                 .iter()
                 .any(|item| item == buckyos_api::features::VISION),

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -2968,7 +2968,7 @@ pub fn provider_model_metadata(
             web_search: features
                 .iter()
                 .any(|item| item == buckyos_api::features::WEB_SEARCH),
-            web_search_with_tool_call: None,
+            unsupported_feature_combinations: vec![],
             vision: features
                 .iter()
                 .any(|item| item == buckyos_api::features::VISION),

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -42,6 +42,13 @@ const GEMINI_VIDEO_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const GEMINI_VIDEO_MAX_WAIT: Duration = Duration::from_secs(600);
 const GEMINI_MODELS_PAGE_SIZE: u32 = 1000;
 const GEMINI_MODELS_MAX_PAGES: usize = 10;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GeminiToolCallContext {
+    name: String,
+    provider_call_id: Option<String>,
+}
+
 const GEMINI_IMAGE_INPUT_ALLOWLIST: &[&str] = &[
     "candidate_count",
     "max_output_tokens",
@@ -919,14 +926,14 @@ impl GoogleGeminiProvider {
 
     fn build_contents(&self, req: &AiMethodRequest) -> Result<Vec<Value>, ProviderError> {
         let mut contents: Vec<Value> = vec![];
-        let mut tool_names = HashMap::new();
+        let mut tool_calls = HashMap::new();
 
         // 主路径:消费 typed `Vec<AiMessage>`,保留 ToolUse/ToolResult/Image
         // 等 block,转成 Gemini parts(functionCall / functionResponse /
         // inlineData / fileData / text)。
         if !req.payload.messages.is_empty() {
             for msg in req.payload.messages.iter() {
-                Self::lower_message_to_gemini(msg, &mut contents, &mut tool_names)?;
+                Self::lower_message_to_gemini(msg, &mut contents, &mut tool_calls)?;
             }
         }
 
@@ -992,33 +999,30 @@ impl GoogleGeminiProvider {
     fn lower_message_to_gemini(
         msg: &AiMessage,
         contents: &mut Vec<Value>,
-        tool_names: &mut HashMap<String, String>,
+        tool_calls: &mut HashMap<String, GeminiToolCallContext>,
     ) -> Result<(), ProviderError> {
         match msg.role {
             AiRole::Tool => {
                 let Some(AiContent::ToolResult {
                     call_id,
                     content,
-                    is_error,
+                    is_error: _,
                 }) = msg.content.first()
                 else {
                     return Ok(());
                 };
-                let mut response_obj = Map::new();
-                let response_text = Self::tool_result_text(content);
-                response_obj.insert("output".to_string(), Value::String(response_text));
-                if *is_error {
-                    response_obj.insert("error".to_string(), Value::Bool(true));
-                }
-                let name = tool_names
-                    .get(call_id)
-                    .cloned()
+                let context = tool_calls.get(call_id);
+                let name = context
+                    .map(|context| context.name.clone())
                     .unwrap_or_else(|| call_id.clone());
                 let mut function_response = Map::new();
                 function_response.insert("name".to_string(), Value::String(name));
-                function_response.insert("response".to_string(), Value::Object(response_obj));
-                if tool_names.contains_key(call_id) && !call_id.starts_with("gemini-no-id-") {
-                    function_response.insert("id".to_string(), Value::String(call_id.clone()));
+                function_response.insert("response".to_string(), Self::tool_result_value(content));
+                if let Some(provider_call_id) =
+                    context.and_then(|context| context.provider_call_id.as_ref())
+                {
+                    function_response
+                        .insert("id".to_string(), Value::String(provider_call_id.clone()));
                 }
                 let part = json!({ "functionResponse": function_response });
                 contents.push(json!({
@@ -1028,11 +1032,16 @@ impl GoogleGeminiProvider {
                 Ok(())
             }
             _ => {
+                if let Some(provider_content) = Self::gemini_provider_content(&msg.content) {
+                    Self::remember_provider_tool_calls(provider_content, tool_calls);
+                    contents.push(provider_content.clone());
+                    return Ok(());
+                }
                 let role = match msg.role {
                     AiRole::Assistant => "model",
                     _ => "user",
                 };
-                let parts = Self::lower_blocks_to_parts(&msg.content, tool_names)?;
+                let parts = Self::lower_blocks_to_parts(&msg.content, tool_calls)?;
                 if !parts.is_empty() {
                     contents.push(json!({
                         "role": role,
@@ -1046,7 +1055,7 @@ impl GoogleGeminiProvider {
 
     fn lower_blocks_to_parts(
         content: &[AiContent],
-        tool_names: &mut HashMap<String, String>,
+        tool_calls: &mut HashMap<String, GeminiToolCallContext>,
     ) -> Result<Vec<Value>, ProviderError> {
         let mut parts = Vec::with_capacity(content.len());
         for block in content {
@@ -1071,7 +1080,13 @@ impl GoogleGeminiProvider {
                     name,
                     args,
                 } => {
-                    tool_names.insert(call_id.clone(), name.clone());
+                    tool_calls.insert(
+                        call_id.clone(),
+                        GeminiToolCallContext {
+                            name: name.clone(),
+                            provider_call_id: Some(call_id.clone()),
+                        },
+                    );
                     let args_value = serde_json::to_value(args).unwrap_or_else(|_| json!({}));
                     parts.push(json!({
                         "functionCall": {
@@ -1093,34 +1108,7 @@ impl GoogleGeminiProvider {
                         parts.push(json!({ "text": text }));
                     }
                 }
-                AiContent::ProviderState { provider, value } => {
-                    if provider.eq_ignore_ascii_case("google")
-                        || provider.eq_ignore_ascii_case("gemini")
-                        || provider.eq_ignore_ascii_case("google-gemini")
-                    {
-                        let raw_function = value.get("functionCall").and_then(Value::as_object);
-                        let existing = raw_function.and_then(|raw| {
-                            let raw_id = raw.get("id").and_then(Value::as_str);
-                            let raw_name = raw.get("name").and_then(Value::as_str);
-                            parts.iter_mut().find(|part| {
-                                let Some(function) =
-                                    part.get("functionCall").and_then(Value::as_object)
-                                else {
-                                    return false;
-                                };
-                                raw_id.is_some()
-                                    && function.get("id").and_then(Value::as_str) == raw_id
-                                    || raw_id.is_none()
-                                        && function.get("name").and_then(Value::as_str) == raw_name
-                            })
-                        });
-                        if let Some(existing) = existing {
-                            *existing = value.clone();
-                        } else {
-                            parts.push(value.clone());
-                        }
-                    }
-                }
+                AiContent::ProviderState { .. } => {}
                 AiContent::ToolResult { .. } => {
                     // Tool role is handled by the caller; ignore defensively.
                 }
@@ -1204,12 +1192,13 @@ impl GoogleGeminiProvider {
                     .filter_map(|(index, part)| {
                         let function = part.get("functionCall")?.as_object()?;
                         let name = function.get("name")?.as_str()?.to_string();
-                        let call_id = function
+                        let provider_call_id = function
                             .get("id")
                             .and_then(Value::as_str)
                             .filter(|value| !value.trim().is_empty())
-                            .map(str::to_string)
-                            .unwrap_or_else(|| format!("gemini-no-id-{}-{}", index, name));
+                            .map(str::to_string);
+                        let call_id =
+                            Self::internal_tool_call_id(index, &name, provider_call_id.as_deref());
                         let args = function
                             .get("args")
                             .cloned()
@@ -1226,25 +1215,63 @@ impl GoogleGeminiProvider {
             .unwrap_or_default()
     }
 
-    fn extract_provider_state(body: &Value) -> Vec<AiContent> {
-        body.pointer("/candidates/0/content/parts")
-            .and_then(Value::as_array)
-            .map(|parts| {
-                parts
-                    .iter()
-                    .filter(|part| {
-                        part.get("thoughtSignature").is_some()
-                            || part.get("toolCall").is_some()
-                            || part.get("toolResponse").is_some()
-                    })
-                    .cloned()
-                    .map(|value| AiContent::ProviderState {
-                        provider: "google-gemini".to_string(),
-                        value,
-                    })
-                    .collect()
+    fn extract_provider_state(body: &Value) -> Option<AiContent> {
+        body.pointer("/candidates/0/content")
+            .cloned()
+            .map(|value| AiContent::ProviderState {
+                provider: "google-gemini".to_string(),
+                value,
             })
-            .unwrap_or_default()
+    }
+
+    fn internal_tool_call_id(index: usize, name: &str, provider_call_id: Option<&str>) -> String {
+        provider_call_id
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("gemini-no-id-{}-{}", index, name))
+    }
+
+    fn gemini_provider_content(content: &[AiContent]) -> Option<&Value> {
+        content.iter().find_map(|block| match block {
+            AiContent::ProviderState { provider, value }
+                if (provider.eq_ignore_ascii_case("google")
+                    || provider.eq_ignore_ascii_case("gemini")
+                    || provider.eq_ignore_ascii_case("google-gemini"))
+                    && value.get("parts").and_then(Value::as_array).is_some() =>
+            {
+                Some(value)
+            }
+            _ => None,
+        })
+    }
+
+    fn remember_provider_tool_calls(
+        provider_content: &Value,
+        tool_calls: &mut HashMap<String, GeminiToolCallContext>,
+    ) {
+        let Some(parts) = provider_content.get("parts").and_then(Value::as_array) else {
+            return;
+        };
+        for (index, part) in parts.iter().enumerate() {
+            let Some(function) = part.get("functionCall").and_then(Value::as_object) else {
+                continue;
+            };
+            let Some(name) = function.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let provider_call_id = function
+                .get("id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string);
+            let call_id = Self::internal_tool_call_id(index, name, provider_call_id.as_deref());
+            tool_calls.insert(
+                call_id,
+                GeminiToolCallContext {
+                    name: name.to_string(),
+                    provider_call_id,
+                },
+            );
+        }
     }
 
     fn resource_to_gemini_part(
@@ -1300,6 +1327,15 @@ impl GoogleGeminiProvider {
             }
         }
         parts.join("\n")
+    }
+
+    fn tool_result_value(content: &[AiToolResultContent]) -> Value {
+        if let [AiToolResultContent::Text { text }] = content {
+            if let Ok(value) = serde_json::from_str(text.trim()) {
+                return value;
+            }
+        }
+        Value::String(Self::tool_result_text(content))
     }
 
     fn resource_placeholder_text(source: &ResourceRef) -> String {
@@ -2150,7 +2186,9 @@ impl GoogleGeminiProvider {
         }
 
         let mut message = AiResponse::message_from_parts(content, tool_calls, vec![]);
-        message.content.extend(Self::extract_provider_state(&body));
+        if let Some(provider_state) = Self::extract_provider_state(&body) {
+            message.content.push(provider_state);
+        }
         let summary = AiResponse {
             message,
             usage,
@@ -3659,12 +3697,16 @@ mod tests {
     }
 
     #[test]
-    fn gemini_function_calls_are_normalized() {
+    fn gemini_candidate_and_structured_tool_result_round_trip() {
         let body = json!({
             "candidates": [{
                 "content": {
+                    "role": "model",
                     "parts": [
-                        { "text": "checking" },
+                        {
+                            "text": "checking",
+                            "thoughtSignature": "text-signed-state"
+                        },
                         {
                             "toolCall": {
                                 "id": "server-call-1",
@@ -3700,24 +3742,92 @@ mod tests {
         assert_eq!(calls[0].args.get("city"), Some(&json!("Shanghai")));
 
         let mut message = AiResponse::message_from_parts(None, calls, vec![]);
-        message
-            .content
-            .extend(GoogleGeminiProvider::extract_provider_state(&body));
+        message.content.push(
+            GoogleGeminiProvider::extract_provider_state(&body)
+                .expect("candidate content should be preserved"),
+        );
         let mut contents = Vec::new();
-        GoogleGeminiProvider::lower_message_to_gemini(&message, &mut contents, &mut HashMap::new())
+        let mut tool_calls = HashMap::new();
+        GoogleGeminiProvider::lower_message_to_gemini(&message, &mut contents, &mut tool_calls)
             .expect("Gemini provider state should lower");
-        assert_eq!(contents[0]["parts"].as_array().map(Vec::len), Some(3));
+        assert_eq!(contents.len(), 1);
+        assert_eq!(&contents[0], body.pointer("/candidates/0/content").unwrap());
+
+        let tool_result = AiMessage::new(
+            AiRole::Tool,
+            vec![AiContent::tool_result_text(
+                "call-1",
+                r#"{"temperature":24,"condition":"sunny"}"#,
+                false,
+            )],
+        );
+        GoogleGeminiProvider::lower_message_to_gemini(&tool_result, &mut contents, &mut tool_calls)
+            .expect("structured tool result should lower");
         assert_eq!(
-            contents[0].pointer("/parts/0/thoughtSignature"),
-            Some(&json!("signed-state"))
+            contents[1].pointer("/parts/0/functionResponse"),
+            Some(&json!({
+                "id": "call-1",
+                "name": "get_weather",
+                "response": { "temperature": 24, "condition": "sunny" }
+            }))
+        );
+    }
+
+    #[test]
+    fn gemini_no_id_function_call_stays_without_provider_id() {
+        let body = json!({
+            "candidates": [{
+                "content": {
+                    "role": "model",
+                    "parts": [{
+                        "functionCall": {
+                            "name": "get_weather",
+                            "args": { "city": "Shanghai" }
+                        },
+                        "thoughtSignature": "signed-state"
+                    }]
+                }
+            }]
+        });
+        let calls = GoogleGeminiProvider::extract_tool_calls(&body);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].call_id, "gemini-no-id-0-get_weather");
+
+        let mut message = AiResponse::message_from_parts(None, calls, vec![]);
+        message.content.push(
+            GoogleGeminiProvider::extract_provider_state(&body)
+                .expect("candidate content should be preserved"),
+        );
+        let mut contents = Vec::new();
+        let mut tool_calls = HashMap::new();
+        GoogleGeminiProvider::lower_message_to_gemini(&message, &mut contents, &mut tool_calls)
+            .expect("candidate should lower");
+        let tool_result = AiMessage::new(
+            AiRole::Tool,
+            vec![AiContent::tool_result_text(
+                "gemini-no-id-0-get_weather",
+                "sunny",
+                false,
+            )],
+        );
+        GoogleGeminiProvider::lower_message_to_gemini(&tool_result, &mut contents, &mut tool_calls)
+            .expect("tool result should lower");
+
+        assert_eq!(&contents[0], body.pointer("/candidates/0/content").unwrap());
+        assert!(contents[0].pointer("/parts/0/functionCall/id").is_none());
+        assert!(
+            contents[1]
+                .pointer("/parts/0/functionResponse/id")
+                .is_none()
         );
         assert_eq!(
-            contents[0].pointer("/parts/1/toolCall/id"),
-            Some(&json!("server-call-1"))
+            contents[1].pointer("/parts/0/functionResponse/name"),
+            Some(&json!("get_weather"))
         );
-        assert_eq!(
-            contents[0].pointer("/parts/2/toolResponse/id"),
-            Some(&json!("server-call-1"))
+        assert!(
+            !serde_json::to_string(&contents)
+                .unwrap()
+                .contains("gemini-no-id")
         );
     }
 
@@ -3739,9 +3849,9 @@ mod tests {
             ),
         ];
         let mut contents = Vec::new();
-        let mut tool_names = HashMap::new();
+        let mut tool_calls = HashMap::new();
         for message in &messages {
-            GoogleGeminiProvider::lower_message_to_gemini(message, &mut contents, &mut tool_names)
+            GoogleGeminiProvider::lower_message_to_gemini(message, &mut contents, &mut tool_calls)
                 .expect("message should lower");
         }
 
@@ -3752,6 +3862,10 @@ mod tests {
         assert_eq!(
             contents[1].pointer("/parts/0/functionResponse/id"),
             Some(&json!("call-1"))
+        );
+        assert_eq!(
+            contents[1].pointer("/parts/0/functionResponse/response"),
+            Some(&json!("sunny"))
         );
     }
 

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -1131,13 +1131,13 @@ impl GoogleGeminiProvider {
             );
         }
         declaration.insert(
-            "parameters".to_string(),
+            "parametersJsonSchema".to_string(),
             Value::Object(spec.args_schema.clone().into_iter().collect()),
         );
         if !spec.output_schema.is_null()
             && !spec.output_schema.as_object().is_some_and(Map::is_empty)
         {
-            declaration.insert("response".to_string(), spec.output_schema.clone());
+            declaration.insert("responseJsonSchema".to_string(), spec.output_schema.clone());
         }
         Value::Object(declaration)
     }
@@ -3521,14 +3521,62 @@ mod tests {
             Some(&json!("get_weather"))
         );
         assert_eq!(
-            request_value
-                .pointer("/tools/0/functionDeclarations/0/parameters/properties/city/type"),
+            request_value.pointer(
+                "/tools/0/functionDeclarations/0/parametersJsonSchema/properties/city/type"
+            ),
             Some(&json!("string"))
+        );
+        assert_eq!(
+            request_value.pointer("/tools/0/functionDeclarations/0/responseJsonSchema/type"),
+            Some(&json!("object"))
         );
         assert_eq!(
             request_value.pointer("/tools/1/googleSearch"),
             Some(&json!({}))
         );
+    }
+
+    #[test]
+    fn gemini_tool_schema_is_passed_through_as_json_schema() {
+        let schema = json!({
+            "type": "object",
+            "additionalProperties": false,
+            "definitions": {
+                "RecallMode": {
+                    "type": "string",
+                    "enum": ["auto", "mechanical", "llm"]
+                },
+                "TagInput": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    },
+                    "required": ["name"]
+                }
+            },
+            "properties": {
+                "mode": {
+                    "anyOf": [
+                        { "$ref": "#/definitions/RecallMode" },
+                        { "type": "null" }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/TagInput" }
+                }
+            }
+        });
+
+        let declaration = GoogleGeminiProvider::function_declaration(&AiToolSpec {
+            name: "recall".to_string(),
+            description: String::new(),
+            args_schema: value_to_object_map(schema.clone()),
+            output_schema: Value::Null,
+        });
+
+        assert_eq!(declaration.get("parametersJsonSchema"), Some(&schema));
+        assert!(declaration.get("parameters").is_none());
     }
 
     #[test]

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -323,23 +323,31 @@ impl GoogleGeminiProvider {
                     .with_latency(Some(120_000)),
             );
         }
-        let mut inventory = resolve_driver_inventory(
+        resolve_driver_inventory(
             provider_instance_name,
             provider_type,
             provider_driver,
             requests.as_slice(),
             inventory_revision,
-        );
-        for model in inventory.models.iter_mut().filter(|model| {
-            model
-                .api_types
-                .iter()
-                .any(|api_type| matches!(api_type, ApiType::Llm))
-        }) {
-            model.capabilities.web_search_with_tool_call =
-                Some(gemini_supports_combined_tools(&model.provider_model_id));
-        }
-        inventory
+        )
+    }
+
+    fn model_supports_feature_combination(
+        &self,
+        provider_model: &str,
+        combination: &[&str],
+    ) -> bool {
+        self.inventory
+            .read()
+            .ok()
+            .and_then(|inventory| {
+                inventory
+                    .models
+                    .iter()
+                    .find(|model| model.provider_model_id == provider_model)
+                    .map(|model| model.capabilities.supports_feature_combination(combination))
+            })
+            .unwrap_or(false)
     }
 
     pub fn start_inventory_refresh(self: Arc<Self>) {
@@ -1146,12 +1154,10 @@ impl GoogleGeminiProvider {
         target: &mut Map<String, Value>,
         provider_model: &str,
         req: &AiMethodRequest,
+        combined_tools_supported: bool,
     ) -> Result<(), ProviderError> {
         let web_search_required = req.requirements.requires_feature(features::WEB_SEARCH);
-        if web_search_required
-            && !req.payload.tool_specs.is_empty()
-            && !gemini_supports_combined_tools(provider_model)
-        {
+        if web_search_required && !req.payload.tool_specs.is_empty() && !combined_tools_supported {
             return Err(ProviderError::fatal(format!(
                 "google gemini model {} does not support combining Google Search with function calling",
                 provider_model
@@ -1173,6 +1179,17 @@ impl GoogleGeminiProvider {
         }
         if !tools.is_empty() {
             target.insert("tools".to_string(), Value::Array(tools));
+        }
+        if web_search_required && !req.payload.tool_specs.is_empty() {
+            target.insert(
+                "toolConfig".to_string(),
+                json!({
+                    "functionCallingConfig": {
+                        "mode": "VALIDATED"
+                    },
+                    "includeServerSideToolInvocations": true
+                }),
+            );
         }
         Ok(())
     }
@@ -2031,7 +2048,16 @@ impl GoogleGeminiProvider {
                 Value::String("application/json".to_string()),
             );
         }
-        Self::merge_llm_tools(&mut request_obj, provider_model, req)?;
+        let combined_tools_supported = self.model_supports_feature_combination(
+            provider_model,
+            &[features::WEB_SEARCH, features::TOOL_CALLING],
+        );
+        Self::merge_llm_tools(
+            &mut request_obj,
+            provider_model,
+            req,
+            combined_tools_supported,
+        )?;
 
         if !ignored_options.is_empty() {
             warn!(
@@ -3088,12 +3114,6 @@ fn parse_gemini_major_minor(name: &str) -> Option<(u32, u32)> {
     Some((major, minor))
 }
 
-fn gemini_supports_combined_tools(name: &str) -> bool {
-    parse_gemini_major_minor(name)
-        .map(|(major, _)| major >= 3)
-        .unwrap_or(false)
-}
-
 /// 若同一 bucket 里既有 alias `X` 又有它的数字后缀版本 `X-NNN`（NNN 是 2~4 位
 /// 数字），就只保留 alias、把版本快照剔除。Google `/v1beta/models` 同时返回这两
 /// 种命名，alias 通常生命周期更长，先停的是版本快照（`gemini-2.0-flash-001` /
@@ -3512,8 +3532,13 @@ mod tests {
         );
         let mut request_obj = Map::new();
 
-        GoogleGeminiProvider::merge_llm_tools(&mut request_obj, "gemini-3.1-pro-preview", &request)
-            .expect("Gemini 3 should support combined tools");
+        GoogleGeminiProvider::merge_llm_tools(
+            &mut request_obj,
+            "gemini-3.1-pro-preview",
+            &request,
+            true,
+        )
+        .expect("Gemini 3 should support combined tools");
         let request_value = Value::Object(request_obj);
 
         assert_eq!(
@@ -3532,6 +3557,34 @@ mod tests {
         );
         assert_eq!(
             request_value.pointer("/tools/1/googleSearch"),
+            Some(&json!({}))
+        );
+        assert_eq!(
+            request_value.pointer("/toolConfig/includeServerSideToolInvocations"),
+            Some(&json!(true))
+        );
+        assert_eq!(
+            request_value.pointer("/toolConfig/functionCallingConfig/mode"),
+            Some(&json!("VALIDATED"))
+        );
+    }
+
+    #[test]
+    fn gemini_builtin_tool_alone_does_not_enable_combination_config() {
+        let request = build_llm_request(vec![features::WEB_SEARCH.to_string()], vec![]);
+        let mut request_obj = Map::new();
+
+        GoogleGeminiProvider::merge_llm_tools(
+            &mut request_obj,
+            "gemini-3-flash-preview",
+            &request,
+            true,
+        )
+        .expect("Google Search should be enabled");
+
+        assert!(request_obj.get("toolConfig").is_none());
+        assert_eq!(
+            Value::Object(request_obj).pointer("/tools/0/googleSearch"),
             Some(&json!({}))
         );
     }
@@ -3594,9 +3647,13 @@ mod tests {
             }],
         );
 
-        let error =
-            GoogleGeminiProvider::merge_llm_tools(&mut Map::new(), "gemini-2.5-flash", &request)
-                .expect_err("Gemini 2.5 must reject combined tools");
+        let error = GoogleGeminiProvider::merge_llm_tools(
+            &mut Map::new(),
+            "gemini-2.5-flash",
+            &request,
+            false,
+        )
+        .expect_err("Gemini 2.5 must reject combined tools");
 
         assert!(error.to_string().contains("does not support combining"));
     }
@@ -3608,6 +3665,20 @@ mod tests {
                 "content": {
                     "parts": [
                         { "text": "checking" },
+                        {
+                            "toolCall": {
+                                "id": "server-call-1",
+                                "name": "google_search",
+                                "args": { "query": "Shanghai weather" }
+                            }
+                        },
+                        {
+                            "toolResponse": {
+                                "id": "server-call-1",
+                                "name": "google_search",
+                                "response": { "result": "search result" }
+                            }
+                        },
                         {
                             "functionCall": {
                                 "id": "call-1",
@@ -3635,10 +3706,18 @@ mod tests {
         let mut contents = Vec::new();
         GoogleGeminiProvider::lower_message_to_gemini(&message, &mut contents, &mut HashMap::new())
             .expect("Gemini provider state should lower");
-        assert_eq!(contents[0]["parts"].as_array().map(Vec::len), Some(1));
+        assert_eq!(contents[0]["parts"].as_array().map(Vec::len), Some(3));
         assert_eq!(
             contents[0].pointer("/parts/0/thoughtSignature"),
             Some(&json!("signed-state"))
+        );
+        assert_eq!(
+            contents[0].pointer("/parts/1/toolCall/id"),
+            Some(&json!("server-call-1"))
+        );
+        assert_eq!(
+            contents[0].pointer("/parts/2/toolResponse/id"),
+            Some(&json!("server-call-1"))
         );
     }
 
@@ -4158,14 +4237,23 @@ mod tests {
             .find(|model| model.provider_model_id == "gemini-2.5-flash")
             .expect("Gemini 2.5 Flash metadata");
         assert!(flash.capabilities.web_search);
-        assert_eq!(flash.capabilities.web_search_with_tool_call, Some(false));
+        assert_eq!(
+            flash.capabilities.unsupported_feature_combinations,
+            vec![vec![
+                features::TOOL_CALLING.to_string(),
+                features::WEB_SEARCH.to_string()
+            ]]
+        );
         let gemini_3 = inventory
             .models
             .iter()
             .find(|model| model.provider_model_id == "gemini-3.1-pro-preview")
             .expect("Gemini 3 metadata");
         assert!(gemini_3.capabilities.web_search);
-        assert_eq!(gemini_3.capabilities.web_search_with_tool_call, Some(true));
+        assert!(gemini_3
+            .capabilities
+            .unsupported_feature_combinations
+            .is_empty());
         let image_items = registry.default_items_for_path("image.txt2img.gemini");
         assert!(image_items
             .values()

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -1330,12 +1330,15 @@ impl GoogleGeminiProvider {
     }
 
     fn tool_result_value(content: &[AiToolResultContent]) -> Value {
-        if let [AiToolResultContent::Text { text }] = content {
-            if let Ok(value) = serde_json::from_str(text.trim()) {
-                return value;
-            }
+        let value = match content {
+            [AiToolResultContent::Text { text }] => serde_json::from_str(text.trim())
+                .unwrap_or_else(|_| Value::String(text.clone())),
+            _ => Value::String(Self::tool_result_text(content)),
+        };
+        match value {
+            Value::Object(_) => value,
+            value => json!({ "output": value }),
         }
-        Value::String(Self::tool_result_text(content))
     }
 
     fn resource_placeholder_text(source: &ResourceRef) -> String {
@@ -3865,7 +3868,7 @@ mod tests {
         );
         assert_eq!(
             contents[1].pointer("/parts/0/functionResponse/response"),
-            Some(&json!("sunny"))
+            Some(&json!({ "output": "sunny" }))
         );
     }
 

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -13,8 +13,9 @@ use async_trait::async_trait;
 use base64::engine::general_purpose;
 use base64::Engine as _;
 use buckyos_api::{
-    ai_methods, features, AiArtifact, AiContent, AiCost, AiMessage, AiMethodRequest, AiResponse,
-    AiRole, AiToolResultContent, AiUsage, Capability, Feature, ResourceRef,
+    ai_methods, features, value_to_object_map, AiArtifact, AiContent, AiCost, AiMessage,
+    AiMethodRequest, AiResponse, AiRole, AiToolCall, AiToolResultContent, AiToolSpec, AiUsage,
+    Capability, Feature, ResourceRef,
 };
 use log::{info, warn};
 use reqwest::{Client, StatusCode};
@@ -322,13 +323,23 @@ impl GoogleGeminiProvider {
                     .with_latency(Some(120_000)),
             );
         }
-        resolve_driver_inventory(
+        let mut inventory = resolve_driver_inventory(
             provider_instance_name,
             provider_type,
             provider_driver,
             requests.as_slice(),
             inventory_revision,
-        )
+        );
+        for model in inventory.models.iter_mut().filter(|model| {
+            model
+                .api_types
+                .iter()
+                .any(|api_type| matches!(api_type, ApiType::Llm))
+        }) {
+            model.capabilities.web_search_with_tool_call =
+                Some(gemini_supports_combined_tools(&model.provider_model_id));
+        }
+        inventory
     }
 
     pub fn start_inventory_refresh(self: Arc<Self>) {
@@ -900,13 +911,14 @@ impl GoogleGeminiProvider {
 
     fn build_contents(&self, req: &AiMethodRequest) -> Result<Vec<Value>, ProviderError> {
         let mut contents: Vec<Value> = vec![];
+        let mut tool_names = HashMap::new();
 
         // 主路径:消费 typed `Vec<AiMessage>`,保留 ToolUse/ToolResult/Image
         // 等 block,转成 Gemini parts(functionCall / functionResponse /
         // inlineData / fileData / text)。
         if !req.payload.messages.is_empty() {
             for msg in req.payload.messages.iter() {
-                Self::lower_message_to_gemini(msg, &mut contents)?;
+                Self::lower_message_to_gemini(msg, &mut contents, &mut tool_names)?;
             }
         }
 
@@ -972,6 +984,7 @@ impl GoogleGeminiProvider {
     fn lower_message_to_gemini(
         msg: &AiMessage,
         contents: &mut Vec<Value>,
+        tool_names: &mut HashMap<String, String>,
     ) -> Result<(), ProviderError> {
         match msg.role {
             AiRole::Tool => {
@@ -989,16 +1002,17 @@ impl GoogleGeminiProvider {
                 if *is_error {
                     response_obj.insert("error".to_string(), Value::Bool(true));
                 }
-                // Gemini convention: functionResponse.name is the tool name; we
-                // don't always have it on the IR side, so reuse call_id as the
-                // stable correlator (model still matches on the immediately
-                // preceding functionCall by position).
-                let part = json!({
-                    "functionResponse": {
-                        "name": call_id,
-                        "response": Value::Object(response_obj),
-                    }
-                });
+                let name = tool_names
+                    .get(call_id)
+                    .cloned()
+                    .unwrap_or_else(|| call_id.clone());
+                let mut function_response = Map::new();
+                function_response.insert("name".to_string(), Value::String(name));
+                function_response.insert("response".to_string(), Value::Object(response_obj));
+                if tool_names.contains_key(call_id) && !call_id.starts_with("gemini-no-id-") {
+                    function_response.insert("id".to_string(), Value::String(call_id.clone()));
+                }
+                let part = json!({ "functionResponse": function_response });
                 contents.push(json!({
                     "role": "user",
                     "parts": [part],
@@ -1010,7 +1024,7 @@ impl GoogleGeminiProvider {
                     AiRole::Assistant => "model",
                     _ => "user",
                 };
-                let parts = Self::lower_blocks_to_parts(&msg.content)?;
+                let parts = Self::lower_blocks_to_parts(&msg.content, tool_names)?;
                 if !parts.is_empty() {
                     contents.push(json!({
                         "role": role,
@@ -1022,7 +1036,10 @@ impl GoogleGeminiProvider {
         }
     }
 
-    fn lower_blocks_to_parts(content: &[AiContent]) -> Result<Vec<Value>, ProviderError> {
+    fn lower_blocks_to_parts(
+        content: &[AiContent],
+        tool_names: &mut HashMap<String, String>,
+    ) -> Result<Vec<Value>, ProviderError> {
         let mut parts = Vec::with_capacity(content.len());
         for block in content {
             match block {
@@ -1046,6 +1063,7 @@ impl GoogleGeminiProvider {
                     name,
                     args,
                 } => {
+                    tool_names.insert(call_id.clone(), name.clone());
                     let args_value = serde_json::to_value(args).unwrap_or_else(|_| json!({}));
                     parts.push(json!({
                         "functionCall": {
@@ -1070,8 +1088,29 @@ impl GoogleGeminiProvider {
                 AiContent::ProviderState { provider, value } => {
                     if provider.eq_ignore_ascii_case("google")
                         || provider.eq_ignore_ascii_case("gemini")
+                        || provider.eq_ignore_ascii_case("google-gemini")
                     {
-                        parts.push(value.clone());
+                        let raw_function = value.get("functionCall").and_then(Value::as_object);
+                        let existing = raw_function.and_then(|raw| {
+                            let raw_id = raw.get("id").and_then(Value::as_str);
+                            let raw_name = raw.get("name").and_then(Value::as_str);
+                            parts.iter_mut().find(|part| {
+                                let Some(function) =
+                                    part.get("functionCall").and_then(Value::as_object)
+                                else {
+                                    return false;
+                                };
+                                raw_id.is_some()
+                                    && function.get("id").and_then(Value::as_str) == raw_id
+                                    || raw_id.is_none()
+                                        && function.get("name").and_then(Value::as_str) == raw_name
+                            })
+                        });
+                        if let Some(existing) = existing {
+                            *existing = value.clone();
+                        } else {
+                            parts.push(value.clone());
+                        }
                     }
                 }
                 AiContent::ToolResult { .. } => {
@@ -1080,6 +1119,115 @@ impl GoogleGeminiProvider {
             }
         }
         Ok(parts)
+    }
+
+    fn function_declaration(spec: &AiToolSpec) -> Value {
+        let mut declaration = Map::new();
+        declaration.insert("name".to_string(), Value::String(spec.name.clone()));
+        if !spec.description.trim().is_empty() {
+            declaration.insert(
+                "description".to_string(),
+                Value::String(spec.description.clone()),
+            );
+        }
+        declaration.insert(
+            "parameters".to_string(),
+            Value::Object(spec.args_schema.clone().into_iter().collect()),
+        );
+        if !spec.output_schema.is_null()
+            && !spec.output_schema.as_object().is_some_and(Map::is_empty)
+        {
+            declaration.insert("response".to_string(), spec.output_schema.clone());
+        }
+        Value::Object(declaration)
+    }
+
+    fn merge_llm_tools(
+        target: &mut Map<String, Value>,
+        provider_model: &str,
+        req: &AiMethodRequest,
+    ) -> Result<(), ProviderError> {
+        let web_search_required = req.requirements.requires_feature(features::WEB_SEARCH);
+        if web_search_required
+            && !req.payload.tool_specs.is_empty()
+            && !gemini_supports_combined_tools(provider_model)
+        {
+            return Err(ProviderError::fatal(format!(
+                "google gemini model {} does not support combining Google Search with function calling",
+                provider_model
+            )));
+        }
+        let mut tools = Vec::new();
+        if !req.payload.tool_specs.is_empty() {
+            tools.push(json!({
+                "functionDeclarations": req
+                    .payload
+                    .tool_specs
+                    .iter()
+                    .map(Self::function_declaration)
+                    .collect::<Vec<_>>()
+            }));
+        }
+        if web_search_required {
+            tools.push(json!({ "googleSearch": {} }));
+        }
+        if !tools.is_empty() {
+            target.insert("tools".to_string(), Value::Array(tools));
+        }
+        Ok(())
+    }
+
+    fn extract_tool_calls(body: &Value) -> Vec<AiToolCall> {
+        body.pointer("/candidates/0/content/parts")
+            .and_then(Value::as_array)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, part)| {
+                        let function = part.get("functionCall")?.as_object()?;
+                        let name = function.get("name")?.as_str()?.to_string();
+                        let call_id = function
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .filter(|value| !value.trim().is_empty())
+                            .map(str::to_string)
+                            .unwrap_or_else(|| format!("gemini-no-id-{}-{}", index, name));
+                        let args = function
+                            .get("args")
+                            .cloned()
+                            .filter(Value::is_object)
+                            .unwrap_or_else(|| Value::Object(Map::new()));
+                        Some(AiToolCall {
+                            call_id,
+                            name,
+                            args: value_to_object_map(args),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn extract_provider_state(body: &Value) -> Vec<AiContent> {
+        body.pointer("/candidates/0/content/parts")
+            .and_then(Value::as_array)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter(|part| {
+                        part.get("thoughtSignature").is_some()
+                            || part.get("toolCall").is_some()
+                            || part.get("toolResponse").is_some()
+                    })
+                    .cloned()
+                    .map(|value| AiContent::ProviderState {
+                        provider: "google-gemini".to_string(),
+                        value,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     fn resource_to_gemini_part(
@@ -1883,6 +2031,7 @@ impl GoogleGeminiProvider {
                 Value::String("application/json".to_string()),
             );
         }
+        Self::merge_llm_tools(&mut request_obj, provider_model, req)?;
 
         if !ignored_options.is_empty() {
             warn!(
@@ -1936,6 +2085,7 @@ impl GoogleGeminiProvider {
         );
 
         let content = Self::extract_text_content(&body);
+        let tool_calls = Self::extract_tool_calls(&body);
         let usage = body.get("usageMetadata").map(|usage| AiUsage {
             input_tokens: usage
                 .get("promptTokenCount")
@@ -1969,9 +2119,14 @@ impl GoogleGeminiProvider {
                 "output": body.clone()
             }),
         );
+        if let Some(grounding_metadata) = body.pointer("/candidates/0/groundingMetadata") {
+            extra.insert("grounding_metadata".to_string(), grounding_metadata.clone());
+        }
 
+        let mut message = AiResponse::message_from_parts(content, tool_calls, vec![]);
+        message.content.extend(Self::extract_provider_state(&body));
         let summary = AiResponse {
-            message: AiResponse::message_from_parts(content, vec![], vec![]),
+            message,
             usage,
             cost,
             finish_reason: body
@@ -2933,6 +3088,12 @@ fn parse_gemini_major_minor(name: &str) -> Option<(u32, u32)> {
     Some((major, minor))
 }
 
+fn gemini_supports_combined_tools(name: &str) -> bool {
+    parse_gemini_major_minor(name)
+        .map(|(major, _)| major >= 3)
+        .unwrap_or(false)
+}
+
 /// 若同一 bucket 里既有 alias `X` 又有它的数字后缀版本 `X-NNN`（NNN 是 2~4 位
 /// 数字），就只保留 alias、把版本快照剔除。Google `/v1beta/models` 同时返回这两
 /// 种命名，alias 通常生命周期更长，先停的是版本快照（`gemini-2.0-flash-001` /
@@ -3308,6 +3469,164 @@ mod tests {
     use crate::aicc::ModelCatalog;
     use buckyos_api::{AiPayload, ModelSpec, Requirements};
     use serde_json::json;
+
+    fn build_llm_request(
+        must_features: Vec<Feature>,
+        tool_specs: Vec<AiToolSpec>,
+    ) -> AiMethodRequest {
+        AiMethodRequest::new(
+            Capability::Llm,
+            ModelSpec::new("llm.chat".to_string(), None),
+            Requirements::new(must_features, None, None, None),
+            AiPayload::new(
+                None,
+                vec![AiMessage::text(AiRole::User, "hello")],
+                tool_specs,
+                vec![],
+                None,
+                None,
+            ),
+            None,
+        )
+    }
+
+    #[test]
+    fn llm_tools_include_function_declarations_and_google_search() {
+        let request = build_llm_request(
+            vec![
+                features::TOOL_CALLING.to_string(),
+                features::WEB_SEARCH.to_string(),
+            ],
+            vec![AiToolSpec {
+                name: "get_weather".to_string(),
+                description: "Get current weather".to_string(),
+                args_schema: value_to_object_map(json!({
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    },
+                    "required": ["city"]
+                })),
+                output_schema: json!({ "type": "object" }),
+            }],
+        );
+        let mut request_obj = Map::new();
+
+        GoogleGeminiProvider::merge_llm_tools(&mut request_obj, "gemini-3.1-pro-preview", &request)
+            .expect("Gemini 3 should support combined tools");
+        let request_value = Value::Object(request_obj);
+
+        assert_eq!(
+            request_value.pointer("/tools/0/functionDeclarations/0/name"),
+            Some(&json!("get_weather"))
+        );
+        assert_eq!(
+            request_value
+                .pointer("/tools/0/functionDeclarations/0/parameters/properties/city/type"),
+            Some(&json!("string"))
+        );
+        assert_eq!(
+            request_value.pointer("/tools/1/googleSearch"),
+            Some(&json!({}))
+        );
+    }
+
+    #[test]
+    fn gemini_2_5_rejects_combined_builtin_and_function_tools() {
+        let request = build_llm_request(
+            vec![
+                features::TOOL_CALLING.to_string(),
+                features::WEB_SEARCH.to_string(),
+            ],
+            vec![AiToolSpec {
+                name: "get_weather".to_string(),
+                description: String::new(),
+                args_schema: value_to_object_map(json!({ "type": "object" })),
+                output_schema: Value::Null,
+            }],
+        );
+
+        let error =
+            GoogleGeminiProvider::merge_llm_tools(&mut Map::new(), "gemini-2.5-flash", &request)
+                .expect_err("Gemini 2.5 must reject combined tools");
+
+        assert!(error.to_string().contains("does not support combining"));
+    }
+
+    #[test]
+    fn gemini_function_calls_are_normalized() {
+        let body = json!({
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        { "text": "checking" },
+                        {
+                            "functionCall": {
+                                "id": "call-1",
+                                "name": "get_weather",
+                                "args": { "city": "Shanghai" }
+                            },
+                            "thoughtSignature": "signed-state"
+                        }
+                    ]
+                }
+            }]
+        });
+
+        let calls = GoogleGeminiProvider::extract_tool_calls(&body);
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].call_id, "call-1");
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].args.get("city"), Some(&json!("Shanghai")));
+
+        let mut message = AiResponse::message_from_parts(None, calls, vec![]);
+        message
+            .content
+            .extend(GoogleGeminiProvider::extract_provider_state(&body));
+        let mut contents = Vec::new();
+        GoogleGeminiProvider::lower_message_to_gemini(&message, &mut contents, &mut HashMap::new())
+            .expect("Gemini provider state should lower");
+        assert_eq!(contents[0]["parts"].as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            contents[0].pointer("/parts/0/thoughtSignature"),
+            Some(&json!("signed-state"))
+        );
+    }
+
+    #[test]
+    fn gemini_tool_result_keeps_function_name_and_call_id() {
+        let messages = vec![
+            AiResponse::message_from_parts(
+                None,
+                vec![AiToolCall {
+                    call_id: "call-1".to_string(),
+                    name: "get_weather".to_string(),
+                    args: value_to_object_map(json!({ "city": "Shanghai" })),
+                }],
+                vec![],
+            ),
+            AiMessage::new(
+                AiRole::Tool,
+                vec![AiContent::tool_result_text("call-1", "sunny", false)],
+            ),
+        ];
+        let mut contents = Vec::new();
+        let mut tool_names = HashMap::new();
+        for message in &messages {
+            GoogleGeminiProvider::lower_message_to_gemini(message, &mut contents, &mut tool_names)
+                .expect("message should lower");
+        }
+
+        assert_eq!(
+            contents[1].pointer("/parts/0/functionResponse/name"),
+            Some(&json!("get_weather"))
+        );
+        assert_eq!(
+            contents[1].pointer("/parts/0/functionResponse/id"),
+            Some(&json!("call-1"))
+        );
+    }
 
     #[test]
     fn gemini_models_pagination_rejects_repeated_tokens() {
@@ -3760,7 +4079,7 @@ mod tests {
                         "provider_type": "cloud_api",
                         "provider_driver": "google-gemini",
                         "base_url": "https://generativelanguage.googleapis.com/v1beta",
-                        "models": ["gemini-2.5-flash", "gemini-2.5-pro"],
+                        "models": ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-3.1-pro-preview"],
                         "image_models": ["gemini-2.5-flash-image-preview"]
                     }
                 ]
@@ -3780,6 +4099,25 @@ mod tests {
         assert!(pro_items
             .values()
             .any(|item| item.target == "gemini-2.5-pro@google-gemini-default"));
+        let inventories = center.registry().inventories();
+        let inventory = inventories
+            .iter()
+            .find(|inventory| inventory.provider_instance_name == "google-gemini-default")
+            .expect("Gemini inventory");
+        let flash = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "gemini-2.5-flash")
+            .expect("Gemini 2.5 Flash metadata");
+        assert!(flash.capabilities.web_search);
+        assert_eq!(flash.capabilities.web_search_with_tool_call, Some(false));
+        let gemini_3 = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "gemini-3.1-pro-preview")
+            .expect("Gemini 3 metadata");
+        assert!(gemini_3.capabilities.web_search);
+        assert_eq!(gemini_3.capabilities.web_search_with_tool_call, Some(true));
         let image_items = registry.default_items_for_path("image.txt2img.gemini");
         assert!(image_items
             .values()

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -1,8 +1,8 @@
 use crate::aicc::exact_model_name;
 use crate::model_types::{
-    ApiType, CostClass, HealthStatus, LatencyClass, ModelAttributes, ModelCapabilities,
-    ModelHealth, ModelMetadata, ModelPricing, PrivacyClass, ProviderInventory, ProviderOrigin,
-    ProviderType, ProviderTypeTrustedSource, QuotaState,
+    is_model_feature_name, ApiType, CostClass, HealthStatus, LatencyClass, ModelAttributes,
+    ModelCapabilities, ModelHealth, ModelMetadata, ModelPricing, PrivacyClass, ProviderInventory,
+    ProviderOrigin, ProviderType, ProviderTypeTrustedSource, QuotaState,
 };
 use buckyos_kit::get_buckyos_system_etc_dir;
 use log::warn;
@@ -64,6 +64,8 @@ pub struct DriverMetadataDocument {
     pub models: Vec<DriverModelRule>,
     #[serde(default)]
     pub patterns: Vec<DriverModelRule>,
+    #[serde(default)]
+    pub capability_overrides: Vec<DriverCapabilityOverride>,
     #[serde(default)]
     pub defaults: DriverModelRule,
     #[serde(default)]
@@ -155,6 +157,16 @@ pub struct DriverModelRule {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct DriverCapabilityOverride {
+    pub pattern: String,
+    #[serde(default)]
+    pub api_types: Vec<ApiType>,
+    #[serde(default)]
+    pub capabilities: DriverCapabilitiesPatch,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DriverVersionRule {
     #[serde(default)]
     pub family: String,
@@ -210,7 +222,7 @@ pub struct DriverCapabilitiesPatch {
     #[serde(default)]
     pub web_search: Option<bool>,
     #[serde(default)]
-    pub web_search_with_tool_call: Option<bool>,
+    pub unsupported_feature_combinations: Option<Vec<Vec<String>>>,
     #[serde(default)]
     pub vision: Option<bool>,
     #[serde(default)]
@@ -411,6 +423,12 @@ fn resolve_driver_model(
             cost_class = next;
         }
     }
+    apply_capability_overrides(
+        provider_model_id,
+        api_types.as_slice(),
+        &mut capabilities,
+        sources,
+    );
     if logical_mounts.is_empty() && !driver_rule_found {
         logical_mounts = provider_fallback_mounts(request.fallback_logical_mounts.as_slice());
     }
@@ -590,6 +608,21 @@ pub(crate) fn validate_driver_metadata_document(
             return Err(format!("duplicate model pattern '{}'", pattern));
         }
         validate_driver_model_rule(rule, format!("patterns[{}]", index).as_str())?;
+    }
+
+    for (index, rule) in document.capability_overrides.iter().enumerate() {
+        let location = format!("capability_overrides[{}]", index);
+        validate_trimmed_value(rule.pattern.as_str(), &format!("{}.pattern", location))?;
+        if !rule.capabilities.has_any() {
+            return Err(format!("{}.capabilities cannot be empty", location));
+        }
+        let mut api_types = HashSet::new();
+        for api_type in &rule.api_types {
+            if !api_types.insert(api_type) {
+                return Err(format!("{}.api_types contains duplicate value", location));
+            }
+        }
+        validate_capabilities_patch(&rule.capabilities, location.as_str())?;
     }
 
     if document.defaults.id.is_some() || document.defaults.pattern.is_some() {
@@ -788,6 +821,39 @@ fn validate_capabilities_patch(
             "{}.capability token limits must be positive",
             location
         ));
+    }
+    if let Some(combinations) = capabilities.unsupported_feature_combinations.as_ref() {
+        let mut unique_combinations = HashSet::new();
+        for (index, combination) in combinations.iter().enumerate() {
+            let combination_location = format!(
+                "{}.capabilities.unsupported_feature_combinations[{}]",
+                location, index
+            );
+            if combination.len() < 2 {
+                return Err(format!(
+                    "{} must contain at least two features",
+                    combination_location
+                ));
+            }
+            validate_string_list(combination, combination_location.as_str())?;
+            if let Some(feature) = combination
+                .iter()
+                .find(|feature| !is_model_feature_name(feature))
+            {
+                return Err(format!(
+                    "{} contains unsupported feature '{}'",
+                    combination_location, feature
+                ));
+            }
+            let mut canonical = combination.clone();
+            canonical.sort();
+            if !unique_combinations.insert(canonical.join("\0")) {
+                return Err(format!(
+                    "{}.capabilities.unsupported_feature_combinations contains duplicate combination",
+                    location
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -989,6 +1055,33 @@ fn find_pattern_rule<'a>(
     None
 }
 
+fn apply_capability_overrides(
+    provider_model_id: &str,
+    api_types: &[ApiType],
+    capabilities: &mut ModelCapabilities,
+    sources: &[DriverMetadataSource],
+) {
+    for source in sources {
+        if source.document.schema_version != DRIVER_METADATA_SCHEMA_VERSION {
+            continue;
+        }
+        for rule in &source.document.capability_overrides {
+            if !wildcard_matches(rule.pattern.as_str(), provider_model_id) {
+                continue;
+            }
+            if !rule.api_types.is_empty()
+                && !rule
+                    .api_types
+                    .iter()
+                    .any(|required| api_types.contains(required))
+            {
+                continue;
+            }
+            apply_capabilities_patch(capabilities, &rule.capabilities);
+        }
+    }
+}
+
 fn find_default_rule(sources: &[DriverMetadataSource]) -> Option<&DriverModelRule> {
     for source in sources.iter().rev() {
         if source.document.schema_version != DRIVER_METADATA_SCHEMA_VERSION {
@@ -1132,7 +1225,7 @@ fn conservative_capabilities() -> ModelCapabilities {
         tool_call: false,
         json_schema: false,
         web_search: false,
-        web_search_with_tool_call: None,
+        unsupported_feature_combinations: vec![],
         vision: false,
         max_context_tokens: None,
         max_output_tokens: None,
@@ -1145,7 +1238,7 @@ impl DriverCapabilitiesPatch {
             || self.tool_call.is_some()
             || self.json_schema.is_some()
             || self.web_search.is_some()
-            || self.web_search_with_tool_call.is_some()
+            || self.unsupported_feature_combinations.is_some()
             || self.vision.is_some()
             || self.max_context_tokens.is_some()
             || self.max_output_tokens.is_some()
@@ -1165,8 +1258,8 @@ fn apply_capabilities_patch(capabilities: &mut ModelCapabilities, patch: &Driver
     if let Some(value) = patch.web_search {
         capabilities.web_search = value;
     }
-    if let Some(value) = patch.web_search_with_tool_call {
-        capabilities.web_search_with_tool_call = Some(value);
+    if let Some(value) = patch.unsupported_feature_combinations.as_ref() {
+        capabilities.unsupported_feature_combinations = value.clone();
     }
     if let Some(value) = patch.vision {
         capabilities.vision = value;
@@ -1647,6 +1740,72 @@ mod tests {
             validate_driver_metadata_document(&document)
                 .unwrap_or_else(|err| panic!("{} metadata is invalid: {}", driver, err));
         }
+    }
+
+    #[test]
+    fn capability_combination_validation_is_generic_and_fail_closed() {
+        let mut patch = DriverCapabilitiesPatch {
+            unsupported_feature_combinations: Some(vec![vec![
+                "web_search".to_string(),
+                "tool_calling".to_string(),
+            ]]),
+            ..Default::default()
+        };
+        assert!(validate_capabilities_patch(&patch, "models[0]").is_ok());
+
+        patch.unsupported_feature_combinations = Some(vec![vec!["web_search".to_string()]]);
+        assert!(validate_capabilities_patch(&patch, "models[0]").is_err());
+
+        patch.unsupported_feature_combinations = Some(vec![vec![
+            "web_search".to_string(),
+            "future_feature".to_string(),
+        ]]);
+        assert!(validate_capabilities_patch(&patch, "models[0]").is_err());
+
+        patch.unsupported_feature_combinations = Some(vec![
+            vec!["web_search".to_string(), "tool_calling".to_string()],
+            vec!["tool_calling".to_string(), "web_search".to_string()],
+        ]);
+        assert!(validate_capabilities_patch(&patch, "models[0]").is_err());
+    }
+
+    #[test]
+    fn capability_overrides_apply_by_model_pattern_and_api_type() {
+        let source = DriverMetadataSource::new(
+            "test".to_string(),
+            DriverMetadataDocument {
+                schema_version: DRIVER_METADATA_SCHEMA_VERSION,
+                capability_overrides: vec![DriverCapabilityOverride {
+                    pattern: "gemini-2.*".to_string(),
+                    api_types: vec![ApiType::Llm],
+                    capabilities: DriverCapabilitiesPatch {
+                        unsupported_feature_combinations: Some(vec![vec![
+                            "tool_calling".to_string(),
+                            "web_search".to_string(),
+                        ]]),
+                        ..Default::default()
+                    },
+                }],
+                ..Default::default()
+            },
+        );
+        let mut llm = ModelCapabilities::default();
+        apply_capability_overrides(
+            "gemini-2.5-flash",
+            &[ApiType::Llm],
+            &mut llm,
+            &[source.clone()],
+        );
+        assert!(!llm.supports_feature_combination(&["tool_calling", "web_search"]));
+
+        let mut image = ModelCapabilities::default();
+        apply_capability_overrides(
+            "gemini-2.5-flash-image-preview",
+            &[ApiType::ImageTextToImage],
+            &mut image,
+            &[source],
+        );
+        assert!(image.supports_feature_combination(&["tool_calling", "web_search"]));
     }
 
     #[test]

--- a/src/frame/aicc/src/metadata_resolver.rs
+++ b/src/frame/aicc/src/metadata_resolver.rs
@@ -210,6 +210,8 @@ pub struct DriverCapabilitiesPatch {
     #[serde(default)]
     pub web_search: Option<bool>,
     #[serde(default)]
+    pub web_search_with_tool_call: Option<bool>,
+    #[serde(default)]
     pub vision: Option<bool>,
     #[serde(default)]
     pub max_context_tokens: Option<u64>,
@@ -1130,6 +1132,7 @@ fn conservative_capabilities() -> ModelCapabilities {
         tool_call: false,
         json_schema: false,
         web_search: false,
+        web_search_with_tool_call: None,
         vision: false,
         max_context_tokens: None,
         max_output_tokens: None,
@@ -1142,6 +1145,7 @@ impl DriverCapabilitiesPatch {
             || self.tool_call.is_some()
             || self.json_schema.is_some()
             || self.web_search.is_some()
+            || self.web_search_with_tool_call.is_some()
             || self.vision.is_some()
             || self.max_context_tokens.is_some()
             || self.max_output_tokens.is_some()
@@ -1160,6 +1164,9 @@ fn apply_capabilities_patch(capabilities: &mut ModelCapabilities, patch: &Driver
     }
     if let Some(value) = patch.web_search {
         capabilities.web_search = value;
+    }
+    if let Some(value) = patch.web_search_with_tool_call {
+        capabilities.web_search_with_tool_call = Some(value);
     }
     if let Some(value) = patch.vision {
         capabilities.vision = value;

--- a/src/frame/aicc/src/model_router.rs
+++ b/src/frame/aicc/src/model_router.rs
@@ -641,7 +641,7 @@ mod tests {
                 tool_call: true,
                 json_schema: true,
                 web_search: true,
-                web_search_with_tool_call: None,
+                unsupported_feature_combinations: vec![],
                 vision: false,
                 max_context_tokens: Some(128_000),
                 max_output_tokens: Some(16_384),

--- a/src/frame/aicc/src/model_router.rs
+++ b/src/frame/aicc/src/model_router.rs
@@ -641,6 +641,7 @@ mod tests {
                 tool_call: true,
                 json_schema: true,
                 web_search: true,
+                web_search_with_tool_call: None,
                 vision: false,
                 max_context_tokens: Some(128_000),
                 max_output_tokens: Some(16_384),

--- a/src/frame/aicc/src/model_types.rs
+++ b/src/frame/aicc/src/model_types.rs
@@ -3,6 +3,13 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 
+pub(crate) fn is_model_feature_name(feature: &str) -> bool {
+    matches!(
+        feature,
+        "streaming" | "tool_calling" | "json_output" | "web_search" | "vision"
+    )
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ExactModelName {
     pub provider_model_id: String,
@@ -337,8 +344,8 @@ pub struct ModelCapabilities {
     pub json_schema: bool,
     #[serde(default)]
     pub web_search: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub web_search_with_tool_call: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unsupported_feature_combinations: Vec<Vec<String>>,
     #[serde(default)]
     pub vision: bool,
     #[serde(default)]
@@ -349,14 +356,14 @@ pub struct ModelCapabilities {
 
 impl ModelCapabilities {
     pub fn supports(&self, required: &RequiredModelFeatures) -> bool {
+        let required_features = required.feature_names();
         (!required.streaming || self.streaming)
             && (!required.tool_call || self.tool_call)
             && (!required.json_schema || self.json_schema)
             && (!required.web_search || self.web_search)
-            && (!(required.web_search && required.tool_call)
-                || self
-                    .web_search_with_tool_call
-                    .unwrap_or(self.web_search && self.tool_call))
+            && self
+                .unsupported_combination(required_features.as_slice())
+                .is_none()
             && (!required.vision || self.vision)
             && required
                 .min_context_tokens
@@ -378,15 +385,21 @@ impl ModelCapabilities {
         if required.web_search && !self.web_search {
             missing.push("web_search".to_string());
         }
-        if required.web_search
-            && required.tool_call
-            && self.web_search
-            && self.tool_call
-            && !self
-                .web_search_with_tool_call
-                .unwrap_or(self.web_search && self.tool_call)
+        let required_features = required.feature_names();
+        if let Some(combination) = self
+            .unsupported_combination(required_features.as_slice())
+            .filter(|combination| {
+                combination
+                    .iter()
+                    .all(|feature| self.supports_feature(feature))
+            })
         {
-            missing.push("web_search_with_tool_call".to_string());
+            let mut combination = combination.to_vec();
+            combination.sort();
+            missing.push(format!(
+                "unsupported_feature_combination:{}",
+                combination.join("+")
+            ));
         }
         if required.vision && !self.vision {
             missing.push("vision".to_string());
@@ -397,6 +410,57 @@ impl ModelCapabilities {
             }
         }
         missing
+    }
+
+    pub fn set_feature_combination_supported(&mut self, features: &[&str], supported: bool) {
+        let mut combination = features
+            .iter()
+            .map(|feature| feature.to_string())
+            .collect::<Vec<_>>();
+        combination.sort();
+        combination.dedup();
+        if combination.len() < 2 {
+            return;
+        }
+        self.unsupported_feature_combinations.retain(|existing| {
+            let mut existing = existing.clone();
+            existing.sort();
+            existing.dedup();
+            existing != combination
+        });
+        if !supported {
+            self.unsupported_feature_combinations.push(combination);
+        }
+    }
+
+    pub fn supports_feature_combination(&self, features: &[&str]) -> bool {
+        let features = features
+            .iter()
+            .map(|feature| feature.to_string())
+            .collect::<Vec<_>>();
+        self.unsupported_combination(features.as_slice()).is_none()
+    }
+
+    fn unsupported_combination(&self, required_features: &[String]) -> Option<&[String]> {
+        self.unsupported_feature_combinations
+            .iter()
+            .find(|combination| {
+                combination
+                    .iter()
+                    .all(|feature| required_features.iter().any(|required| required == feature))
+            })
+            .map(Vec::as_slice)
+    }
+
+    fn supports_feature(&self, feature: &str) -> bool {
+        match feature {
+            "streaming" => self.streaming,
+            "tool_calling" => self.tool_call,
+            "json_output" => self.json_schema,
+            "web_search" => self.web_search,
+            "vision" => self.vision,
+            _ => false,
+        }
     }
 }
 
@@ -414,6 +478,20 @@ pub struct RequiredModelFeatures {
     pub vision: bool,
     #[serde(default)]
     pub min_context_tokens: Option<u64>,
+}
+
+impl RequiredModelFeatures {
+    fn feature_names(&self) -> Vec<String> {
+        ModelRequirement {
+            streaming: self.streaming,
+            tool_call: self.tool_call,
+            json_schema: self.json_schema,
+            web_search: self.web_search,
+            vision: self.vision,
+            min_context_tokens: None,
+        }
+        .feature_names()
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -1479,7 +1557,7 @@ mod tests {
                 tool_call: true,
                 json_schema: true,
                 web_search: true,
-                web_search_with_tool_call: None,
+                unsupported_feature_combinations: vec![],
                 vision: false,
                 max_context_tokens: Some(128_000),
                 max_output_tokens: Some(16_384),
@@ -1515,7 +1593,7 @@ mod tests {
     }
 
     #[test]
-    fn combined_search_and_tool_call_requires_combination_capability() {
+    fn unsupported_feature_combination_rejects_matching_request() {
         let required = RequiredModelFeatures {
             web_search: true,
             tool_call: true,
@@ -1524,7 +1602,10 @@ mod tests {
         let capabilities = ModelCapabilities {
             web_search: true,
             tool_call: true,
-            web_search_with_tool_call: Some(false),
+            unsupported_feature_combinations: vec![vec![
+                "web_search".to_string(),
+                "tool_calling".to_string(),
+            ]],
             ..Default::default()
         };
 
@@ -1535,8 +1616,41 @@ mod tests {
                 tool_call: true,
                 ..Default::default()
             }),
-            vec!["web_search_with_tool_call"]
+            vec!["unsupported_feature_combination:tool_calling+web_search"]
         );
+    }
+
+    #[test]
+    fn unsupported_feature_combination_matches_only_the_complete_set() {
+        let mut capabilities = ModelCapabilities {
+            tool_call: true,
+            web_search: true,
+            vision: true,
+            ..Default::default()
+        };
+        capabilities
+            .set_feature_combination_supported(&["vision", "web_search", "tool_calling"], false);
+
+        assert!(capabilities.supports(&RequiredModelFeatures {
+            web_search: true,
+            tool_call: true,
+            ..Default::default()
+        }));
+        assert!(!capabilities.supports(&RequiredModelFeatures {
+            web_search: true,
+            tool_call: true,
+            vision: true,
+            ..Default::default()
+        }));
+
+        capabilities
+            .set_feature_combination_supported(&["tool_calling", "vision", "web_search"], true);
+        assert!(capabilities.supports(&RequiredModelFeatures {
+            web_search: true,
+            tool_call: true,
+            vision: true,
+            ..Default::default()
+        }));
     }
 
     #[test]

--- a/src/frame/aicc/src/model_types.rs
+++ b/src/frame/aicc/src/model_types.rs
@@ -337,6 +337,8 @@ pub struct ModelCapabilities {
     pub json_schema: bool,
     #[serde(default)]
     pub web_search: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_search_with_tool_call: Option<bool>,
     #[serde(default)]
     pub vision: bool,
     #[serde(default)]
@@ -351,6 +353,10 @@ impl ModelCapabilities {
             && (!required.tool_call || self.tool_call)
             && (!required.json_schema || self.json_schema)
             && (!required.web_search || self.web_search)
+            && (!(required.web_search && required.tool_call)
+                || self
+                    .web_search_with_tool_call
+                    .unwrap_or(self.web_search && self.tool_call))
             && (!required.vision || self.vision)
             && required
                 .min_context_tokens
@@ -371,6 +377,16 @@ impl ModelCapabilities {
         }
         if required.web_search && !self.web_search {
             missing.push("web_search".to_string());
+        }
+        if required.web_search
+            && required.tool_call
+            && self.web_search
+            && self.tool_call
+            && !self
+                .web_search_with_tool_call
+                .unwrap_or(self.web_search && self.tool_call)
+        {
+            missing.push("web_search_with_tool_call".to_string());
         }
         if required.vision && !self.vision {
             missing.push("vision".to_string());
@@ -1463,6 +1479,7 @@ mod tests {
                 tool_call: true,
                 json_schema: true,
                 web_search: true,
+                web_search_with_tool_call: None,
                 vision: false,
                 max_context_tokens: Some(128_000),
                 max_output_tokens: Some(16_384),
@@ -1495,6 +1512,31 @@ mod tests {
             web_search: true,
             ..Default::default()
         }));
+    }
+
+    #[test]
+    fn combined_search_and_tool_call_requires_combination_capability() {
+        let required = RequiredModelFeatures {
+            web_search: true,
+            tool_call: true,
+            ..Default::default()
+        };
+        let capabilities = ModelCapabilities {
+            web_search: true,
+            tool_call: true,
+            web_search_with_tool_call: Some(false),
+            ..Default::default()
+        };
+
+        assert!(!capabilities.supports(&required));
+        assert_eq!(
+            capabilities.explain_missing_requirements(&ModelRequirement {
+                web_search: true,
+                tool_call: true,
+                ..Default::default()
+            }),
+            vec!["web_search_with_tool_call"]
+        );
     }
 
     #[test]

--- a/src/frame/desktop/src/api/aicc_mgr.ts
+++ b/src/frame/desktop/src/api/aicc_mgr.ts
@@ -1599,10 +1599,9 @@ function toModelMetadata(
       tool_call: asBoolean(capabilities.tool_call, false),
       json_schema: asBoolean(capabilities.json_schema, false),
       web_search: asBoolean(capabilities.web_search, false),
-      web_search_with_tool_call:
-        typeof capabilities.web_search_with_tool_call === 'boolean'
-          ? capabilities.web_search_with_tool_call
-          : undefined,
+      unsupported_feature_combinations: toStringArrayArray(
+        capabilities.unsupported_feature_combinations,
+      ),
       vision: asBoolean(capabilities.vision, apiTypes.some((type) => type.startsWith('vision.'))),
       max_context_tokens: asOptionalNumber(capabilities.max_context_tokens),
       max_output_tokens: asOptionalNumber(capabilities.max_output_tokens),
@@ -2113,6 +2112,14 @@ function toApiTypes(value: unknown): ApiType[] {
 function toStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : []
+}
+
+function toStringArrayArray(value: unknown): string[][] {
+  return Array.isArray(value)
+    ? value
+        .map(toStringArray)
+        .filter((combination) => combination.length >= 2)
     : []
 }
 

--- a/src/frame/desktop/src/api/aicc_mgr.ts
+++ b/src/frame/desktop/src/api/aicc_mgr.ts
@@ -1599,6 +1599,10 @@ function toModelMetadata(
       tool_call: asBoolean(capabilities.tool_call, false),
       json_schema: asBoolean(capabilities.json_schema, false),
       web_search: asBoolean(capabilities.web_search, false),
+      web_search_with_tool_call:
+        typeof capabilities.web_search_with_tool_call === 'boolean'
+          ? capabilities.web_search_with_tool_call
+          : undefined,
       vision: asBoolean(capabilities.vision, apiTypes.some((type) => type.startsWith('vision.'))),
       max_context_tokens: asOptionalNumber(capabilities.max_context_tokens),
       max_output_tokens: asOptionalNumber(capabilities.max_output_tokens),

--- a/src/frame/desktop/src/app/ai-center/mock/types.ts
+++ b/src/frame/desktop/src/app/ai-center/mock/types.ts
@@ -47,6 +47,7 @@ export interface ModelMetadata {
     tool_call: boolean
     json_schema: boolean
     web_search: boolean
+    web_search_with_tool_call?: boolean
     vision: boolean
     max_context_tokens?: number
     max_output_tokens?: number

--- a/src/frame/desktop/src/app/ai-center/mock/types.ts
+++ b/src/frame/desktop/src/app/ai-center/mock/types.ts
@@ -47,7 +47,7 @@ export interface ModelMetadata {
     tool_call: boolean
     json_schema: boolean
     web_search: boolean
-    web_search_with_tool_call?: boolean
+    unsupported_feature_combinations?: string[][]
     vision: boolean
     max_context_tokens?: number
     max_output_tokens?: number


### PR DESCRIPTION
## 背景

Gemini Provider 的模型能力声明与驱动实际实现不一致：metadata 声明支持工具调用，却没有声明多数 Gemini LLM 已支持的 Google Search；同时驱动没有完整实现 Gemini 的函数声明、函数调用结果、Google Search grounding 和引用信息转换。

Jarvis 使用 Gemini 作为唯一 Provider 时，请求通常同时要求 `web_search` 和 `tool_calling`。旧实现会在路由阶段得到 `AICC_ROUTE_NO_CANDIDATE`，或者即使选中模型也无法完整执行工具调用流程。

## 本 PR 修复内容

### 1. 对齐 Gemini 模型能力 metadata

- 为实际支持 Google Search 的 Gemini LLM 声明 `web_search`。
- 保留并校准 `tool_calling` 等能力。
- 让动态发现的模型与内置 driver metadata 使用相同的能力规则。
- 根据模型实际能力区分 Gemini 2.5 与 Gemini 3 的工具组合限制。

### 2. 完整接入 Gemini 函数调用协议

- 将 AICC `AiToolSpec` 转换为 Gemini `functionDeclarations`。
- 将工具执行结果转换为 Gemini `functionResponse`。
- 将 Gemini 返回的 `functionCall` 规范化为 AICC `AiToolCall`。
- 保留函数调用 ID、函数名称和参数，支持多轮工具调用。

### 3. 接入 Google Search grounding

- 当请求要求 `web_search` 时注入 Gemini `googleSearch` built-in tool。
- 对支持组合工具的模型同时发送 `googleSearch` 与函数声明。
- 保留 Gemini 返回的 `groundingMetadata`，避免搜索引用信息在统一响应中丢失。

### 4. 使用 Gemini JSON Schema 字段

- 函数输入改用 `parametersJsonSchema`。
- 函数输出改用 `responseJsonSchema`。
- JSON Schema 原样透传，包括 `definitions`、`$ref`、`anyOf` 等标准结构，不再针对具体字段增加特殊处理。

### 5. 将能力组合限制建模为通用规则

- 删除 Provider 场景化的 `web_search_with_tool_call` 表达。
- 新增通用 `unsupported_feature_combinations` metadata 规则。
- 路由器按 feature 集合判断组合是否可用，不包含 Gemini 特殊分支。
- Gemini 2.5 可分别支持搜索和函数调用，但声明二者不可在同一请求中组合；Gemini 3 可同时使用。
- 同步更新 metadata schema 文档、Rust 共享类型及 Desktop TypeScript 类型。

## 关联 issue

- Closes #554

本 PR 只关联并修复 #554。以下近期问题不在本 PR 范围内：

- #553：旧 `complete` 示例调用不存在的方法。
- #555：TaskMgr 服务 token 生命周期与强制验签不一致。
- #558：OpenDAN 将正常中断或 Behavior 切换显示为“思考失败”。
- Jarvis 媒体附件使用相对路径导致交付失败的问题也不包含在本 PR 中。

## 验证

- `cargo test -p aicc`：全部通过。
- `git diff --check buckyos/beta2.2...HEAD`：通过。
- 实际日志验证：Gemini 3 Flash 能同时接收 `googleSearch` 与函数声明，并返回可被 AICC 规范化的函数调用。

## 影响范围

- AICC Gemini driver。
- driver metadata schema、解析与路由能力判断。
- Desktop 共享 metadata 类型。
- 不修改 Jarvis/OpenDAN 行为，不引入新依赖，不包含向前兼容分支。