### PR TITLE
fix(aicc): complete async video generation and Jarvis task feedback

### DIFF
--- a/doc/aicc/aicc_agent_cli_tools.md
+++ b/doc/aicc/aicc_agent_cli_tools.md
@@ -128,6 +128,11 @@ URL 输入通过 `--url` 或参数值的 URL scheme 识别，转换为：
 
 输出文件不存在时创建，存在时覆盖。CLI 不做交互确认，因为这些工具面向 Agent 自动化。
 
+异步任务返回 `running` 后，CLI 每 5 秒向 stderr 写一行结构化进度心跳：前缀为
+`__BUCKYOS_AGENT_PROGRESS__`，后面紧跟 JSON，包含协议版本、AICC method、stage、task_id
+和 elapsed_ms。stdout 仍只写最终 `AgentToolResult`。OpenDAN 消费心跳后更新会话状态，并在
+默认超时之外继续等待活跃任务；无心跳的普通命令仍使用原有超时规则。
+
 ### 2.5 退出码
 
 | code | 含义 |

--- a/doc/aicc/aicc_agent_cli_tools.md
+++ b/doc/aicc/aicc_agent_cli_tools.md
@@ -130,7 +130,9 @@ URL 输入通过 `--url` 或参数值的 URL scheme 识别，转换为：
 
 异步任务返回 `running` 后，CLI 每 5 秒向 stderr 写一行结构化进度心跳：前缀为
 `__BUCKYOS_AGENT_PROGRESS__`，后面紧跟 JSON，包含协议版本、AICC method、stage、task_id
-和 elapsed_ms。stdout 仍只写最终 `AgentToolResult`。OpenDAN 消费心跳后更新会话状态，并在
+和 elapsed_ms。stdout 仍只写最终 `AgentToolResult`。其中 `task_id` 是 TaskMgr 2.0 的正式
+任务 ID，CLI 通过 `get_task({ task_id })` 直接读取 `phase / outcome / result / error`，不通过
+`list_tasks` 或 AICC external id 反查。OpenDAN 消费心跳后更新会话状态，并在
 默认超时之外继续等待活跃任务；无心跳的普通命令仍使用原有超时规则。
 
 ### 2.5 退出码
@@ -659,7 +661,7 @@ http://127.0.0.1:3180/kapi/aicc
 AICC_ENDPOINT
 BUCKYOS_SESSION_TOKEN
 AICC_DEFAULT_PROFILE
-AICC_DEFAULT_TIMEOUT
+AICC_DEFAULT_TIMEOUT  # milliseconds; default 900000
 ```
 
 ### 10.3 JSON 输出契约

--- a/doc/aicc/aicc_api设计.md
+++ b/doc/aicc/aicc_api设计.md
@@ -127,7 +127,7 @@ AICC 不定义私有 Job API。长任务使用 `task-manager`：
 | AICC response | task-manager 是否创建 task | task-manager 状态 | `task_id` 来源 | `event_ref` 是否可订阅 |
 |---|---|---|---|---|
 | `status=succeeded` | 是 | `Completed` | AICC 外部 task id | 是，用于审计、最终结果和可观察数据。 |
-| `status=running` | 是 | `Pending` / `Running` | AICC 外部 task id | 是，用于进度、取消和最终结果。 |
+| `status=running` | 是 | `Accepted` / `Running` | TaskMgr 2.0 `task_id` | 是，用于进度、取消和最终结果。调用方直接使用 `get_task({ task_id })`，不扫描任务列表。 |
 | `status=failed` | best effort | `Failed` 或未创建 | AICC 诊断 id | 已创建 task 时可订阅；鉴权、反序列化、早期校验失败可直接返回 kRPC error。 |
 
 视频生成、音乐生成、大批量 embedding、长文件转录等默认走异步任务。

--- a/doc/aicc/aicc_provider_plan.md
+++ b/doc/aicc/aicc_provider_plan.md
@@ -35,12 +35,12 @@ P1 optional:
 
 | Provider Adapter | Credential                    | 定位                                             | 必须支持的 ApiType                                                                                                                                                                                                                                      |
 | ---------------- | ----------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `openai.rs`      | `OPENAI_API_KEY`              | 文本、embedding、图像编辑、ASR/TTS、rerank MVP           | `llm.chat`、`llm.completion` wrapper、`embedding.text`、`rerank`、`image.txt2img`、`image.img2img`、`image.inpaint`、`audio.asr`、`audio.tts`                                                                                                              |
+| `openai.rs`      | `OPENAI_API_KEY`              | 文本、视觉理解、embedding、图像编辑、ASR/TTS、rerank MVP     | `llm.chat`、`llm.completion` wrapper、`vision.caption`、`vision.ocr`、`embedding.text`、`rerank`、`image.txt2img`、`image.img2img`、`image.inpaint`、`audio.asr`、`audio.tts`                                                                                  |
 | `claude.rs`      | `ANTHROPIC_API_KEY`           | 主流 LLM 与视觉理解 fallback                          | `llm.chat`、`vision.caption`、`vision.ocr`                                                                                                                                                                                                           |
 | `google.rs`      | `GOOGLE_API_KEY` / Gemini key | 多模态主力 provider，覆盖 embedding、vision、music、video | `llm.chat`、`embedding.text`、`embedding.multimodal`、`image.txt2img`、`image.img2img`、`vision.ocr`、`vision.caption`、`vision.detect`、`vision.segment`、`audio.tts`、`audio.music`、`video.txt2video`、`video.img2video`、`video.video2video`、`video.extend` |
 | `fal.rs`         | `FAL_KEY`                     | 专用媒体处理工具 provider                              | `image.upscale`、`image.bg_remove`、`audio.enhance`、`video.upscale`                                                                                                                                                                                  |
 
-OpenAI 负责 `embedding.text`、图像生成/编辑、mask inpaint、ASR、TTS 等通用能力；OpenAI 文档中已有 `text-embedding-3-*` embedding 示例，GPT Image 支持生成和编辑图片，image edit 也支持 mask，Audio API 支持 speech-to-text 和 text-to-speech。([OpenAI开发者][1])
+OpenAI 负责 `vision.caption`、`vision.ocr`、`embedding.text`、图像生成/编辑、mask inpaint、ASR、TTS 等通用能力；支持图片输入的 GPT 模型通过现有多模态 LLM 请求完成 caption 和 OCR。OpenAI 文档中已有 `text-embedding-3-*` embedding 示例，GPT Image 支持生成和编辑图片，image edit 也支持 mask，Audio API 支持 speech-to-text 和 text-to-speech。([OpenAI开发者][1])
 
 Google 是本方案的多模态主力：Gemini Embedding 2 支持 text、image、video、audio、document 映射到同一 embedding space；Gemini 图像能力支持 text-to-image 和 text+image-to-image 编辑；Gemini image understanding 支持 bounding boxes 和 segmentation 示例；Gemini API 也支持 TTS、Lyria 3 音乐生成、Veo 3.1 视频生成、图生视频、video-to-video 和 extend。([Google AI for Developers][2])
 
@@ -65,7 +65,7 @@ fal.ai 只用于通用大模型不擅长的专用媒体处理：ESRGAN 负责 im
 | `image`     | `image.upscale`        | fal.ai                   | `fal-ai/esrgan`                                            |
 | `image`     | `image.bg_remove`      | fal.ai                   | `fal-ai/imageutils/rembg`                                  |
 | `vision`    | `vision.ocr`           | Google                   | Claude / OpenAI vision 可 fallback                          |
-| `vision`    | `vision.caption`       | Google / Claude          | Claude 适合通用视觉理解 fallback                                   |
+| `vision`    | `vision.caption`       | Google / Claude          | Claude / OpenAI 适合通用视觉理解 fallback                          |
 | `vision`    | `vision.detect`        | Google                   | 使用 bounding box / spatial understanding                    |
 | `vision`    | `vision.segment`       | Google                   | 使用 segmentation masks 能力                                   |
 | `audio`     | `audio.asr`            | OpenAI                   | `audio/transcriptions`                                     |
@@ -89,6 +89,8 @@ fal.ai 只用于通用大模型不擅长的专用媒体处理：ESRGAN 负责 im
 ```text
 llm.chat
 llm.completion        # system-level wrapper to chat
+vision.caption
+vision.ocr
 embedding.text
 rerank                # MVP: LLM structured rerank
 image.txt2img

--- a/doc/aicc/aicc_provider_plan.md
+++ b/doc/aicc/aicc_provider_plan.md
@@ -72,8 +72,8 @@ fal.ai 只用于通用大模型不擅长的专用媒体处理：ESRGAN 负责 im
 | `audio`     | `audio.tts`            | OpenAI / Google          | OpenAI speech 或 Gemini TTS                                 |
 | `audio`     | `audio.music`          | Google                   | Lyria 3                                                    |
 | `audio`     | `audio.enhance`        | fal.ai                   | `fal-ai/deepfilternet3`                                    |
-| `video`     | `video.txt2video`      | Google                   | Veo 3.1                                                    |
-| `video`     | `video.img2video`      | Google                   | Veo 3.1 image-to-video                                     |
+| `video`     | `video.txt2video`      | Google / OpenAI          | Veo 3.1；OpenAI Sora 2 fallback                            |
+| `video`     | `video.img2video`      | Google / OpenAI          | Veo 3.1 / Sora 2 image-to-video                            |
 | `video`     | `video.video2video`    | Google                   | Veo 3.1 支持 video-to-video 输入模式                             |
 | `video`     | `video.extend`         | Google                   | Veo 3.1 extend；需要保留 `continuation_handle`                  |
 | `video`     | `video.upscale`        | fal.ai                   | `fal-ai/video-upscaler`                                    |
@@ -96,6 +96,8 @@ image.img2img
 image.inpaint
 audio.asr
 audio.tts
+video.txt2video
+video.img2video
 ```
 
 说明：
@@ -103,7 +105,8 @@ audio.tts
 * `llm.completion` 不接旧 Completion API，统一转成 chat message。
 * `rerank` 是 MVP 实现，使用 LLM 对候选文档输出 structured scores；不是 native rerank model。
 * `image.inpaint` 使用 OpenAI image edit + mask。
-* 不要求 OpenAI 承担视频主路由。
+* OpenAI 视频使用 Sora 2 / Sora 2 Pro 的 `/v1/videos` 异步任务 API，仅作为 Veo 之外的候选。
+* Sora 2 和 Videos API 已由 OpenAI 标记废弃，计划于 2026-09-24 下线；后续替代模型必须通过 driver metadata 和 adapter 协议同步更新。
 
 ---
 

--- a/src/frame/aicc/Cargo.toml
+++ b/src/frame/aicc/Cargo.toml
@@ -20,6 +20,7 @@ http = { workspace = true }
 http-body-util = { workspace = true } 
 buckyos-http-server = { workspace = true }
 reqwest = { workspace = true }
+image = { version = "0.25.5", default-features = false, features = ["jpeg", "png", "webp"] }
 buckyos-api = { path = "../../kernel/buckyos-api" }
 name-lib = { workspace = true }
 ndn-lib = { workspace = true }

--- a/src/frame/aicc/driver_metadata/gemini.json
+++ b/src/frame/aicc/driver_metadata/gemini.json
@@ -47,12 +47,16 @@
     },
     {
       "id": "veo-3.1-generate-preview",
-      "api_types": ["video.txt2video"],
+      "api_types": ["video.txt2video", "video.img2video"],
       "logical_mounts": [
         "video.txt2video",
         "video.txt2video.google",
         "video.txt2video.gemini",
-        "video.txt2video.{model}"
+        "video.txt2video.{model}",
+        "video.img2video",
+        "video.img2video.google",
+        "video.img2video.gemini",
+        "video.img2video.{model}"
       ],
       "pricing": {
         "currency": "USD",
@@ -103,12 +107,16 @@
     },
     {
       "pattern": "veo-*",
-      "api_types": ["video.txt2video"],
+      "api_types": ["video.txt2video", "video.img2video"],
       "logical_mounts": [
         "video.txt2video",
         "video.txt2video.google",
         "video.txt2video.gemini",
-        "video.txt2video.{model}"
+        "video.txt2video.{model}",
+        "video.img2video",
+        "video.img2video.google",
+        "video.img2video.gemini",
+        "video.img2video.{model}"
       ],
       "pricing": {
         "currency": "USD",

--- a/src/frame/aicc/driver_metadata/openai.json
+++ b/src/frame/aicc/driver_metadata/openai.json
@@ -7,6 +7,40 @@
   "required_features": [],
   "models": [
     {
+      "id": "sora-2",
+      "api_types": ["video.txt2video", "video.img2video"],
+      "logical_mounts": [
+        "video.txt2video",
+        "video.txt2video.{driver}",
+        "video.txt2video.{model}",
+        "video.img2video",
+        "video.img2video.{driver}",
+        "video.img2video.{model}"
+      ],
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.4
+      },
+      "estimated_latency_ms": 120000
+    },
+    {
+      "id": "sora-2-pro",
+      "api_types": ["video.txt2video", "video.img2video"],
+      "logical_mounts": [
+        "video.txt2video",
+        "video.txt2video.{driver}",
+        "video.txt2video.{model}",
+        "video.img2video",
+        "video.img2video.{driver}",
+        "video.img2video.{model}"
+      ],
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 1.2
+      },
+      "estimated_latency_ms": 180000
+    },
+    {
       "id": "gpt-image-1",
       "api_types": ["image.txt2img", "image.img2img", "image.inpaint"],
       "logical_mounts": [
@@ -109,6 +143,23 @@
     }
   ],
   "patterns": [
+    {
+      "pattern": "sora-*",
+      "api_types": ["video.txt2video", "video.img2video"],
+      "logical_mounts": [
+        "video.txt2video",
+        "video.txt2video.{driver}",
+        "video.txt2video.{model}",
+        "video.img2video",
+        "video.img2video.{driver}",
+        "video.img2video.{model}"
+      ],
+      "pricing": {
+        "currency": "USD",
+        "estimated_cost": 0.4
+      },
+      "estimated_latency_ms": 120000
+    },
     {
       "pattern": "*transcribe*",
       "api_types": ["audio.asr"],

--- a/src/frame/aicc/driver_metadata/openai.json
+++ b/src/frame/aicc/driver_metadata/openai.json
@@ -231,19 +231,26 @@
     },
     {
       "pattern": "gpt-*",
-      "api_types": ["llm", "rerank"],
+      "api_types": ["llm", "rerank", "vision.ocr", "vision.caption"],
       "logical_mounts": [
         "llm.{driver}",
         "llm.openai.{model}",
         "rerank",
         "rerank.openai",
-        "rerank.{model}"
+        "rerank.{model}",
+        "vision.ocr",
+        "vision.ocr.{driver}",
+        "vision.ocr.{model}",
+        "vision.caption",
+        "vision.caption.{driver}",
+        "vision.caption.{model}"
       ],
       "capabilities": {
         "streaming": true,
         "tool_call": true,
         "json_schema": true,
         "web_search": true,
+        "vision": true,
         "max_context_tokens": 128000,
         "max_output_tokens": 8192
       },

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -4436,12 +4436,12 @@ impl AIComputeCenter {
                     external_task_id.as_str(),
                     invoke_ctx.tenant_id.as_str(),
                     instance_id.as_str(),
-                    task_mgr_id,
+                    task_mgr_id.clone(),
                 );
                 self.emit_task_started(event_sink, external_task_id.as_str(), instance_id.as_str())
                     .await;
                 Ok(AiMethodResponse::new(
-                    external_task_id,
+                    task_mgr_id,
                     AiMethodStatus::Running,
                     None,
                     event_ref,
@@ -4469,12 +4469,12 @@ impl AIComputeCenter {
                     external_task_id.as_str(),
                     invoke_ctx.tenant_id.as_str(),
                     instance_id.as_str(),
-                    task_mgr_id,
+                    task_mgr_id.clone(),
                 );
                 self.emit_task_queued(event_sink, external_task_id.as_str(), position)
                     .await;
                 Ok(AiMethodResponse::new(
-                    external_task_id,
+                    task_mgr_id,
                     AiMethodStatus::Running,
                     None,
                     event_ref,
@@ -4510,12 +4510,17 @@ impl AIComputeCenter {
             invoke_ctx.tenant_id, invoke_ctx.caller_app_id, task_id
         );
 
-        let binding = self
-            .task_bindings
-            .read()
-            .ok()
-            .and_then(|bindings| bindings.get(task_id).cloned());
-        let Some(binding) = binding else {
+        let binding = self.task_bindings.read().ok().and_then(|bindings| {
+            bindings
+                .get_key_value(task_id)
+                .or_else(|| {
+                    bindings
+                        .iter()
+                        .find(|(_, item)| item.task_mgr_id == task_id)
+                })
+                .map(|(external_task_id, item)| (external_task_id.clone(), item.clone()))
+        });
+        let Some((external_task_id, binding)) = binding else {
             return Ok(CancelResponse::new(task_id.to_string(), false));
         };
 
@@ -4530,11 +4535,14 @@ impl AIComputeCenter {
             return Ok(CancelResponse::new(task_id.to_string(), false));
         };
 
-        let accepted = provider.cancel(invoke_ctx.clone(), task_id).await.is_ok();
+        let accepted = provider
+            .cancel(invoke_ctx.clone(), external_task_id.as_str())
+            .await
+            .is_ok();
         if accepted {
             if let Ok(taskmgr) = self.acquire_task_manager_client(&invoke_ctx).await {
                 let event = TaskEvent {
-                    task_id: task_id.to_string(),
+                    task_id: external_task_id.clone(),
                     kind: TaskEventKind::CancelRequested,
                     timestamp_ms: now_ms(),
                     data: Some(json!({
@@ -4564,7 +4572,7 @@ impl AIComputeCenter {
                 }
             }
             if let Ok(mut bindings) = self.task_bindings.write() {
-                bindings.remove(task_id);
+                bindings.remove(external_task_id.as_str());
             }
         }
         Ok(CancelResponse::new(task_id.to_string(), accepted))
@@ -5474,7 +5482,7 @@ pub(crate) async fn emit_background_provider_result(
                     kind: TaskEventKind::Final,
                     timestamp_ms: now_ms(),
                     data: Some(json!({
-                        "summary": summary,
+                        "summary": redacted_summary_value(&summary),
                         "finish_reason": finish_reason,
                         "has_text": has_text,
                         "artifact_count": artifact_count
@@ -6141,6 +6149,10 @@ mod tests {
             self.shutdown_call_count.load(AtomicOrdering::Relaxed)
         }
 
+        fn canceled_ids(&self) -> Vec<String> {
+            self.canceled.lock().unwrap().clone()
+        }
+
         fn with_refresh_inventory(mut self, inventory: ProviderInventory) -> Self {
             self.refresh_inventory = Some(inventory);
             self
@@ -6409,6 +6421,47 @@ mod tests {
         assert!(!logged.contains("def456"));
         assert!(!logged.contains("ghi789"));
         assert!(!logged.contains(&"a".repeat(LOG_BASE64_LIKE_MIN_CHARS)));
+    }
+
+    #[test]
+    fn async_final_task_data_redacts_provider_inline_data() {
+        let request = base_request();
+        let mut data = build_initial_aicc_task_data(
+            &request,
+            "aicc-redaction-test",
+            None,
+            &InvokeCtx::default(),
+        );
+        let event = TaskEvent {
+            task_id: "aicc-redaction-test".to_string(),
+            kind: TaskEventKind::Final,
+            timestamp_ms: 1,
+            data: Some(json!({
+                "summary": redacted_summary_value(&AiResponse {
+                    extra: Some(json!({
+                        "provider_io": {
+                            "input": {
+                                "contents": [{
+                                    "parts": [{
+                                        "inlineData": {
+                                            "mimeType": "image/jpeg",
+                                            "data": "raw-image-base64"
+                                        }
+                                    }]
+                                }]
+                            }
+                        }
+                    })),
+                    ..Default::default()
+                })
+            })),
+        };
+
+        merge_task_data_with_event(&mut data, &event);
+
+        let encoded = serde_json::to_string(&data).expect("serialize task data");
+        assert!(!encoded.contains("raw-image-base64"));
+        assert!(encoded.contains("[redacted_base64] len=16"));
     }
 
     #[test]
@@ -6866,11 +6919,10 @@ mod tests {
         assert!(!response.task_id.is_empty());
 
         let taskmgr = center.taskmgr.as_ref().expect("task manager").clone();
-        let tasks = all_tasks(&taskmgr).await;
-        let task = tasks
-            .into_iter()
-            .find(|item| aicc_external_task_id(item).as_deref() == Some(response.task_id.as_str()))
-            .expect("running response should persist task");
+        let task = taskmgr
+            .get_task(&response.task_id)
+            .await
+            .expect("running response should return the task-manager task id");
         assert_eq!(task.phase, TaskPhase::Running);
         assert_eq!(
             task.message.as_deref(),
@@ -6907,11 +6959,10 @@ mod tests {
         assert_eq!(response.status, AiMethodStatus::Running);
 
         let taskmgr = center.taskmgr.as_ref().expect("task manager").clone();
-        let tasks = all_tasks(&taskmgr).await;
-        let task = tasks
-            .into_iter()
-            .find(|item| aicc_external_task_id(item).as_deref() == Some(response.task_id.as_str()))
-            .expect("queued response should persist task");
+        let task = taskmgr
+            .get_task(&response.task_id)
+            .await
+            .expect("queued response should return the task-manager task id");
 
         assert_eq!(task.phase, TaskPhase::Accepted);
         assert_eq!(task.message.as_deref(), Some(QUEUE_STATUS_QUEUED));
@@ -6967,11 +7018,10 @@ mod tests {
             .expect("complete should succeed");
         assert_eq!(response.status, AiMethodStatus::Running);
 
-        let tasks = all_tasks(&taskmgr).await;
-        let task = tasks
-            .into_iter()
-            .find(|item| aicc_external_task_id(item).as_deref() == Some(response.task_id.as_str()))
-            .expect("aicc task should exist");
+        let task = taskmgr
+            .get_task(&response.task_id)
+            .await
+            .expect("running response should return the task-manager task id");
         assert_eq!(task.parent_id, Some(parent_task.task_id.clone()));
     }
 
@@ -7008,11 +7058,10 @@ mod tests {
         assert_eq!(response.status, AiMethodStatus::Running);
 
         let taskmgr = center.taskmgr.as_ref().expect("task manager").clone();
-        let tasks = all_tasks(&taskmgr).await;
-        let task = tasks
-            .into_iter()
-            .find(|item| aicc_external_task_id(item).as_deref() == Some(response.task_id.as_str()))
-            .expect("aicc task should exist");
+        let task = taskmgr
+            .get_task(&response.task_id)
+            .await
+            .expect("running response should return the task-manager task id");
         // Free-form root ids are gone in 2.0; the session id still rides in
         // the immutable request payload.
         assert_eq!(task.root_id, task.task_id);
@@ -7211,5 +7260,47 @@ mod tests {
             cancel_result.unwrap_err(),
             RPCErrors::NoPermission(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn cancel_with_task_manager_id_uses_provider_task_id() {
+        let registry = Registry::default();
+        let catalog = ModelCatalog::default();
+        catalog.set_mapping(
+            Capability::Llm,
+            "llm.plan.default",
+            "provider-a",
+            "gpt-4o-mini",
+        );
+        let provider = Arc::new(MockProvider::new(
+            mock_instance("provider-a-1", "provider-a"),
+            cost(0.001, 100),
+            vec![Ok(ProviderStartResult::Started)],
+        ));
+        registry.add_provider(provider.clone());
+        let center = center_with_taskmgr(registry, catalog);
+        let ctx = RPCContext {
+            token: Some("tenant-alice".to_string()),
+            ..Default::default()
+        };
+
+        let response = center.complete(base_request(), ctx.clone()).await.unwrap();
+        let task = center
+            .taskmgr
+            .as_ref()
+            .unwrap()
+            .get_task(&response.task_id)
+            .await
+            .unwrap();
+        let external_task_id = aicc_external_task_id(&task).unwrap();
+
+        let canceled = center
+            .handle_cancel(response.task_id.as_str(), ctx)
+            .await
+            .unwrap();
+
+        assert!(canceled.accepted);
+        assert_ne!(external_task_id, response.task_id);
+        assert_eq!(provider.canceled_ids(), vec![external_task_id]);
     }
 }

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -2137,6 +2137,7 @@ fn method_for_route_api_type(api_type: &str) -> std::result::Result<&'static str
         "audio.asr" | "audio.transcriptions.create" => Ok(ai_methods::AUDIO_ASR),
         "audio.tts" | "audio.speech.create" => Ok(ai_methods::AUDIO_TTS),
         "video.txt2video" | "videos.generate" => Ok(ai_methods::VIDEO_TXT2VIDEO),
+        "video.img2video" => Ok(ai_methods::VIDEO_IMG2VIDEO),
         other => Err(reason_error(
             "invalid_request",
             format!("unsupported api_type '{}'", other),

--- a/src/frame/aicc/src/aicc.rs
+++ b/src/frame/aicc/src/aicc.rs
@@ -130,6 +130,7 @@ pub struct InvokeCtx {
     pub caller_app_id: Option<String>,
     pub session_token: Option<String>,
     pub trace_id: Option<String>,
+    pub task_id: Option<String>,
 }
 
 impl InvokeCtx {
@@ -158,6 +159,7 @@ impl InvokeCtx {
             caller_app_id,
             session_token,
             trace_id: ctx.trace_id.clone(),
+            task_id: None,
         }
     }
 }
@@ -4176,7 +4178,7 @@ impl AIComputeCenter {
         mut request: AiMethodRequest,
         rpc_ctx: RPCContext,
     ) -> std::result::Result<AiMethodResponse, RPCErrors> {
-        let invoke_ctx = InvokeCtx::from_rpc(&rpc_ctx);
+        let mut invoke_ctx = InvokeCtx::from_rpc(&rpc_ctx);
         apply_default_features_for_method(method, &mut request);
         info!(
             "aicc.complete received: tenant={} caller_app={:?} method={} capability={:?} model_alias={} idempotency_key={:?}",
@@ -4188,6 +4190,7 @@ impl AIComputeCenter {
             request.idempotency_key
         );
         let external_task_id = self.generate_task_id();
+        invoke_ctx.task_id = Some(external_task_id.clone());
         let base_sink = self.sink_factory.build(&invoke_ctx, &external_task_id);
         let event_ref = base_sink.event_ref();
         let deferred_sink = Arc::new(DeferredTaskEventSink::new(base_sink));
@@ -5363,7 +5366,7 @@ struct StoredNamedArtifact {
     height: Option<u32>,
 }
 
-async fn materialize_response_artifacts_if_needed(
+pub(crate) async fn materialize_response_artifacts_if_needed(
     task_id: &str,
     req: &AiMethodRequest,
     summary: &mut AiResponse,
@@ -5440,6 +5443,61 @@ async fn materialize_response_artifacts_if_needed(
         append_materialized_artifact_extra(summary, materialized);
     }
     Ok(count)
+}
+
+pub(crate) async fn emit_background_provider_result(
+    sink: Arc<dyn TaskEventSink>,
+    task_id: &str,
+    request: &AiMethodRequest,
+    result: std::result::Result<AiResponse, ProviderError>,
+) {
+    let event = match result {
+        Ok(mut summary) => {
+            if let Err(error) =
+                materialize_response_artifacts_if_needed(task_id, request, &mut summary).await
+            {
+                TaskEvent {
+                    task_id: task_id.to_string(),
+                    kind: TaskEventKind::Error,
+                    timestamp_ms: now_ms(),
+                    data: Some(json!({
+                        "code": "artifact_materialize_failed",
+                        "message": format!("materialize artifact failed: {}", error)
+                    })),
+                }
+            } else {
+                let has_text = !summary.text_content().is_empty();
+                let artifact_count = summary.artifacts().len();
+                let finish_reason = summary.finish_reason.clone();
+                TaskEvent {
+                    task_id: task_id.to_string(),
+                    kind: TaskEventKind::Final,
+                    timestamp_ms: now_ms(),
+                    data: Some(json!({
+                        "summary": summary,
+                        "finish_reason": finish_reason,
+                        "has_text": has_text,
+                        "artifact_count": artifact_count
+                    })),
+                }
+            }
+        }
+        Err(error) => TaskEvent {
+            task_id: task_id.to_string(),
+            kind: TaskEventKind::Error,
+            timestamp_ms: now_ms(),
+            data: Some(json!({
+                "code": "provider_error",
+                "message": error.to_string()
+            })),
+        },
+    };
+    if let Err(error) = sink.emit(event).await {
+        error!(
+            "aicc.background_provider_event_failed task_id={} err={}",
+            task_id, error
+        );
+    }
 }
 
 async fn store_base64_artifact(

--- a/src/frame/aicc/src/fal.rs
+++ b/src/frame/aicc/src/fal.rs
@@ -1,6 +1,7 @@
 use crate::aicc::{
-    provider_type_from_settings, redacted_json_log, AIComputeCenter, Provider, ProviderError,
-    ProviderInstance, ProviderRefreshTask, ProviderStartResult, ResolvedRequest, TaskEventSink,
+    emit_background_provider_result, provider_type_from_settings, redacted_json_log,
+    AIComputeCenter, Provider, ProviderError, ProviderInstance, ProviderRefreshTask,
+    ProviderStartResult, ResolvedRequest, TaskEventSink,
 };
 use crate::metadata_resolver::{resolve_driver_inventory, DriverModelResolveRequest};
 use crate::model_registry::DEFAULT_INVENTORY_REFRESH_INTERVAL;
@@ -579,13 +580,10 @@ impl Provider for FalProvider {
         ctx: crate::aicc::InvokeCtx,
         provider_model: String,
         req: ResolvedRequest,
-        _sink: Arc<dyn TaskEventSink>,
+        sink: Arc<dyn TaskEventSink>,
     ) -> std::result::Result<ProviderStartResult, ProviderError> {
         match req.method.as_str() {
-            ai_methods::IMAGE_UPSCALE
-            | ai_methods::IMAGE_BG_REMOVE
-            | ai_methods::AUDIO_ENHANCE
-            | ai_methods::VIDEO_UPSCALE => {
+            ai_methods::IMAGE_UPSCALE | ai_methods::IMAGE_BG_REMOVE | ai_methods::AUDIO_ENHANCE => {
                 self.run_method(
                     &ctx,
                     req.method.as_str(),
@@ -593,6 +591,34 @@ impl Provider for FalProvider {
                     &req.request,
                 )
                 .await
+            }
+            ai_methods::VIDEO_UPSCALE => {
+                let provider = self.clone();
+                let task_id = ctx
+                    .task_id
+                    .clone()
+                    .unwrap_or_else(|| "fal-video-upscale".to_string());
+                let request = req.request;
+                tokio::spawn(async move {
+                    let result = match provider
+                        .run_method(
+                            &ctx,
+                            ai_methods::VIDEO_UPSCALE,
+                            provider_model.as_str(),
+                            &request,
+                        )
+                        .await
+                    {
+                        Ok(ProviderStartResult::Immediate(summary)) => Ok(summary),
+                        Ok(other) => Err(ProviderError::fatal(format!(
+                            "fal video upscale returned unexpected start result: {:?}",
+                            other
+                        ))),
+                        Err(error) => Err(error),
+                    };
+                    emit_background_provider_result(sink, task_id.as_str(), &request, result).await;
+                });
+                Ok(ProviderStartResult::Started)
             }
             method => Err(ProviderError::fatal(format!(
                 "fal provider does not support method '{}'",

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -1,6 +1,7 @@
 use crate::aicc::{
-    provider_type_from_settings, redacted_json_log, AIComputeCenter, Provider, ProviderError,
-    ProviderInstance, ProviderRefreshTask, ProviderStartResult, ResolvedRequest, TaskEventSink,
+    emit_background_provider_result, provider_type_from_settings, redacted_json_log,
+    AIComputeCenter, Provider, ProviderError, ProviderInstance, ProviderRefreshTask,
+    ProviderStartResult, ResolvedRequest, TaskEventSink,
 };
 use crate::metadata_resolver::{resolve_driver_inventory, DriverModelResolveRequest};
 use crate::model_types::{
@@ -99,7 +100,7 @@ pub struct GoogleGeminiInstanceConfig {
     pub alias_map: HashMap<String, String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GoogleGeminiProvider {
     instance: ProviderInstance,
     inventory: Arc<RwLock<ProviderInventory>>,
@@ -2402,6 +2403,7 @@ impl GoogleGeminiProvider {
         provider_model: &str,
         method: &str,
         req: &AiMethodRequest,
+        sink: Arc<dyn TaskEventSink>,
     ) -> Result<ProviderStartResult, ProviderError> {
         if method == ai_methods::VIDEO_IMG2VIDEO
             && req.payload.resources.is_empty()
@@ -2483,7 +2485,43 @@ impl GoogleGeminiProvider {
                 ProviderError::fatal("google gemini video response is missing operation name")
             })?
             .to_string();
-        let mut operation = body;
+
+        let provider = self.clone();
+        let task_id = ctx
+            .task_id
+            .clone()
+            .unwrap_or_else(|| operation_name.clone());
+        let provider_model = provider_model.to_string();
+        let method = method.to_string();
+        let request = req.clone();
+        tokio::spawn(async move {
+            let result = provider
+                .finish_video(
+                    provider_model.as_str(),
+                    method.as_str(),
+                    operation_name,
+                    body,
+                    request_obj,
+                    started_at,
+                    latency_ms,
+                )
+                .await;
+            emit_background_provider_result(sink, task_id.as_str(), &request, result).await;
+        });
+
+        Ok(ProviderStartResult::Started)
+    }
+
+    async fn finish_video(
+        &self,
+        provider_model: &str,
+        method: &str,
+        operation_name: String,
+        mut operation: Value,
+        request_obj: Map<String, Value>,
+        started_at: std::time::Instant,
+        latency_ms: u64,
+    ) -> Result<AiResponse, ProviderError> {
         loop {
             if let Some(error) = operation.get("error") {
                 let message = error
@@ -2570,13 +2608,13 @@ impl GoogleGeminiProvider {
             "provider_io".to_string(),
             json!({ "input": request_obj, "output": operation }),
         );
-        Ok(ProviderStartResult::Immediate(AiResponse {
+        Ok(AiResponse {
             message: AiResponse::message_from_parts(None, vec![], vec![artifact]),
             provider_task_ref: Some(operation_name),
             finish_reason: Some("stop".to_string()),
             extra: Some(Value::Object(extra)),
             ..Default::default()
-        }))
+        })
     }
 }
 
@@ -2662,7 +2700,7 @@ impl Provider for GoogleGeminiProvider {
         ctx: crate::aicc::InvokeCtx,
         provider_model: String,
         req: ResolvedRequest,
-        _sink: Arc<dyn TaskEventSink>,
+        sink: Arc<dyn TaskEventSink>,
     ) -> std::result::Result<ProviderStartResult, ProviderError> {
         match req.method.as_str() {
             ai_methods::LLM_CHAT => {
@@ -2715,6 +2753,7 @@ impl Provider for GoogleGeminiProvider {
                     provider_model.as_str(),
                     req.method.as_str(),
                     &req.request,
+                    sink,
                 )
                 .await
             }

--- a/src/frame/aicc/src/gemini.rs
+++ b/src/frame/aicc/src/gemini.rs
@@ -36,6 +36,8 @@ const DEFAULT_GEMINI_TTS_MODELS: &str = "gemini-2.5-flash-preview-tts";
 const DEFAULT_GEMINI_MUSIC_MODELS: &str = "lyria-002";
 const DEFAULT_GEMINI_VIDEO_MODELS: &str = "veo-3.1-generate-preview";
 const DEFAULT_GEMINI_INVENTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+const GEMINI_VIDEO_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const GEMINI_VIDEO_MAX_WAIT: Duration = Duration::from_secs(600);
 const GEMINI_MODELS_PAGE_SIZE: u32 = 1000;
 const GEMINI_MODELS_MAX_PAGES: usize = 10;
 const GEMINI_IMAGE_INPUT_ALLOWLIST: &[&str] = &[
@@ -73,6 +75,7 @@ const GEMINI_VIDEO_PARAMETER_ALLOWLIST: &[&str] = &[
     "duration_seconds",
     "negative_prompt",
     "person_generation",
+    "resolution",
     "sample_count",
     "seed",
 ];
@@ -1469,6 +1472,7 @@ impl GoogleGeminiProvider {
             "duration_seconds" | "durationSeconds" => Some("durationSeconds"),
             "negative_prompt" | "negativePrompt" => Some("negativePrompt"),
             "person_generation" | "personGeneration" => Some("personGeneration"),
+            "resolution" => Some("resolution"),
             "sample_count" | "sampleCount" => Some("sampleCount"),
             "seed" => Some("seed"),
             _ => None,
@@ -1666,6 +1670,84 @@ impl GoogleGeminiProvider {
             )
         })?;
         Ok((status, body, latency_ms))
+    }
+
+    async fn get_video_operation(
+        &self,
+        operation_name: &str,
+    ) -> Result<(StatusCode, Value), ProviderError> {
+        let url = if operation_name.starts_with("http://") || operation_name.starts_with("https://")
+        {
+            operation_name.to_string()
+        } else {
+            format!(
+                "{}/{}",
+                self.base_url,
+                operation_name.trim_start_matches('/')
+            )
+        };
+        let response = self
+            .client
+            .get(url)
+            .header("x-goog-api-key", self.api_token.as_str())
+            .send()
+            .await
+            .map_err(|err| {
+                ProviderError::fatal(format!(
+                    "google gemini video status request failed: {}",
+                    err
+                ))
+            })?;
+        let status = response.status();
+        let body = response.json::<Value>().await.map_err(|err| {
+            ProviderError::fatal(format!(
+                "failed to parse google gemini video status response: {}",
+                err
+            ))
+        })?;
+        Ok((status, body))
+    }
+
+    async fn download_video(
+        &self,
+        url: &str,
+    ) -> Result<(StatusCode, Vec<u8>, String), ProviderError> {
+        let url = if url.starts_with("http://") || url.starts_with("https://") {
+            url.to_string()
+        } else {
+            format!("{}/{}", self.base_url, url.trim_start_matches('/'))
+        };
+        let response = self
+            .client
+            .get(url)
+            .header("x-goog-api-key", self.api_token.as_str())
+            .send()
+            .await
+            .map_err(|err| {
+                ProviderError::fatal(format!("google gemini video download failed: {}", err))
+            })?;
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("video/mp4")
+            .to_string();
+        let bytes = response.bytes().await.map_err(|err| {
+            ProviderError::fatal(format!(
+                "failed to read google gemini video content: {}",
+                err
+            ))
+        })?;
+        Ok((status, bytes.to_vec(), content_type))
+    }
+
+    fn video_uri(operation: &Value) -> Option<&str> {
+        operation
+            .pointer("/response/generateVideoResponse/generatedSamples/0/video/uri")
+            .or_else(|| operation.pointer("/response/generatedVideos/0/video/uri"))
+            .or_else(|| operation.pointer("/response/generated_videos/0/video/uri"))
+            .and_then(|value| value.as_str())
     }
 
     fn resource_from_input_json(req: &AiMethodRequest, keys: &[&str]) -> Option<ResourceRef> {
@@ -2321,6 +2403,14 @@ impl GoogleGeminiProvider {
         method: &str,
         req: &AiMethodRequest,
     ) -> Result<ProviderStartResult, ProviderError> {
+        if method == ai_methods::VIDEO_IMG2VIDEO
+            && req.payload.resources.is_empty()
+            && Self::resource_from_input_json(req, &["image"]).is_none()
+        {
+            return Err(ProviderError::fatal(
+                "video.img2video requires an image input",
+            ));
+        }
         let mut instance = Map::new();
         instance.insert(
             "prompt".to_string(),
@@ -2333,7 +2423,12 @@ impl GoogleGeminiProvider {
             .cloned()
             .or_else(|| Self::resource_from_input_json(req, &["image", "video"]))
         {
-            instance.insert("input".to_string(), Self::resource_part(&resource)?);
+            let field = match method {
+                ai_methods::VIDEO_IMG2VIDEO => "image",
+                ai_methods::VIDEO_VIDEO2VIDEO | ai_methods::VIDEO_EXTEND => "video",
+                _ => "image",
+            };
+            instance.insert(field.to_string(), Self::resource_part(&resource)?);
         }
         if let Some(handle) = req
             .payload
@@ -2363,9 +2458,13 @@ impl GoogleGeminiProvider {
         if !ignored_parameters.is_empty() {
             warn!(
                 "aicc.gemini ignored unsupported video parameters: provider_instance_name={} model={} trace_id={:?} ignored={:?}",
-                self.instance.provider_instance_name, provider_model, ctx.trace_id, ignored_parameters
+                self.instance.provider_instance_name,
+                provider_model,
+                ctx.trace_id,
+                ignored_parameters
             );
         }
+        let started_at = std::time::Instant::now();
         let (status, body, latency_ms) = self
             .post_model_action(provider_model, "predictLongRunning", &request_obj)
             .await?;
@@ -2376,6 +2475,72 @@ impl GoogleGeminiProvider {
                 .unwrap_or("google gemini video returned non-success status");
             return Err(Self::classify_api_error(status, message.to_string()));
         }
+        let operation_name = body
+            .get("name")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                ProviderError::fatal("google gemini video response is missing operation name")
+            })?
+            .to_string();
+        let mut operation = body;
+        loop {
+            if let Some(error) = operation.get("error") {
+                let message = error
+                    .get("message")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("google gemini video generation failed");
+                return Err(ProviderError::fatal(message.to_string()));
+            }
+            if operation
+                .get("done")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
+            {
+                break;
+            }
+            if started_at.elapsed() >= GEMINI_VIDEO_MAX_WAIT {
+                return Err(ProviderError::fatal(format!(
+                    "google gemini video generation timed out after {} seconds",
+                    GEMINI_VIDEO_MAX_WAIT.as_secs()
+                )));
+            }
+            time::sleep(GEMINI_VIDEO_POLL_INTERVAL).await;
+            let (poll_status, next_operation) =
+                self.get_video_operation(operation_name.as_str()).await?;
+            if !poll_status.is_success() {
+                let message = next_operation
+                    .pointer("/error/message")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("google gemini video status returned non-success status");
+                return Err(ProviderError::fatal(message.to_string()));
+            }
+            operation = next_operation;
+        }
+        let video_uri = Self::video_uri(&operation).ok_or_else(|| {
+            ProviderError::fatal("google gemini completed video response is missing video uri")
+        })?;
+        let (download_status, bytes, content_type) = self.download_video(video_uri).await?;
+        if !download_status.is_success() {
+            return Err(ProviderError::fatal(format!(
+                "google gemini video download returned status {}",
+                download_status.as_u16()
+            )));
+        }
+        let mime = if content_type.contains("video/") {
+            content_type
+        } else {
+            "video/mp4".to_string()
+        };
+        let artifact = AiArtifact {
+            name: "video.mp4".to_string(),
+            resource: ResourceRef::Base64 {
+                mime: mime.clone(),
+                data_base64: general_purpose::STANDARD.encode(bytes),
+            },
+            mime: Some(mime),
+            metadata: None,
+        };
         let mut extra = Map::new();
         extra.insert(
             "provider".to_string(),
@@ -2386,23 +2551,29 @@ impl GoogleGeminiProvider {
             "model".to_string(),
             Value::String(provider_model.to_string()),
         );
-        extra.insert("latency_ms".to_string(), Value::from(latency_ms));
-        if let Some(name) = body.get("name").cloned() {
-            extra.insert("operation_name".to_string(), name.clone());
-            if method == ai_methods::VIDEO_EXTEND {
-                extra.insert("continuation_handle".to_string(), name);
-            }
+        extra.insert(
+            "latency_ms".to_string(),
+            Value::from(started_at.elapsed().as_millis() as u64),
+        );
+        extra.insert("submit_latency_ms".to_string(), Value::from(latency_ms));
+        extra.insert(
+            "operation_name".to_string(),
+            Value::String(operation_name.clone()),
+        );
+        if method == ai_methods::VIDEO_EXTEND {
+            extra.insert(
+                "continuation_handle".to_string(),
+                Value::String(video_uri.to_string()),
+            );
         }
         extra.insert(
             "provider_io".to_string(),
-            json!({ "input": request_obj, "output": body }),
+            json!({ "input": request_obj, "output": operation }),
         );
         Ok(ProviderStartResult::Immediate(AiResponse {
-            provider_task_ref: extra
-                .get("operation_name")
-                .and_then(|value| value.as_str())
-                .map(|value| value.to_string()),
-            finish_reason: Some("started".to_string()),
+            message: AiResponse::message_from_parts(None, vec![], vec![artifact]),
+            provider_task_ref: Some(operation_name),
+            finish_reason: Some("stop".to_string()),
             extra: Some(Value::Object(extra)),
             ..Default::default()
         }))
@@ -2443,6 +2614,18 @@ impl Provider for GoogleGeminiProvider {
                 quota_state: QuotaState::Normal,
                 confidence: 0.5,
                 estimated_latency_ms: Some(6000),
+            };
+        }
+        if matches!(
+            input.api_type,
+            ApiType::VideoTextToVideo | ApiType::VideoImageToVideo
+        ) {
+            return CostEstimateOutput {
+                estimated_cost_usd: 0.5,
+                pricing_mode: PricingMode::Unknown,
+                quota_state: QuotaState::Normal,
+                confidence: 0.5,
+                estimated_latency_ms: Some(120_000),
             };
         }
 
@@ -3148,6 +3331,82 @@ mod tests {
         assert_eq!(parse_gemini_major_minor("text-embedding-004"), None);
         // 三段版本 (2.5.1) 不识别——Google 没有这种命名，避免误判
         assert_eq!(parse_gemini_major_minor("gemini-2.5.1-flash"), None);
+    }
+
+    #[test]
+    fn veo_inventory_exposes_text_and_image_to_video() {
+        let inventory = GoogleGeminiProvider::build_inventory_from_buckets(
+            "gemini-primary",
+            ProviderType::CloudApi,
+            "google-gemini",
+            &GeminiModelBuckets {
+                video: vec!["veo-3.1-generate-preview".to_string()],
+                ..Default::default()
+            },
+            &[],
+            Some("test".to_string()),
+        );
+        let veo = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "veo-3.1-generate-preview")
+            .expect("veo model should exist");
+        assert!(veo.api_types.contains(&ApiType::VideoTextToVideo));
+        assert!(veo.api_types.contains(&ApiType::VideoImageToVideo));
+        assert!(veo
+            .logical_mounts
+            .iter()
+            .any(|mount| mount == "video.img2video"));
+    }
+
+    #[test]
+    fn video_uri_parses_gemini_operation_response() {
+        let operation = json!({
+            "done": true,
+            "response": {
+                "generateVideoResponse": {
+                    "generatedSamples": [{
+                        "video": { "uri": "https://example.com/video.mp4" }
+                    }]
+                }
+            }
+        });
+        assert_eq!(
+            GoogleGeminiProvider::video_uri(&operation),
+            Some("https://example.com/video.mp4")
+        );
+    }
+
+    #[test]
+    fn estimate_video_cost_uses_veo_long_task_latency() {
+        let provider = GoogleGeminiProvider::new(
+            GoogleGeminiInstanceConfig {
+                provider_instance_name: "gemini-primary".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "google-gemini".to_string(),
+                api_token: "token".to_string(),
+                base_url: default_base_url(),
+                timeout_ms: default_timeout_ms(),
+                models: vec![],
+                default_model: None,
+                image_models: vec![],
+                default_image_model: None,
+                features: vec![],
+                alias_map: HashMap::new(),
+            },
+            "token".to_string(),
+        )
+        .expect("provider should be built");
+        let estimate = provider.estimate_cost(&CostEstimateInput {
+            api_type: ApiType::VideoImageToVideo,
+            exact_model: "veo-3.1-generate-preview@gemini-primary".to_string(),
+            input_tokens: 0,
+            estimated_output_tokens: None,
+            cached_input_tokens: None,
+            request_features: vec![],
+        });
+        assert_eq!(estimate.estimated_cost_usd, 0.5);
+        assert_eq!(estimate.estimated_latency_ms, Some(120_000));
     }
 
     #[test]

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -23,6 +23,8 @@ use buckyos_api::{
     AiUsage, Capability, ResourceRef,
 };
 use buckyos_kit::buckyos_get_unix_timestamp;
+use image::imageops::FilterType;
+use image::ImageFormat;
 use log::{error, info, warn};
 use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE};
 use reqwest::{Client, StatusCode};
@@ -31,6 +33,7 @@ use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::error::Error as _;
 use std::hash::{Hash, Hasher};
+use std::io::Cursor;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 use tokio::sync::watch;
@@ -3353,6 +3356,51 @@ impl OpenAIProvider {
         }
     }
 
+    fn video_dimensions(size: &str) -> Option<(u32, u32)> {
+        match size {
+            "720x1280" => Some((720, 1280)),
+            "1280x720" => Some((1280, 720)),
+            "1024x1792" => Some((1024, 1792)),
+            "1792x1024" => Some((1792, 1024)),
+            "1080x1920" => Some((1080, 1920)),
+            "1920x1080" => Some((1920, 1080)),
+            _ => None,
+        }
+    }
+
+    fn normalize_video_reference_image(
+        bytes: &[u8],
+        requested_size: Option<&str>,
+    ) -> Result<(String, Vec<u8>), ProviderError> {
+        let image = image::load_from_memory(bytes).map_err(|err| {
+            ProviderError::fatal(format!(
+                "failed to decode video input_reference image: {}",
+                err
+            ))
+        })?;
+        let size = requested_size.map(ToString::to_string).unwrap_or_else(|| {
+            if image.width() > image.height() {
+                "1280x720".to_string()
+            } else {
+                "720x1280".to_string()
+            }
+        });
+        let (width, height) = Self::video_dimensions(size.as_str()).ok_or_else(|| {
+            ProviderError::fatal(format!("unsupported OpenAI video size '{}'", size))
+        })?;
+        let normalized = image.resize_to_fill(width, height, FilterType::Lanczos3);
+        let mut output = Cursor::new(Vec::new());
+        normalized
+            .write_to(&mut output, ImageFormat::Png)
+            .map_err(|err| {
+                ProviderError::fatal(format!(
+                    "failed to encode normalized video input_reference image: {}",
+                    err
+                ))
+            })?;
+        Ok((size, output.into_inner()))
+    }
+
     async fn start_video(
         &self,
         ctx: &crate::aicc::InvokeCtx,
@@ -3373,9 +3421,7 @@ impl OpenAIProvider {
         ) {
             fields.push(("seconds".to_string(), value_to_form_field(&seconds)));
         }
-        if let Some(size) = Self::video_size(req) {
-            fields.push(("size".to_string(), size));
-        }
+        let requested_size = Self::video_size(req);
 
         let mut files = vec![];
         if method == ai_methods::VIDEO_IMG2VIDEO {
@@ -3385,7 +3431,34 @@ impl OpenAIProvider {
             let (name, mime, bytes) = self
                 .resource_to_file_bytes(resource, "input_reference.png")
                 .await?;
-            files.push(("input_reference".to_string(), name, mime, bytes));
+            let normalize_size = requested_size.clone();
+            let (size, normalized_bytes) = tokio::task::spawn_blocking(move || {
+                Self::normalize_video_reference_image(bytes.as_slice(), normalize_size.as_deref())
+            })
+            .await
+            .map_err(|err| {
+                ProviderError::fatal(format!(
+                    "failed to normalize video input_reference image: {}",
+                    err
+                ))
+            })??;
+            info!(
+                "aicc.openai.video.input_reference_normalized provider_instance_name={} model={} source_name={} source_mime={} target_size={}",
+                self.instance.provider_instance_name,
+                provider_model,
+                name,
+                mime,
+                size
+            );
+            fields.push(("size".to_string(), size));
+            files.push((
+                "input_reference".to_string(),
+                "input_reference.png".to_string(),
+                "image/png".to_string(),
+                normalized_bytes,
+            ));
+        } else if let Some(size) = requested_size {
+            fields.push(("size".to_string(), size));
         }
 
         let started_at = std::time::Instant::now();
@@ -4365,6 +4438,42 @@ mod tests {
             OpenAIProvider::estimate_text2image_cost(&high_landscape, "gpt-image-1"),
             Some(0.5)
         );
+    }
+
+    #[test]
+    fn normalize_video_reference_uses_orientation_default_size() {
+        let mut source = Cursor::new(Vec::new());
+        image::DynamicImage::new_rgb8(640, 480)
+            .write_to(&mut source, ImageFormat::Png)
+            .expect("encode source image");
+
+        let (size, normalized) =
+            OpenAIProvider::normalize_video_reference_image(source.get_ref().as_slice(), None)
+                .expect("normalize video reference");
+        let normalized = image::load_from_memory(normalized.as_slice())
+            .expect("decode normalized video reference");
+
+        assert_eq!(size, "1280x720");
+        assert_eq!((normalized.width(), normalized.height()), (1280, 720));
+    }
+
+    #[test]
+    fn normalize_video_reference_honors_requested_size() {
+        let mut source = Cursor::new(Vec::new());
+        image::DynamicImage::new_rgb8(480, 640)
+            .write_to(&mut source, ImageFormat::Png)
+            .expect("encode source image");
+
+        let (size, normalized) = OpenAIProvider::normalize_video_reference_image(
+            source.get_ref().as_slice(),
+            Some("1024x1792"),
+        )
+        .expect("normalize video reference");
+        let normalized = image::load_from_memory(normalized.as_slice())
+            .expect("decode normalized video reference");
+
+        assert_eq!(size, "1024x1792");
+        assert_eq!((normalized.width(), normalized.height()), (1024, 1792));
     }
 
     #[test]

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -1,6 +1,7 @@
 use crate::aicc::{
-    provider_type_from_settings, redacted_json_log, AIComputeCenter, Provider, ProviderError,
-    ProviderInstance, ProviderRefreshTask, ProviderStartResult, ResolvedRequest, TaskEventSink,
+    emit_background_provider_result, provider_type_from_settings, redacted_json_log,
+    AIComputeCenter, Provider, ProviderError, ProviderInstance, ProviderRefreshTask,
+    ProviderStartResult, ResolvedRequest, TaskEventSink,
 };
 use crate::metadata_resolver::{resolve_driver_inventory, DriverModelResolveRequest};
 #[cfg(test)]
@@ -102,7 +103,7 @@ pub struct OpenAIInstanceConfig {
     pub timeout_ms: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OpenAIProvider {
     instance: ProviderInstance,
     inventory: Arc<RwLock<ProviderInventory>>,
@@ -3407,6 +3408,7 @@ impl OpenAIProvider {
         provider_model: &str,
         method: &str,
         req: &AiMethodRequest,
+        sink: Arc<dyn TaskEventSink>,
     ) -> Result<ProviderStartResult, ProviderError> {
         let prompt = Self::extract_text2image_prompt(req).ok_or_else(|| {
             ProviderError::fatal(format!("{} requires a non-empty prompt", method))
@@ -3463,7 +3465,7 @@ impl OpenAIProvider {
 
         let started_at = std::time::Instant::now();
         let url = format!("{}/videos", self.base_url);
-        let (status, mut job, _) = self
+        let (status, job, _) = self
             .post_multipart(ctx, url.as_str(), fields, files)
             .await?;
         if !status.is_success() {
@@ -3480,6 +3482,38 @@ impl OpenAIProvider {
             .ok_or_else(|| ProviderError::fatal("openai video create response is missing id"))?
             .to_string();
 
+        let provider = self.clone();
+        let task_id = ctx.task_id.clone().unwrap_or_else(|| video_id.clone());
+        let invoke_ctx = ctx.clone();
+        let provider_model = provider_model.to_string();
+        let method = method.to_string();
+        let request = req.clone();
+        tokio::spawn(async move {
+            let result = provider
+                .finish_video(
+                    &invoke_ctx,
+                    provider_model.as_str(),
+                    method.as_str(),
+                    video_id.as_str(),
+                    job,
+                    started_at,
+                )
+                .await;
+            emit_background_provider_result(sink, task_id.as_str(), &request, result).await;
+        });
+
+        Ok(ProviderStartResult::Started)
+    }
+
+    async fn finish_video(
+        &self,
+        ctx: &crate::aicc::InvokeCtx,
+        provider_model: &str,
+        method: &str,
+        video_id: &str,
+        mut job: Value,
+        started_at: std::time::Instant,
+    ) -> Result<AiResponse, ProviderError> {
         loop {
             let state = job
                 .get("status")
@@ -3544,10 +3578,10 @@ impl OpenAIProvider {
             mime: Some(mime),
             metadata: None,
         };
-        Ok(ProviderStartResult::Immediate(AiResponse {
+        Ok(AiResponse {
             message: AiResponse::message_from_parts(None, vec![], vec![artifact]),
             finish_reason: Some("stop".to_string()),
-            provider_task_ref: Some(video_id),
+            provider_task_ref: Some(video_id.to_string()),
             extra: Some(json!({
                 "provider": "openai",
                 "method": method,
@@ -3556,7 +3590,7 @@ impl OpenAIProvider {
                 "provider_io": { "output": job }
             })),
             ..Default::default()
-        }))
+        })
     }
 
     async fn start_image_edit(
@@ -3720,7 +3754,7 @@ impl Provider for OpenAIProvider {
         ctx: crate::aicc::InvokeCtx,
         provider_model: String,
         req: ResolvedRequest,
-        _sink: Arc<dyn TaskEventSink>,
+        sink: Arc<dyn TaskEventSink>,
     ) -> std::result::Result<ProviderStartResult, ProviderError> {
         match req.method.as_str() {
             ai_methods::LLM_CHAT => {
@@ -3770,6 +3804,7 @@ impl Provider for OpenAIProvider {
                     provider_model.as_str(),
                     req.method.as_str(),
                     &req.request,
+                    sink,
                 )
                 .await
             }

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -43,6 +43,7 @@ const DEFAULT_OPENAI_IMAGE_MODELS: &str = "gpt-image-1,dall-e-3,dall-e-2";
 const DEFAULT_OPENAI_EMBEDDING_MODELS: &str = "text-embedding-3-large,text-embedding-3-small";
 const DEFAULT_OPENAI_ASR_MODELS: &str = "gpt-4o-mini-transcribe,whisper-1";
 const DEFAULT_OPENAI_TTS_MODELS: &str = "gpt-4o-mini-tts,tts-1";
+const DEFAULT_OPENAI_VIDEO_MODELS: &str = "sora-2,sora-2-pro";
 const DEFAULT_SN_AI_PROVIDER_MODELS: &str = "gpt-5.4,gpt-5.4-mini,gpt-5.4-nano,gpt-5.4-pro";
 const DEFAULT_SN_AI_PROVIDER_IMAGE_MODELS: &str = "gpt-image-1,dall-e-3,dall-e-2";
 const DEFAULT_OPENAI_PROVIDER_DRIVER: &str = "openai";
@@ -84,6 +85,8 @@ const OPENAI_IMAGE_EDIT_OPTION_ALLOWLIST: &[&str] = &[
     "size",
     "user",
 ];
+const OPENAI_VIDEO_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const OPENAI_VIDEO_MAX_WAIT: Duration = Duration::from_secs(600);
 
 #[derive(Debug, Clone)]
 pub struct OpenAIInstanceConfig {
@@ -376,7 +379,7 @@ impl OpenAIProvider {
         provider_type: crate::model_types::ProviderType,
         provider_driver: &str,
     ) -> ProviderInventory {
-        let (models, image_models, embedding_models, asr_models, tts_models) =
+        let (mut models, image_models, embedding_models, asr_models, tts_models) =
             if provider_driver == "openrouter" {
                 (vec![], vec![], vec![], vec![], vec![])
             } else if provider_driver == SN_AI_PROVIDER_DRIVER {
@@ -396,6 +399,10 @@ impl OpenAIProvider {
                     normalize_model_list(parse_csv_list(DEFAULT_OPENAI_TTS_MODELS)),
                 )
             };
+        if provider_driver == DEFAULT_OPENAI_PROVIDER_DRIVER {
+            models.extend(parse_csv_list(DEFAULT_OPENAI_VIDEO_MODELS));
+            models = normalize_model_list(models);
+        }
 
         Self::build_inventory(
             provider_instance_name,
@@ -416,6 +423,11 @@ impl OpenAIProvider {
         image_models: &[String],
         revision: Option<String>,
     ) -> ProviderInventory {
+        let mut models = models.to_vec();
+        if self.provider_driver == DEFAULT_OPENAI_PROVIDER_DRIVER {
+            models.extend(parse_csv_list(DEFAULT_OPENAI_VIDEO_MODELS));
+            models = normalize_model_list(models);
+        }
         let (embedding_models, asr_models, tts_models) = if self.provider_driver == "openrouter" {
             (vec![], vec![], vec![])
         } else {
@@ -429,7 +441,7 @@ impl OpenAIProvider {
             self.instance.provider_instance_name.as_str(),
             self.provider_type.clone(),
             self.provider_driver.as_str(),
-            models,
+            models.as_slice(),
             image_models,
             embedding_models.as_slice(),
             asr_models.as_slice(),
@@ -2508,6 +2520,59 @@ impl OpenAIProvider {
         Ok((status, body, latency_ms))
     }
 
+    async fn get_json(
+        &self,
+        ctx: &crate::aicc::InvokeCtx,
+        url: &str,
+    ) -> Result<(StatusCode, Value), ProviderError> {
+        let auth_token = self.build_auth_token(ctx).await?;
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(auth_token.as_str())
+            .send()
+            .await
+            .map_err(|err| {
+                ProviderError::fatal(format!("openai video status request failed: {}", err))
+            })?;
+        let status = response.status();
+        let body = response.json::<Value>().await.map_err(|err| {
+            ProviderError::fatal(format!(
+                "failed to parse openai video status response: {}",
+                err
+            ))
+        })?;
+        Ok((status, body))
+    }
+
+    async fn get_binary(
+        &self,
+        ctx: &crate::aicc::InvokeCtx,
+        url: &str,
+    ) -> Result<(StatusCode, Vec<u8>, String), ProviderError> {
+        let auth_token = self.build_auth_token(ctx).await?;
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(auth_token.as_str())
+            .send()
+            .await
+            .map_err(|err| {
+                ProviderError::fatal(format!("openai video download failed: {}", err))
+            })?;
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("video/mp4")
+            .to_string();
+        let bytes = response.bytes().await.map_err(|err| {
+            ProviderError::fatal(format!("failed to read openai video content: {}", err))
+        })?;
+        Ok((status, bytes.to_vec(), content_type))
+    }
+
     async fn start_llm(
         &self,
         ctx: &crate::aicc::InvokeCtx,
@@ -2540,7 +2605,10 @@ impl OpenAIProvider {
         if !stripped_options.is_empty() {
             info!(
                 "aicc.openai omitted incompatible llm options: provider_instance_name={} model={} trace_id={:?} omitted={:?}",
-                self.instance.provider_instance_name, provider_model, ctx.trace_id, stripped_options
+                self.instance.provider_instance_name,
+                provider_model,
+                ctx.trace_id,
+                stripped_options
             );
         }
         merge_requirements_response_format(&mut request_obj, req);
@@ -3157,6 +3225,176 @@ impl OpenAIProvider {
         }))
     }
 
+    fn video_option(req: &AiMethodRequest, keys: &[&str]) -> Option<Value> {
+        for source in [
+            req.payload.input_json.as_ref(),
+            req.payload.options.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            for key in keys {
+                if let Some(value) = source.get(*key) {
+                    return Some(value.clone());
+                }
+            }
+        }
+        None
+    }
+
+    fn video_size(req: &AiMethodRequest) -> Option<String> {
+        let raw = Self::video_option(req, &["size", "resolution"])?;
+        let value = raw.as_str()?.trim();
+        if value.contains('x') {
+            return Some(value.to_string());
+        }
+        let aspect_ratio = Self::video_option(req, &["aspect_ratio", "aspectRatio"])
+            .and_then(|value| value.as_str().map(ToString::to_string))
+            .unwrap_or_else(|| "16:9".to_string());
+        match (value.to_ascii_lowercase().as_str(), aspect_ratio.as_str()) {
+            ("720p", "9:16") => Some("720x1280".to_string()),
+            ("720p", _) => Some("1280x720".to_string()),
+            ("1024p", "9:16") => Some("1024x1792".to_string()),
+            ("1024p", _) => Some("1792x1024".to_string()),
+            ("1080p", "9:16") => Some("1080x1920".to_string()),
+            ("1080p", _) => Some("1920x1080".to_string()),
+            _ => None,
+        }
+    }
+
+    async fn start_video(
+        &self,
+        ctx: &crate::aicc::InvokeCtx,
+        provider_model: &str,
+        method: &str,
+        req: &AiMethodRequest,
+    ) -> Result<ProviderStartResult, ProviderError> {
+        let prompt = Self::extract_text2image_prompt(req).ok_or_else(|| {
+            ProviderError::fatal(format!("{} requires a non-empty prompt", method))
+        })?;
+        let mut fields = vec![
+            ("model".to_string(), provider_model.to_string()),
+            ("prompt".to_string(), prompt),
+        ];
+        if let Some(seconds) = Self::video_option(
+            req,
+            &["seconds", "duration", "duration_seconds", "durationSeconds"],
+        ) {
+            fields.push(("seconds".to_string(), value_to_form_field(&seconds)));
+        }
+        if let Some(size) = Self::video_size(req) {
+            fields.push(("size".to_string(), size));
+        }
+
+        let mut files = vec![];
+        if method == ai_methods::VIDEO_IMG2VIDEO {
+            let resource = req.payload.resources.first().ok_or_else(|| {
+                ProviderError::fatal("video.img2video requires resources[0] image input")
+            })?;
+            let (name, mime, bytes) = self
+                .resource_to_file_bytes(resource, "input_reference.png")
+                .await?;
+            files.push(("input_reference".to_string(), name, mime, bytes));
+        }
+
+        let started_at = std::time::Instant::now();
+        let url = format!("{}/videos", self.base_url);
+        let (status, mut job, _) = self
+            .post_multipart(ctx, url.as_str(), fields, files)
+            .await?;
+        if !status.is_success() {
+            let message = job
+                .pointer("/error/message")
+                .and_then(|value| value.as_str())
+                .unwrap_or("openai video create returned non-success status");
+            return Err(Self::classify_api_error(status, message.to_string()));
+        }
+        let video_id = job
+            .get("id")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| ProviderError::fatal("openai video create response is missing id"))?
+            .to_string();
+
+        loop {
+            let state = job
+                .get("status")
+                .and_then(|value| value.as_str())
+                .unwrap_or("queued");
+            match state {
+                "completed" => break,
+                "queued" | "in_progress" => {}
+                "failed" => {
+                    let message = job
+                        .pointer("/error/message")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("openai video generation failed");
+                    return Err(ProviderError::fatal(message.to_string()));
+                }
+                other => {
+                    return Err(ProviderError::fatal(format!(
+                        "openai video generation returned unknown status '{}'",
+                        other
+                    )));
+                }
+            }
+            if started_at.elapsed() >= OPENAI_VIDEO_MAX_WAIT {
+                return Err(ProviderError::fatal(format!(
+                    "openai video generation timed out after {} seconds",
+                    OPENAI_VIDEO_MAX_WAIT.as_secs()
+                )));
+            }
+            time::sleep(OPENAI_VIDEO_POLL_INTERVAL).await;
+            let status_url = format!("{}/videos/{}", self.base_url, video_id);
+            let (poll_status, next_job) = self.get_json(ctx, status_url.as_str()).await?;
+            if !poll_status.is_success() {
+                let message = next_job
+                    .pointer("/error/message")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("openai video status returned non-success status");
+                return Err(ProviderError::fatal(message.to_string()));
+            }
+            job = next_job;
+        }
+
+        let content_url = format!("{}/videos/{}/content", self.base_url, video_id);
+        let (download_status, bytes, content_type) =
+            self.get_binary(ctx, content_url.as_str()).await?;
+        if !download_status.is_success() {
+            return Err(ProviderError::fatal(format!(
+                "openai video download returned status {}",
+                download_status.as_u16()
+            )));
+        }
+        let mime = if content_type.contains("video/") {
+            content_type
+        } else {
+            "video/mp4".to_string()
+        };
+        let artifact = AiArtifact {
+            name: "video.mp4".to_string(),
+            resource: ResourceRef::Base64 {
+                mime: mime.clone(),
+                data_base64: general_purpose::STANDARD.encode(bytes),
+            },
+            mime: Some(mime),
+            metadata: None,
+        };
+        Ok(ProviderStartResult::Immediate(AiResponse {
+            message: AiResponse::message_from_parts(None, vec![], vec![artifact]),
+            finish_reason: Some("stop".to_string()),
+            provider_task_ref: Some(video_id),
+            extra: Some(json!({
+                "provider": "openai",
+                "method": method,
+                "model": provider_model,
+                "latency_ms": started_at.elapsed().as_millis() as u64,
+                "provider_io": { "output": job }
+            })),
+            ..Default::default()
+        }))
+    }
+
     async fn start_image_edit(
         &self,
         ctx: &crate::aicc::InvokeCtx,
@@ -3268,6 +3506,22 @@ impl Provider for OpenAIProvider {
                 estimated_latency_ms: Some(5000),
             };
         }
+        if matches!(
+            input.api_type,
+            ApiType::VideoTextToVideo | ApiType::VideoImageToVideo
+        ) {
+            return CostEstimateOutput {
+                estimated_cost_usd: if provider_model.contains("pro") {
+                    1.2
+                } else {
+                    0.4
+                },
+                pricing_mode: PricingMode::Unknown,
+                quota_state: QuotaState::Normal,
+                confidence: 0.5,
+                estimated_latency_ms: Some(120_000),
+            };
+        }
 
         let input_tokens = input.input_tokens.max(1);
         let output_tokens = input.estimated_output_tokens.unwrap_or(1024).max(1);
@@ -3336,6 +3590,15 @@ impl Provider for OpenAIProvider {
             ai_methods::AUDIO_ASR => {
                 self.start_asr(&ctx, provider_model.as_str(), &req.request)
                     .await
+            }
+            ai_methods::VIDEO_TXT2VIDEO | ai_methods::VIDEO_IMG2VIDEO => {
+                self.start_video(
+                    &ctx,
+                    provider_model.as_str(),
+                    req.method.as_str(),
+                    &req.request,
+                )
+                .await
             }
             method => Err(ProviderError::fatal(format!(
                 "openai provider does not support method '{}'",
@@ -3567,6 +3830,7 @@ fn is_supported_llm_model_name(model: &str) -> bool {
 
     normalized.starts_with("gpt-")
         || normalized.starts_with("chatgpt-")
+        || normalized.starts_with("sora-")
         || normalized.starts_with("o1")
         || normalized.starts_with("o3")
         || normalized.starts_with("o4")
@@ -4546,6 +4810,87 @@ data: [DONE]
             .models
             .iter()
             .any(|model| model.exact_model == "gpt-image-1@openai-primary"));
+        let sora = inventory
+            .models
+            .iter()
+            .find(|model| model.provider_model_id == "sora-2")
+            .expect("default inventory should include sora-2");
+        assert!(sora.api_types.contains(&ApiType::VideoTextToVideo));
+        assert!(sora.api_types.contains(&ApiType::VideoImageToVideo));
+        assert!(sora
+            .logical_mounts
+            .iter()
+            .any(|mount| mount == "video.img2video"));
+    }
+
+    #[test]
+    fn remote_inventory_keeps_sora_video_models() {
+        let (models, image_models) = normalize_remote_model_ids(
+            vec![
+                OpenAIModelEntry {
+                    id: "sora-2".to_string(),
+                },
+                OpenAIModelEntry {
+                    id: "sora-2-pro".to_string(),
+                },
+            ],
+            "openai",
+        );
+        assert_eq!(models, vec!["sora-2", "sora-2-pro"]);
+        assert!(image_models.is_empty());
+    }
+
+    #[test]
+    fn official_inventory_refresh_keeps_sora_fallback() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openai-primary".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
+                api_token: "token".to_string(),
+                base_url: default_base_url(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: default_timeout_ms(),
+            },
+            "token",
+        )
+        .expect("provider should be built");
+        let inventory = provider
+            .build_inventory_from_remote_value(json!({
+                "data": [{ "id": "gpt-5" }]
+            }))
+            .expect("inventory should resolve");
+        assert!(inventory.models.iter().any(|model| {
+            model.provider_model_id == "sora-2"
+                && model.api_types.contains(&ApiType::VideoImageToVideo)
+        }));
+    }
+
+    #[test]
+    fn estimate_video_cost_uses_sora_render_pricing() {
+        let provider = OpenAIProvider::new(
+            OpenAIInstanceConfig {
+                provider_instance_name: "openai-primary".to_string(),
+                provider_type: "cloud_api".to_string(),
+                provider_driver: "openai".to_string(),
+                api_token: "token".to_string(),
+                base_url: default_base_url(),
+                auth_mode: "bearer".to_string(),
+                timeout_ms: default_timeout_ms(),
+            },
+            "token",
+        )
+        .expect("provider should be built");
+        let estimate = provider.estimate_cost(&CostEstimateInput {
+            api_type: ApiType::VideoImageToVideo,
+            exact_model: "sora-2-pro@openai-primary".to_string(),
+            input_tokens: 0,
+            estimated_output_tokens: None,
+            cached_input_tokens: None,
+            request_features: vec![],
+        });
+        assert_eq!(estimate.estimated_cost_usd, 1.2);
+        assert_eq!(estimate.estimated_latency_ms, Some(120_000));
     }
 
     #[test]

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -3351,8 +3351,6 @@ impl OpenAIProvider {
             ("720p", _) => Some("1280x720".to_string()),
             ("1024p", "9:16") => Some("1024x1792".to_string()),
             ("1024p", _) => Some("1792x1024".to_string()),
-            ("1080p", "9:16") => Some("1080x1920".to_string()),
-            ("1080p", _) => Some("1920x1080".to_string()),
             _ => None,
         }
     }
@@ -3363,8 +3361,6 @@ impl OpenAIProvider {
             "1280x720" => Some((1280, 720)),
             "1024x1792" => Some((1024, 1792)),
             "1792x1024" => Some((1792, 1024)),
-            "1080x1920" => Some((1080, 1920)),
-            "1920x1080" => Some((1920, 1080)),
             _ => None,
         }
     }
@@ -4358,6 +4354,23 @@ mod tests {
         )
     }
 
+    fn build_video_request(options: Value) -> AiMethodRequest {
+        AiMethodRequest::new(
+            Capability::Video,
+            ModelSpec::new("video.sora".to_string(), None),
+            Requirements::default(),
+            AiPayload::new(
+                Some("animate the image".to_string()),
+                vec![],
+                vec![],
+                vec![],
+                Some(options),
+                None,
+            ),
+            None,
+        )
+    }
+
     fn assert_model_mount(
         inventory: &ProviderInventory,
         provider_model_id: &str,
@@ -4490,6 +4503,25 @@ mod tests {
 
         assert_eq!(size, "1280x720");
         assert_eq!((normalized.width(), normalized.height()), (1280, 720));
+    }
+
+    #[test]
+    fn video_size_only_maps_openai_supported_dimensions() {
+        assert_eq!(
+            OpenAIProvider::video_size(&build_video_request(json!({
+                "resolution": "1024p",
+                "aspect_ratio": "9:16"
+            }))),
+            Some("1024x1792".to_string())
+        );
+        assert_eq!(
+            OpenAIProvider::video_size(&build_video_request(json!({
+                "resolution": "1080p",
+                "aspect_ratio": "16:9"
+            }))),
+            None
+        );
+        assert_eq!(OpenAIProvider::video_dimensions("1920x1080"), None);
     }
 
     #[test]

--- a/src/frame/aicc/src/openai.rs
+++ b/src/frame/aicc/src/openai.rs
@@ -2782,6 +2782,97 @@ impl OpenAIProvider {
         Ok(ProviderStartResult::Immediate(summary))
     }
 
+    fn resource_from_input_json(req: &AiMethodRequest, keys: &[&str]) -> Option<ResourceRef> {
+        let input = req.payload.input_json.as_ref()?;
+        for key in keys {
+            if let Some(value) = input.get(*key) {
+                if let Ok(resource) = serde_json::from_value::<ResourceRef>(value.clone()) {
+                    return Some(resource);
+                }
+            }
+        }
+        None
+    }
+
+    fn vision_prompt(method: &str, req: &AiMethodRequest) -> String {
+        if let Some(prompt) = req
+            .payload
+            .input_json
+            .as_ref()
+            .and_then(|value| value.get("prompt"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return prompt.to_string();
+        }
+
+        let mut prompt = if method == ai_methods::VISION_OCR {
+            "Extract all readable text from this image. Preserve reading order, line breaks, and layout as closely as possible. Return only the extracted text."
+                .to_string()
+        } else {
+            "Describe this image accurately and concisely.".to_string()
+        };
+        if let Some(options) = req.payload.input_json.as_ref().and_then(Value::as_object) {
+            let mut options = options.clone();
+            options.remove("image");
+            options.remove("document");
+            options.remove("prompt");
+            if !options.is_empty() {
+                prompt.push_str(" Follow these request options: ");
+                prompt.push_str(Value::Object(options).to_string().as_str());
+            }
+        }
+        prompt
+    }
+
+    async fn start_vision(
+        &self,
+        ctx: &crate::aicc::InvokeCtx,
+        provider_model: &str,
+        method: &str,
+        req: &AiMethodRequest,
+    ) -> Result<ProviderStartResult, ProviderError> {
+        let resource = req
+            .payload
+            .resources
+            .first()
+            .cloned()
+            .or_else(|| Self::resource_from_input_json(req, &["image", "document"]))
+            .ok_or_else(|| ProviderError::fatal("vision request requires an image resource"))?;
+        let prompt = Self::vision_prompt(method, req);
+        let mut vision_req = req.clone();
+        vision_req.payload.text = None;
+        vision_req.payload.messages = vec![AiMessage::new(
+            AiRole::User,
+            vec![AiContent::text(prompt), AiContent::image(resource)],
+        )];
+        vision_req.payload.tool_specs.clear();
+        vision_req.payload.resources.clear();
+        vision_req.payload.input_json = None;
+        vision_req.payload.options = None;
+
+        match self.start_llm(ctx, provider_model, &vision_req).await? {
+            ProviderStartResult::Immediate(mut response) => {
+                let text = response.text_content();
+                let key = if method == ai_methods::VISION_OCR {
+                    "ocr"
+                } else {
+                    "captions"
+                };
+                let extra = response.extra.get_or_insert_with(|| json!({}));
+                if !extra.is_object() {
+                    *extra = json!({});
+                }
+                if let Some(extra) = extra.as_object_mut() {
+                    extra.insert(key.to_string(), json!({ "text": text }));
+                }
+                Ok(ProviderStartResult::Immediate(response))
+            }
+            other => Ok(other),
+        }
+    }
+
     async fn start_text2image(
         &self,
         ctx: &crate::aicc::InvokeCtx,
@@ -3591,6 +3682,15 @@ impl Provider for OpenAIProvider {
                 self.start_asr(&ctx, provider_model.as_str(), &req.request)
                     .await
             }
+            ai_methods::VISION_OCR | ai_methods::VISION_CAPTION => {
+                self.start_vision(
+                    &ctx,
+                    provider_model.as_str(),
+                    req.method.as_str(),
+                    &req.request,
+                )
+                .await
+            }
             ai_methods::VIDEO_TXT2VIDEO | ai_methods::VIDEO_IMG2VIDEO => {
                 self.start_video(
                     &ctx,
@@ -3708,6 +3808,8 @@ fn is_supported_openai_api_type(api_type: &ApiType) -> bool {
         ApiType::Llm
             | ApiType::Embedding
             | ApiType::Rerank
+            | ApiType::VisionOcr
+            | ApiType::VisionCaption
             | ApiType::ImageTextToImage
             | ApiType::ImageToImage
             | ApiType::ImageInpaint
@@ -4802,10 +4904,18 @@ data: [DONE]
 
         let inventory = provider.inventory();
         assert_eq!(inventory.provider_driver, "openai");
-        assert!(inventory
+        let gpt = inventory
             .models
             .iter()
-            .any(|model| model.exact_model == "gpt-5@openai-primary"));
+            .find(|model| model.exact_model == "gpt-5@openai-primary")
+            .expect("default inventory should include gpt-5");
+        assert!(gpt.api_types.contains(&ApiType::VisionOcr));
+        assert!(gpt.api_types.contains(&ApiType::VisionCaption));
+        assert!(gpt.logical_mounts.iter().any(|mount| mount == "vision.ocr"));
+        assert!(gpt
+            .logical_mounts
+            .iter()
+            .any(|mount| mount == "vision.caption"));
         assert!(inventory
             .models
             .iter()

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -1,10 +1,13 @@
 mod common;
 
 use aicc::claude::{ClaudeInstanceConfig, ClaudeProvider};
+use aicc::fal::{FalInstanceConfig, FalProvider};
 use aicc::gemini::{GoogleGeminiInstanceConfig, GoogleGeminiProvider};
 use aicc::openai::{OpenAIInstanceConfig, OpenAIProvider};
-use aicc::{InvokeCtx, Provider, ProviderStartResult, ResolvedRequest};
-use buckyos_api::{ai_methods, Capability, ResourceRef};
+use aicc::{
+    InvokeCtx, Provider, ProviderStartResult, ResolvedRequest, TaskEventKind, TaskEventSinkFactory,
+};
+use buckyos_api::{ai_methods, AiResponse, Capability, ResourceRef};
 use common::*;
 use image::{DynamicImage, ImageFormat};
 use std::collections::HashMap;
@@ -17,6 +20,30 @@ fn png_image(width: u32, height: u32) -> Vec<u8> {
         .write_to(&mut output, ImageFormat::Png)
         .expect("encode test PNG");
     output.into_inner()
+}
+
+async fn wait_for_final_summary(sink_factory: &CollectingSinkFactory, task_id: &str) -> AiResponse {
+    let final_event = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(event) = sink_factory
+                .events_for(task_id)
+                .into_iter()
+                .find(|event| matches!(event.kind, TaskEventKind::Final))
+            {
+                break event;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("background task should emit final event");
+    serde_json::from_value(
+        final_event
+            .data
+            .and_then(|data| data.get("summary").cloned())
+            .expect("final event should include summary"),
+    )
+    .expect("final event summary should be a valid AiResponse")
 }
 
 fn openai_provider(base_url: String, timeout_ms: u64) -> OpenAIProvider {
@@ -149,32 +176,37 @@ async fn adapter_openai_video_img2video_returns_downloaded_artifact() {
     ])
     .await;
     let provider = openai_provider(base_url, 500);
-    let request = request_with_resource(ResourceRef::Base64 {
+    let mut request = request_with_resource(ResourceRef::Base64 {
         mime: "image/png".to_string(),
         data_base64: openai_b64(png_image(320, 640).as_slice()),
     });
+    request.payload.options = Some(serde_json::json!({ "response_format": "base64" }));
+    let task_id = "openai-video-task";
+    let sink_factory = Arc::new(CollectingSinkFactory::new());
+    let sink = sink_factory.build(&InvokeCtx::default(), task_id);
     let result = provider
         .start(
-            InvokeCtx::default(),
+            InvokeCtx {
+                task_id: Some(task_id.to_string()),
+                ..Default::default()
+            },
             "sora-2".to_string(),
             ResolvedRequest::new_with_method(ai_methods::VIDEO_IMG2VIDEO, request),
-            Arc::new(NoopSink),
+            sink,
         )
         .await
         .expect("openai img2video should succeed");
-    match result {
-        ProviderStartResult::Immediate(summary) => {
-            let artifacts = summary.artifacts();
-            assert_eq!(artifacts.len(), 1);
-            assert_eq!(artifacts[0].mime.as_deref(), Some("video/mp4"));
-            match &artifacts[0].resource {
-                ResourceRef::Base64 { data_base64, .. } => {
-                    assert_eq!(data_base64, &openai_b64(video_bytes));
-                }
-                other => panic!("unexpected video artifact: {:?}", other),
-            }
+    assert!(matches!(result, ProviderStartResult::Started));
+
+    let summary = wait_for_final_summary(sink_factory.as_ref(), task_id).await;
+    let artifacts = summary.artifacts();
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].mime.as_deref(), Some("video/mp4"));
+    match &artifacts[0].resource {
+        ResourceRef::Base64 { data_base64, .. } => {
+            assert_eq!(data_base64, &openai_b64(video_bytes));
         }
-        other => panic!("expected immediate video artifact, got {:?}", other),
+        other => panic!("unexpected video artifact: {:?}", other),
     }
 }
 
@@ -203,32 +235,93 @@ async fn adapter_gemini_video_img2video_returns_downloaded_artifact() {
     ])
     .await;
     let provider = gemini_provider(base_url, 500);
-    let request = request_with_resource(ResourceRef::Base64 {
+    let mut request = request_with_resource(ResourceRef::Base64 {
         mime: "image/png".to_string(),
         data_base64: openai_b64(b"image"),
     });
+    request.payload.options = Some(serde_json::json!({ "response_format": "base64" }));
+    let task_id = "gemini-video-task";
+    let sink_factory = Arc::new(CollectingSinkFactory::new());
+    let sink = sink_factory.build(&InvokeCtx::default(), task_id);
     let result = provider
         .start(
-            InvokeCtx::default(),
+            InvokeCtx {
+                task_id: Some(task_id.to_string()),
+                ..Default::default()
+            },
             "veo-3.1-generate-preview".to_string(),
             ResolvedRequest::new_with_method(ai_methods::VIDEO_IMG2VIDEO, request),
-            Arc::new(NoopSink),
+            sink,
         )
         .await
         .expect("gemini img2video should succeed");
-    match result {
-        ProviderStartResult::Immediate(summary) => {
-            let artifacts = summary.artifacts();
-            assert_eq!(artifacts.len(), 1);
-            assert_eq!(artifacts[0].mime.as_deref(), Some("video/mp4"));
-            match &artifacts[0].resource {
-                ResourceRef::Base64 { data_base64, .. } => {
-                    assert_eq!(data_base64, &openai_b64(video_bytes));
-                }
-                other => panic!("unexpected video artifact: {:?}", other),
-            }
+    assert!(matches!(result, ProviderStartResult::Started));
+
+    let summary = wait_for_final_summary(sink_factory.as_ref(), task_id).await;
+    let artifacts = summary.artifacts();
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].mime.as_deref(), Some("video/mp4"));
+    match &artifacts[0].resource {
+        ResourceRef::Base64 { data_base64, .. } => {
+            assert_eq!(data_base64, &openai_b64(video_bytes));
         }
-        other => panic!("expected immediate video artifact, got {:?}", other),
+        other => panic!("unexpected video artifact: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn adapter_fal_video_upscale_runs_in_background() {
+    let base_url = spawn_fake_http_server(vec![MockHttpReply {
+        status_code: 200,
+        body: r#"{"request_id":"fal-1","video":{"url":"https://example.com/upscaled.mp4","content_type":"video/mp4"}}"#.to_string(),
+        content_type: "application/json",
+        delay_ms: 100,
+    }])
+    .await;
+    let provider = FalProvider::new(
+        FalInstanceConfig {
+            provider_instance_name: "fal-test".to_string(),
+            provider_type: "cloud_api".to_string(),
+            api_token: "token".to_string(),
+            base_url,
+            timeout_ms: 500,
+            image_upscale_models: vec![],
+            image_bg_remove_models: vec![],
+            audio_enhance_models: vec![],
+            video_upscale_models: vec!["fal-ai/video-upscaler".to_string()],
+        },
+        "token".to_string(),
+    )
+    .expect("fal provider");
+    let request = request_with_resource(ResourceRef::Url {
+        url: "https://example.com/input.mp4".to_string(),
+        mime_hint: Some("video/mp4".to_string()),
+    });
+    let task_id = "fal-video-task";
+    let sink_factory = Arc::new(CollectingSinkFactory::new());
+    let sink = sink_factory.build(&InvokeCtx::default(), task_id);
+    let result = provider
+        .start(
+            InvokeCtx {
+                task_id: Some(task_id.to_string()),
+                ..Default::default()
+            },
+            "fal-ai/video-upscaler".to_string(),
+            ResolvedRequest::new_with_method(ai_methods::VIDEO_UPSCALE, request),
+            sink,
+        )
+        .await
+        .expect("fal video upscale should start");
+    assert!(matches!(result, ProviderStartResult::Started));
+
+    let summary = wait_for_final_summary(sink_factory.as_ref(), task_id).await;
+    let artifacts = summary.artifacts();
+    assert_eq!(artifacts.len(), 1);
+    match &artifacts[0].resource {
+        ResourceRef::Url { url, .. } => {
+            assert_eq!(url, "https://example.com/upscaled.mp4");
+        }
+        other => panic!("unexpected video artifact: {:?}", other),
     }
 }
 

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -4,7 +4,7 @@ use aicc::claude::{ClaudeInstanceConfig, ClaudeProvider};
 use aicc::gemini::{GoogleGeminiInstanceConfig, GoogleGeminiProvider};
 use aicc::openai::{OpenAIInstanceConfig, OpenAIProvider};
 use aicc::{InvokeCtx, Provider, ProviderStartResult, ResolvedRequest};
-use buckyos_api::Capability;
+use buckyos_api::{ai_methods, Capability, ResourceRef};
 use common::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -23,6 +23,115 @@ fn openai_provider(base_url: String, timeout_ms: u64) -> OpenAIProvider {
         "token",
     )
     .expect("openai provider")
+}
+
+#[tokio::test]
+async fn adapter_openai_video_img2video_returns_downloaded_artifact() {
+    let video_bytes = b"openai-video";
+    let base_url = spawn_fake_http_server(vec![
+        MockHttpReply {
+            status_code: 200,
+            body: r#"{"id":"video_1","status":"queued","model":"sora-2","progress":0}"#.to_string(),
+            content_type: "application/json",
+            delay_ms: 0,
+        },
+        MockHttpReply {
+            status_code: 200,
+            body: r#"{"id":"video_1","status":"completed","model":"sora-2","progress":100}"#
+                .to_string(),
+            content_type: "application/json",
+            delay_ms: 0,
+        },
+        MockHttpReply {
+            status_code: 200,
+            body: String::from_utf8_lossy(video_bytes).to_string(),
+            content_type: "video/mp4",
+            delay_ms: 0,
+        },
+    ])
+    .await;
+    let provider = openai_provider(base_url, 500);
+    let request = request_with_resource(ResourceRef::Base64 {
+        mime: "image/png".to_string(),
+        data_base64: openai_b64(b"image"),
+    });
+    let result = provider
+        .start(
+            InvokeCtx::default(),
+            "sora-2".to_string(),
+            ResolvedRequest::new_with_method(ai_methods::VIDEO_IMG2VIDEO, request),
+            Arc::new(NoopSink),
+        )
+        .await
+        .expect("openai img2video should succeed");
+    match result {
+        ProviderStartResult::Immediate(summary) => {
+            let artifacts = summary.artifacts();
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].mime.as_deref(), Some("video/mp4"));
+            match &artifacts[0].resource {
+                ResourceRef::Base64 { data_base64, .. } => {
+                    assert_eq!(data_base64, &openai_b64(video_bytes));
+                }
+                other => panic!("unexpected video artifact: {:?}", other),
+            }
+        }
+        other => panic!("expected immediate video artifact, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn adapter_gemini_video_img2video_returns_downloaded_artifact() {
+    let video_bytes = b"gemini-video";
+    let base_url = spawn_fake_http_server(vec![
+        MockHttpReply {
+            status_code: 200,
+            body: r#"{"name":"operations/op1","done":false}"#.to_string(),
+            content_type: "application/json",
+            delay_ms: 0,
+        },
+        MockHttpReply {
+            status_code: 200,
+            body: r#"{"name":"operations/op1","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":"video.mp4"}}]}}}"#.to_string(),
+            content_type: "application/json",
+            delay_ms: 0,
+        },
+        MockHttpReply {
+            status_code: 200,
+            body: String::from_utf8_lossy(video_bytes).to_string(),
+            content_type: "video/mp4",
+            delay_ms: 0,
+        },
+    ])
+    .await;
+    let provider = gemini_provider(base_url, 500);
+    let request = request_with_resource(ResourceRef::Base64 {
+        mime: "image/png".to_string(),
+        data_base64: openai_b64(b"image"),
+    });
+    let result = provider
+        .start(
+            InvokeCtx::default(),
+            "veo-3.1-generate-preview".to_string(),
+            ResolvedRequest::new_with_method(ai_methods::VIDEO_IMG2VIDEO, request),
+            Arc::new(NoopSink),
+        )
+        .await
+        .expect("gemini img2video should succeed");
+    match result {
+        ProviderStartResult::Immediate(summary) => {
+            let artifacts = summary.artifacts();
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].mime.as_deref(), Some("video/mp4"));
+            match &artifacts[0].resource {
+                ResourceRef::Base64 { data_base64, .. } => {
+                    assert_eq!(data_base64, &openai_b64(video_bytes));
+                }
+                other => panic!("unexpected video artifact: {:?}", other),
+            }
+        }
+        other => panic!("expected immediate video artifact, got {:?}", other),
+    }
 }
 
 fn gemini_provider(base_url: String, timeout_ms: u64) -> GoogleGeminiProvider {

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -6,8 +6,18 @@ use aicc::openai::{OpenAIInstanceConfig, OpenAIProvider};
 use aicc::{InvokeCtx, Provider, ProviderStartResult, ResolvedRequest};
 use buckyos_api::{ai_methods, Capability, ResourceRef};
 use common::*;
+use image::{DynamicImage, ImageFormat};
 use std::collections::HashMap;
+use std::io::Cursor;
 use std::sync::Arc;
+
+fn png_image(width: u32, height: u32) -> Vec<u8> {
+    let mut output = Cursor::new(Vec::new());
+    DynamicImage::new_rgb8(width, height)
+        .write_to(&mut output, ImageFormat::Png)
+        .expect("encode test PNG");
+    output.into_inner()
+}
 
 fn openai_provider(base_url: String, timeout_ms: u64) -> OpenAIProvider {
     OpenAIProvider::new(
@@ -141,7 +151,7 @@ async fn adapter_openai_video_img2video_returns_downloaded_artifact() {
     let provider = openai_provider(base_url, 500);
     let request = request_with_resource(ResourceRef::Base64 {
         mime: "image/png".to_string(),
-        data_base64: openai_b64(b"image"),
+        data_base64: openai_b64(png_image(320, 640).as_slice()),
     });
     let result = provider
         .start(

--- a/src/frame/aicc/tests/adapter_protocol_tests.rs
+++ b/src/frame/aicc/tests/adapter_protocol_tests.rs
@@ -26,6 +26,94 @@ fn openai_provider(base_url: String, timeout_ms: u64) -> OpenAIProvider {
 }
 
 #[tokio::test]
+async fn adapter_openai_vision_ocr_uses_multimodal_model() {
+    let base_url = spawn_fake_http_server(vec![MockHttpReply {
+        status_code: 200,
+        body: r#"{"id":"r1","status":"completed","output":[{"type":"message","id":"msg_1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"first line\nsecond line","annotations":[]}]}],"usage":{"input_tokens":10,"output_tokens":4,"total_tokens":14}}"#.to_string(),
+        content_type: "application/json",
+        delay_ms: 0,
+    }])
+    .await;
+    let provider = openai_provider(base_url, 500);
+    let mut request = request_with_resource(ResourceRef::Base64 {
+        mime: "image/png".to_string(),
+        data_base64: openai_b64(b"image"),
+    });
+    request.capability = Capability::Vision;
+    request.payload.text = None;
+    request.payload.input_json = Some(serde_json::json!({ "include_layout": true }));
+    request.payload.options = None;
+
+    let result = provider
+        .start(
+            InvokeCtx::default(),
+            "gpt-5".to_string(),
+            ResolvedRequest::new_with_method(ai_methods::VISION_OCR, request),
+            Arc::new(NoopSink),
+        )
+        .await
+        .expect("openai vision OCR should succeed");
+    match result {
+        ProviderStartResult::Immediate(summary) => {
+            assert_eq!(summary.text_content(), "first line\nsecond line");
+            assert_eq!(
+                summary
+                    .extra
+                    .as_ref()
+                    .and_then(|extra| extra.pointer("/ocr/text"))
+                    .and_then(|text| text.as_str()),
+                Some("first line\nsecond line")
+            );
+        }
+        other => panic!("expected immediate OCR response, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn adapter_openai_vision_caption_uses_multimodal_model() {
+    let base_url = spawn_fake_http_server(vec![MockHttpReply {
+        status_code: 200,
+        body: r#"{"id":"r1","status":"completed","output":[{"type":"message","id":"msg_1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"A cat sitting by a window.","annotations":[]}]}],"usage":{"input_tokens":10,"output_tokens":6,"total_tokens":16}}"#.to_string(),
+        content_type: "application/json",
+        delay_ms: 0,
+    }])
+    .await;
+    let provider = openai_provider(base_url, 500);
+    let mut request = request_with_resource(ResourceRef::Base64 {
+        mime: "image/png".to_string(),
+        data_base64: openai_b64(b"image"),
+    });
+    request.capability = Capability::Vision;
+    request.payload.text = None;
+    request.payload.input_json = Some(serde_json::json!({ "style": "short" }));
+    request.payload.options = None;
+
+    let result = provider
+        .start(
+            InvokeCtx::default(),
+            "gpt-5".to_string(),
+            ResolvedRequest::new_with_method(ai_methods::VISION_CAPTION, request),
+            Arc::new(NoopSink),
+        )
+        .await
+        .expect("openai vision caption should succeed");
+    match result {
+        ProviderStartResult::Immediate(summary) => {
+            assert_eq!(summary.text_content(), "A cat sitting by a window.");
+            assert_eq!(
+                summary
+                    .extra
+                    .as_ref()
+                    .and_then(|extra| extra.pointer("/captions/text"))
+                    .and_then(|text| text.as_str()),
+                Some("A cat sitting by a window.")
+            );
+        }
+        other => panic!("expected immediate caption response, got {:?}", other),
+    }
+}
+
+#[tokio::test]
 async fn adapter_openai_video_img2video_returns_downloaded_artifact() {
     let video_bytes = b"openai-video";
     let base_url = spawn_fake_http_server(vec![

--- a/src/frame/msg_center/src/main.rs
+++ b/src/frame/msg_center/src/main.rs
@@ -12,7 +12,8 @@ use ::kRPC::*;
 use anyhow::{Context, Result};
 use buckyos_api::{
     get_buckyos_api_runtime, init_buckyos_api_runtime, set_buckyos_api_runtime, AccountBinding,
-    BuckyOSRuntimeType, DeliveryReportResult, MsgCenterClient, MsgCenterServerHandler,
+    BuckyOSRuntimeType, DeliveryRecordWithObject, DeliveryReportResult, DeliveryState,
+    MsgCenterClient, MsgCenterServerHandler,
     SystemConfigClient, UserContactSettings, UserPrivateProfile, UserSettings, UserState,
     MSG_CENTER_SERVICE_NAME, MSG_CENTER_SERVICE_PORT,
 };
@@ -27,6 +28,7 @@ use http::{Method, Version};
 use http_body_util::combinators::BoxBody;
 use log::{error, info, warn};
 use name_lib::DID;
+use ndn_lib::{MsgContent, MsgContentFormat, MsgObject};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -337,6 +339,7 @@ async fn pump_delivery_queue_once(
             continue;
         };
         let delivery_id = record.record.delivery_id.clone();
+        let failure_notice = build_delivery_failure_notice(&record);
         worked = true;
 
         let report = match executor_mgr.execute_via(&transport_did, record).await {
@@ -362,34 +365,87 @@ async fn pump_delivery_queue_once(
         };
 
         let report_ok = report.ok;
-        if let Err(err) = msg_center
+        match msg_center
             .report_delivery(delivery_id.clone(), report)
             .await
         {
-            // The SENDING lease sweep will reclaim this row if the report is
-            // lost for good.
-            warn!(
-                "msg-center report_delivery failed: executor={} delivery_id={} err={}",
-                transport_did.to_string(),
-                delivery_id,
-                err
-            );
-        } else if report_ok {
-            info!(
-                "msg-center delivery done: executor={} delivery_id={}",
-                transport_did.to_string(),
-                delivery_id
-            );
-        } else {
-            warn!(
-                "msg-center delivery reported failure: executor={} delivery_id={}",
-                transport_did.to_string(),
-                delivery_id
-            );
+            Err(err) => {
+                // The SENDING lease sweep will reclaim this row if the report is
+                // lost for good.
+                warn!(
+                    "msg-center report_delivery failed: executor={} delivery_id={} err={}",
+                    transport_did.to_string(),
+                    delivery_id,
+                    err
+                );
+            }
+            Ok(_) if report_ok => {
+                info!(
+                    "msg-center delivery done: executor={} delivery_id={}",
+                    transport_did.to_string(),
+                    delivery_id
+                );
+            }
+            Ok(record) => {
+                warn!(
+                    "msg-center delivery reported failure: executor={} delivery_id={}",
+                    transport_did.to_string(),
+                    delivery_id
+                );
+                if record.state == DeliveryState::Dead {
+                    if let Some(notice) = failure_notice {
+                        let idempotency_key = Some(format!("delivery-failure:{delivery_id}"));
+                        match msg_center.post_send(notice, idempotency_key).await {
+                            Ok(result) if result.ok => {}
+                            Ok(result) => warn!(
+                                "msg-center delivery failure notice rejected: delivery_id={} reason={:?}",
+                                delivery_id, result.reason
+                            ),
+                            Err(err) => warn!(
+                                "msg-center delivery failure notice failed: delivery_id={} err={}",
+                                delivery_id, err
+                            ),
+                        }
+                    }
+                }
+            }
         }
     }
 
     Ok(worked)
+}
+
+fn build_delivery_failure_notice(record: &DeliveryRecordWithObject) -> Option<MsgObject> {
+    let mut msg = record.msg.clone()?;
+    if msg
+        .meta
+        .get("delivery_failure_fallback")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let text = msg
+        .meta
+        .remove("delivery_failure_notice")?
+        .as_str()?
+        .trim()
+        .to_string();
+    if text.is_empty() {
+        return None;
+    }
+    msg.to = vec![record.record.envelope.target_did.clone()];
+    msg.created_at_ms = now_ms();
+    msg.content = MsgContent {
+        format: Some(MsgContentFormat::TextPlain),
+        content: text,
+        ..Default::default()
+    };
+    msg.meta.insert(
+        "delivery_failure_fallback".to_string(),
+        Value::Bool(true),
+    );
+    Some(msg)
 }
 
 fn start_delivery_pump(center: MessageCenter, executor_mgr: Arc<DeliveryExecutorMgr>) {
@@ -1001,5 +1057,82 @@ async fn main() {
     init_logging("msg_center", true);
     if let Err(err) = start_msg_center_service().await {
         error!("msg-center service start failed: {:?}", err);
+    }
+}
+
+#[cfg(test)]
+mod delivery_failure_tests {
+    use super::*;
+    use buckyos_api::{DeliveryEnvelope, DeliveryRecord, TransportKind};
+    use ndn_lib::{MsgObjKind, NamedObject};
+
+    fn record_with_notice() -> DeliveryRecordWithObject {
+        let transport_did = DID::new("bns", "telegram");
+        let target_did = DID::new("msgtunnel", "42.user.telegram");
+        let mut msg = MsgObject {
+            from: DID::new("bns", "jarvis"),
+            to: vec![target_did.clone()],
+            kind: MsgObjKind::Chat,
+            content: MsgContent {
+                format: Some(MsgContentFormat::TextPlain),
+                content: "result".to_string(),
+                ..Default::default()
+            },
+            created_at_ms: 1,
+            ..Default::default()
+        };
+        msg.meta.insert(
+            "delivery_failure_notice".to_string(),
+            Value::String("delivery failed".to_string()),
+        );
+        let msg_id = msg.gen_obj_id().0;
+        DeliveryRecordWithObject {
+            record: DeliveryRecord {
+                delivery_id: "delivery-1".to_string(),
+                envelope: DeliveryEnvelope {
+                    msg_id,
+                    target_did,
+                    transport_did,
+                    transport: TransportKind::Tunnel {
+                        platform: "telegram".to_string(),
+                        tunnel_instance_id: "telegram".to_string(),
+                    },
+                    address: None,
+                },
+                state: DeliveryState::Sending,
+                attempts: 4,
+                next_retry_at_ms: None,
+                external_msg_id: None,
+                delivered_at_ms: None,
+                last_error: None,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            },
+            msg: Some(msg),
+        }
+    }
+
+    #[test]
+    fn builds_plain_text_failure_notice() {
+        let record = record_with_notice();
+        let notice = build_delivery_failure_notice(&record).unwrap();
+        assert_eq!(notice.to, vec![record.record.envelope.target_did]);
+        assert_eq!(notice.content.content, "delivery failed");
+        assert!(notice.content.refs.is_empty());
+        assert_eq!(
+            notice.meta.get("delivery_failure_fallback"),
+            Some(&Value::Bool(true))
+        );
+        assert!(!notice.meta.contains_key("delivery_failure_notice"));
+    }
+
+    #[test]
+    fn does_not_recurse_for_failure_notice() {
+        let mut record = record_with_notice();
+        record.msg.as_mut().unwrap().meta.insert(
+            "delivery_failure_fallback".to_string(),
+            Value::Bool(true),
+        );
+        assert!(build_delivery_failure_notice(&record).is_none());
     }
 }

--- a/src/frame/opendan/src/agent.rs
+++ b/src/frame/opendan/src/agent.rs
@@ -27,8 +27,8 @@ use agent_tool::{AgentAttentionSignalStore, AttentionSignalStoreConfig};
 use anyhow::{anyhow, Result};
 use buckyos_api::{
     get_buckyos_api_runtime, parse_typed_task_data, AgentDelegateProgress, AgentDelegateTaskData,
-    AgentDelegateTaskRequest, AiMessage, AiRole, Task, TimerOptions,
-    TypedTaskData,
+    AgentDelegateTaskRequest, AiMessage, AiRole, Task, TimerOptions, TypedTaskData,
+    UI_SESSION_STATE_STATUS_LINE_KEY,
 };
 use chrono::{Datelike, Local, Timelike, Utc};
 use log::{info, warn};
@@ -36,7 +36,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::time::{sleep, Duration};
 
-use crate::agent_bash::{build_session_tools, SessionBinLayout, SessionToolsBuild};
+use crate::agent_bash::{
+    build_session_tools, BashProgressSink, SessionBinLayout, SessionToolsBuild,
+};
 use crate::agent_config::{AgentConfig, SessionIdStrategy};
 use crate::agent_session::{AgentSession, AgentSessionBuild, SessionReply};
 use crate::agent_task_executor::TASK_TYPE_AGENT_DELEGATE;
@@ -1837,6 +1839,49 @@ impl AIAgent {
         let agent_id = self.agent_id();
         let bin_renderer = self.build_session_bin_renderer(&agent_id, &session_id, &behavior_name);
         let appclient_session_token = resolve_appclient_session_token().await?;
+        let progress_sink = self.runtime.msg_center.as_ref().map(|msg_center| {
+            let msg_center = msg_center.clone();
+            let progress_session_id = session_id.clone();
+            let i18n = self.config.i18n.clone();
+            Arc::new(move |ctx: &agent_tool::SessionRuntimeContext, progress: &crate::agent_bash::BashProgressUpdate| {
+                let line = if progress.stage == "finalizing" {
+                    i18n.render(
+                        "status.aicc_finalizing",
+                        &[("method", progress.method.clone())],
+                    )
+                } else {
+                    i18n.render(
+                        "status.aicc_running",
+                        &[
+                            ("method", progress.method.clone()),
+                            ("seconds", progress.elapsed_ms.div_ceil(1000).to_string()),
+                        ],
+                    )
+                };
+                let msg_center = msg_center.clone();
+                let session_id = progress_session_id.clone();
+                let turn_nonce = ctx.trace_id.clone();
+                tokio::spawn(async move {
+                    let value = serde_json::json!({
+                        "value": line,
+                        "turn_nonce": turn_nonce,
+                    });
+                    if let Err(err) = msg_center
+                        .update_ui_session_state(
+                            session_id.clone(),
+                            UI_SESSION_STATE_STATUS_LINE_KEY.to_string(),
+                            value,
+                        )
+                        .await
+                    {
+                        warn!(
+                            "opendan.agent: update AICC progress for session {} failed: {err}",
+                            session_id
+                        );
+                    }
+                });
+            }) as BashProgressSink
+        });
 
         let tools = build_session_tools(SessionToolsBuild {
             workspace_root: tool_root.clone(),
@@ -1847,6 +1892,7 @@ impl AIAgent {
             appclient_session_token,
             filesystem_policy: self.config.toml.runtime.filesystem_policy,
             bin_renderer,
+            progress_sink,
         })
         .map_err(|err| anyhow!("build session tools: {err}"))?;
         // Worksession control tools (create_worksession / forward_msg) are

--- a/src/frame/opendan/src/agent.rs
+++ b/src/frame/opendan/src/agent.rs
@@ -1929,6 +1929,7 @@ impl AIAgent {
         let log_sid = session_id.clone();
         let agent_name = self.agent_name.clone();
         let owner_for_log = owner.clone();
+        let reply_session = Arc::downgrade(&session);
         tokio::spawn(async move {
             while let Some(reply) = reply_rx.recv().await {
                 match reply {
@@ -1940,6 +1941,9 @@ impl AIAgent {
                     }
                     SessionReply::Error { message } => {
                         warn!("opendan.agent[{agent_name}]: session={log_sid} error: {message}");
+                        if let Some(session) = reply_session.upgrade() {
+                            session.post_outbound_error(&message).await;
+                        }
                     }
                     SessionReply::Ended => {
                         info!("opendan.agent[{agent_name}]: session={log_sid} ended");

--- a/src/frame/opendan/src/agent.rs
+++ b/src/frame/opendan/src/agent.rs
@@ -42,7 +42,7 @@ use crate::agent_bash::{
 use crate::agent_config::{AgentConfig, SessionIdStrategy};
 use crate::agent_session::{AgentSession, AgentSessionBuild, SessionReply};
 use crate::agent_task_executor::TASK_TYPE_AGENT_DELEGATE;
-use crate::ai_runtime::AgentRuntime;
+use crate::ai_runtime::{ui_status_nonce, AgentRuntime};
 use crate::contact::ContactLookup;
 use crate::dispatch::{
     DispatchEvaluator, EnumSessionIdStrategy, FixedRulesDispatch, SessionIdEvaluator,
@@ -73,6 +73,14 @@ const SELF_IMPROVE_STAGE1_SESSION_PREFIX: &str = "self_improve_signals";
 const SELF_IMPROVE_STAGE2_SESSION_PREFIX: &str = "self_improve_set_memory";
 const SELF_IMPROVE_SKILL_STAGE2_SESSION_PREFIX: &str = "try_create_new_skill";
 const SELF_IMPROVE_STAGE2_ROTATE_AFTER_MS: u64 = 72 * 60 * 60 * 1000;
+
+fn progress_status_session_id(kind: SessionKind, session_id: &str, owner: &str) -> String {
+    if matches!(kind, SessionKind::Work) && !owner.trim().is_empty() {
+        owner.trim().to_string()
+    } else {
+        session_id.to_string()
+    }
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -1841,7 +1849,8 @@ impl AIAgent {
         let appclient_session_token = resolve_appclient_session_token().await?;
         let progress_sink = self.runtime.msg_center.as_ref().map(|msg_center| {
             let msg_center = msg_center.clone();
-            let progress_session_id = session_id.clone();
+            let progress_session_id =
+                progress_status_session_id(kind, &session_id, &owner);
             let i18n = self.config.i18n.clone();
             Arc::new(move |ctx: &agent_tool::SessionRuntimeContext, progress: &crate::agent_bash::BashProgressUpdate| {
                 let line = if progress.stage == "finalizing" {
@@ -1860,7 +1869,7 @@ impl AIAgent {
                 };
                 let msg_center = msg_center.clone();
                 let session_id = progress_session_id.clone();
-                let turn_nonce = ctx.trace_id.clone();
+                let turn_nonce = ui_status_nonce(&ctx.trace_id);
                 tokio::spawn(async move {
                     let value = serde_json::json!({
                         "value": line,
@@ -2451,8 +2460,24 @@ impl AIAgent {
         source_session_id: &str,
         text: &str,
     ) -> Result<String> {
+        self.forward_ai_message(
+            target_session_id,
+            source_session_id,
+            text,
+            AiMessage::text(AiRole::User, text.trim().to_string()),
+        )
+        .await
+    }
+
+    pub async fn forward_ai_message(
+        &self,
+        target_session_id: &str,
+        source_session_id: &str,
+        text: &str,
+        mut ai_message: AiMessage,
+    ) -> Result<String> {
         let trimmed = text.trim();
-        if trimmed.is_empty() {
+        if trimmed.is_empty() && ai_message.content.is_empty() {
             return Err(anyhow!("forward_message: text is empty"));
         }
         let target = {
@@ -2475,6 +2500,12 @@ impl AIAgent {
             return Err(anyhow!("{}", ended_forward_message_guidance(&summary)));
         }
         let record_id = format!("forward:{source_session_id}:{}", mint_session_id("fwd"));
+        ai_message.role = AiRole::User;
+        let pending_text = if trimmed.is_empty() {
+            ai_message.text_content()
+        } else {
+            trimmed.to_string()
+        };
         target
             .enqueue_pending(PendingInput::Msg {
                 record_id: record_id.clone(),
@@ -2482,8 +2513,8 @@ impl AIAgent {
                 from_did: None,
                 from_name: None,
                 tunnel_did: None,
-                text: trimmed.to_string(),
-                ai_message: AiMessage::text(AiRole::User, trimmed.to_string()),
+                text: pending_text,
+                ai_message,
             })
             .await?;
         Ok(record_id)
@@ -3675,6 +3706,18 @@ runner_id = "agent"
             }
             (dst, patch) => *dst = patch.clone(),
         }
+    }
+
+    #[test]
+    fn worksession_progress_targets_owner_ui_session() {
+        assert_eq!(
+            progress_status_session_id(SessionKind::Work, "work-1", "ui-1"),
+            "ui-1"
+        );
+        assert_eq!(
+            progress_status_session_id(SessionKind::Ui, "ui-1", "owner"),
+            "ui-1"
+        );
     }
 
     fn delegate_task(id: &str, data: serde_json::Value) -> Task {

--- a/src/frame/opendan/src/agent_bash.rs
+++ b/src/frame/opendan/src/agent_bash.rs
@@ -38,6 +38,7 @@ use agent_tool::{
     LlmUnderstandMediaTool, NoopFileWriteAudit, SessionRuntimeContext, WriteFileTool,
 };
 use serde_json::json;
+use serde::Deserialize;
 
 use crate::agent_config::FilesystemPolicy;
 use crate::paths;
@@ -49,6 +50,8 @@ const TMUX_SESSION_PREFIX: &str = "od_";
 /// Polling interval while waiting for the per-run exit-code file. Short enough
 /// to feel snappy on small commands, large enough to avoid burning a core.
 const TMUX_POLL_MS: u64 = 120;
+const AGENT_TOOL_PROGRESS_PREFIX: &str = "__BUCKYOS_AGENT_PROGRESS__";
+const PROGRESS_HARD_TIMEOUT_MULTIPLIER: u32 = 5;
 /// How many lines of scrollback `capture-pane` should pull back when we read
 /// pane output for fallback / partial-output paths.
 const TMUX_CAPTURE_SCROLLBACK: &str = "-6000";
@@ -277,7 +280,21 @@ pub struct TmuxBashRunner {
     /// session restart. `None` in unit tests that don't need the layer.
     bin_renderer: Option<Arc<SessionBinRenderer>>,
     base_env: Vec<(String, String)>,
+    progress_sink: Option<BashProgressSink>,
 }
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct BashProgressUpdate {
+    pub agent_tool_progress: String,
+    pub kind: String,
+    pub method: String,
+    pub stage: String,
+    pub task_id: String,
+    pub elapsed_ms: u64,
+}
+
+pub type BashProgressSink =
+    Arc<dyn Fn(&SessionRuntimeContext, &BashProgressUpdate) + Send + Sync>;
 
 impl TmuxBashRunner {
     pub fn new(runtime_dir: impl Into<PathBuf>) -> Self {
@@ -285,6 +302,7 @@ impl TmuxBashRunner {
             runtime_dir: runtime_dir.into(),
             bin_renderer: None,
             base_env: Vec::new(),
+            progress_sink: None,
         }
     }
 
@@ -295,6 +313,11 @@ impl TmuxBashRunner {
 
     pub fn with_base_env(mut self, env: Vec<(String, String)>) -> Self {
         self.base_env = env;
+        self
+    }
+
+    pub fn with_progress_sink(mut self, sink: BashProgressSink) -> Self {
+        self.progress_sink = Some(sink);
         self
     }
 }
@@ -385,8 +408,16 @@ impl BashRunner for TmuxBashRunner {
         let invoke = format!(". {}", shell_quote(script_path.to_string_lossy().as_ref()));
         send_keys(&tmux_target, &invoke).await?;
 
-        let exit_code = match wait_exit_code(&exit_code_path, &tmux_target, &run_id, req.timeout_ms)
-            .await?
+        let exit_code = match wait_exit_code(
+            &exit_code_path,
+            &stderr_path,
+            &tmux_target,
+            &run_id,
+            req.timeout_ms,
+            self.progress_sink.as_ref(),
+            ctx,
+        )
+        .await?
         {
             Some(code) => code,
             None => {
@@ -406,9 +437,9 @@ impl BashRunner for TmuxBashRunner {
         cleanup_run_files(&script_path, &stdout_path, &stderr_path, &exit_code_path).await;
 
         let stdout = String::from_utf8_lossy(&stdout_bytes).to_string();
-        let stderr = String::from_utf8_lossy(&stderr_bytes).to_string();
+        let stderr = strip_progress_lines(&String::from_utf8_lossy(&stderr_bytes));
         let (output, output_truncated) =
-            assemble_output(&stdout_bytes, &stderr_bytes, req.max_output_bytes);
+            assemble_output(&stdout_bytes, stderr.as_bytes(), req.max_output_bytes);
 
         Ok(BashRunOutput {
             exit_code,
@@ -441,6 +472,7 @@ pub struct SessionToolsBuild {
     /// plan). `None` ⇒ no tombstones and no Agent tool sync — useful in
     /// tests that just want the file tools wired.
     pub bin_renderer: Option<Arc<SessionBinRenderer>>,
+    pub progress_sink: Option<BashProgressSink>,
 }
 
 /// Build a tool manager pre-populated with the §3 UI-session defaults.
@@ -453,6 +485,7 @@ pub fn build_default_tool_manager(
     bash_runtime_dir: &Path,
     bin_renderer: Option<Arc<SessionBinRenderer>>,
     bash_base_env: Vec<(String, String)>,
+    progress_sink: Option<BashProgressSink>,
 ) -> Arc<AgentToolManager> {
     let manager = AgentToolManager::new();
 
@@ -461,6 +494,9 @@ pub fn build_default_tool_manager(
     let mut runner = TmuxBashRunner::new(bash_runtime_dir).with_base_env(bash_base_env);
     if let Some(renderer) = bin_renderer {
         runner = runner.with_bin_renderer(renderer);
+    }
+    if let Some(progress_sink) = progress_sink {
+        runner = runner.with_progress_sink(progress_sink);
     }
     let runner: Arc<dyn BashRunner> = Arc::new(runner);
     let _ = manager.register_tool(ExecBashTool::with_runner(bash_cfg, runner));
@@ -520,6 +556,7 @@ pub fn build_session_tools(build: SessionToolsBuild) -> std::io::Result<Arc<Agen
             &build.session_id,
             &build.appclient_session_token,
         ),
+        build.progress_sink,
     );
     Ok(manager)
 }
@@ -871,19 +908,34 @@ async fn capture_pane(target: &str) -> Result<String, AgentToolError> {
 /// scrollback (fallback in case the file write races with our poll).
 async fn wait_exit_code(
     exit_code_path: &Path,
+    stderr_path: &Path,
     tmux_target: &str,
     run_id: &str,
     timeout_ms: u64,
+    progress_sink: Option<&BashProgressSink>,
+    ctx: &SessionRuntimeContext,
 ) -> Result<Option<i32>, AgentToolError> {
     let started = Instant::now();
-    let deadline = Duration::from_millis(timeout_ms);
+    let mut last_progress = Instant::now();
+    let idle_timeout = Duration::from_millis(timeout_ms);
+    let hard_timeout = idle_timeout.saturating_mul(PROGRESS_HARD_TIMEOUT_MULTIPLIER);
+    let mut progress_lines_seen = 0usize;
     let pane_marker = format!("__OD_EXIT__{run_id}:");
     loop {
-        if started.elapsed() >= deadline {
+        if started.elapsed() >= hard_timeout || last_progress.elapsed() >= idle_timeout {
             return Ok(None);
         }
         if let Some(code) = read_exit_code_file(exit_code_path).await? {
             return Ok(Some(code));
+        }
+        let updates = read_progress_updates(stderr_path, &mut progress_lines_seen).await;
+        if !updates.is_empty() {
+            last_progress = Instant::now();
+            if let Some(sink) = progress_sink {
+                for update in updates {
+                    sink(ctx, &update);
+                }
+            }
         }
         if let Ok(pane) = capture_pane(tmux_target).await {
             if let Some(code) = parse_exit_code_from_pane(&pane, &pane_marker)? {
@@ -892,6 +944,39 @@ async fn wait_exit_code(
         }
         sleep(Duration::from_millis(TMUX_POLL_MS)).await;
     }
+}
+
+async fn read_progress_updates(path: &Path, lines_seen: &mut usize) -> Vec<BashProgressUpdate> {
+    let raw = match fs::read_to_string(path).await {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(_) => return Vec::new(),
+    };
+    let lines = raw.lines().collect::<Vec<_>>();
+    let updates = lines
+        .iter()
+        .skip(*lines_seen)
+        .filter_map(|line| parse_progress_line(line))
+        .collect();
+    *lines_seen = lines.len();
+    updates
+}
+
+fn parse_progress_line(line: &str) -> Option<BashProgressUpdate> {
+    let payload = line.strip_prefix(AGENT_TOOL_PROGRESS_PREFIX)?;
+    let update = serde_json::from_str::<BashProgressUpdate>(payload).ok()?;
+    if update.agent_tool_progress != "1" || update.kind != "aicc" {
+        return None;
+    }
+    Some(update)
+}
+
+fn strip_progress_lines(stderr: &str) -> String {
+    stderr
+        .lines()
+        .filter(|line| parse_progress_line(line).is_none())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 async fn read_exit_code_file(path: &Path) -> Result<Option<i32>, AgentToolError> {
@@ -1073,6 +1158,28 @@ mod tests {
     }
 
     #[test]
+    fn parses_and_strips_agent_tool_progress_lines() {
+        let line = concat!(
+            "__BUCKYOS_AGENT_PROGRESS__",
+            r#"{"agent_tool_progress":"1","kind":"aicc","method":"video.img2video","stage":"running","task_id":"task-1","elapsed_ms":5000}"#
+        );
+        let update = parse_progress_line(line).expect("progress update");
+        assert_eq!(update.method, "video.img2video");
+        assert_eq!(update.elapsed_ms, 5000);
+        assert_eq!(strip_progress_lines(&format!("before\n{line}\nafter\n")), "before\nafter");
+    }
+
+    #[test]
+    fn ignores_unrecognized_progress_protocol() {
+        let line = concat!(
+            "__BUCKYOS_AGENT_PROGRESS__",
+            r#"{"agent_tool_progress":"2","kind":"aicc","method":"llm","stage":"running","task_id":"task-1","elapsed_ms":1}"#
+        );
+        assert!(parse_progress_line(line).is_none());
+        assert_eq!(strip_progress_lines(line), line);
+    }
+
+    #[test]
     fn registers_default_tools() {
         let dir = tempdir().unwrap();
         // BUCKYOS_ROOT is consulted at layout-compute time; pin it under the
@@ -1087,6 +1194,7 @@ mod tests {
             appclient_session_token: "test-token".to_string(),
             filesystem_policy: FilesystemPolicy::Workspace,
             bin_renderer: None,
+            progress_sink: None,
         })
         .expect("build tools");
         for name in ["exec_bash", "read"] {

--- a/src/frame/opendan/src/agent_bash.rs
+++ b/src/frame/opendan/src/agent_bash.rs
@@ -51,7 +51,7 @@ const TMUX_SESSION_PREFIX: &str = "od_";
 /// to feel snappy on small commands, large enough to avoid burning a core.
 const TMUX_POLL_MS: u64 = 120;
 const AGENT_TOOL_PROGRESS_PREFIX: &str = "__BUCKYOS_AGENT_PROGRESS__";
-const PROGRESS_HARD_TIMEOUT_MULTIPLIER: u32 = 5;
+const PROGRESS_HARD_TIMEOUT_MULTIPLIER: u32 = 15;
 /// How many lines of scrollback `capture-pane` should pull back when we read
 /// pane output for fallback / partial-output paths.
 const TMUX_CAPTURE_SCROLLBACK: &str = "-6000";

--- a/src/frame/opendan/src/agent_session.rs
+++ b/src/frame/opendan/src/agent_session.rs
@@ -5966,6 +5966,19 @@ impl AgentSession {
         )
     }
 
+    pub(crate) async fn post_outbound_error(&self, error: &str) {
+        self.status.set_with_nonce(
+            self.agent_config.i18n.render("status.llm_failed", &[]),
+            self.status.nonce_snapshot(),
+        );
+        let text = self
+            .agent_config
+            .i18n
+            .render("response.failed", &[("error", error.trim().to_string())]);
+        self.post_outbound_message(&AiMessage::text(AiRole::Assistant, text))
+            .await;
+    }
+
     async fn post_outbound_message(&self, message: &AiMessage) {
         // UI sessions are the only ones that reply through msg-center
         // today — work sessions surface their result via report.md instead.
@@ -6037,6 +6050,14 @@ impl AgentSession {
                 serde_json::Value::String(turn_nonce),
             );
         }
+        msg.meta.insert(
+            "delivery_failure_notice".to_string(),
+            serde_json::Value::String(
+                self.agent_config
+                    .i18n
+                    .render("response.delivery_failed", &[]),
+            ),
+        );
 
         let workspace_id = {
             let meta = self.meta.lock().await;
@@ -6061,6 +6082,7 @@ impl AgentSession {
                 .runtime
                 .preserve_attachment_tag_in_egress,
         };
+        let fallback_msg = msg.clone();
         let msg = match llm_context::ai_message_to_msg_object_with_base_validated_async(
             message,
             msg,
@@ -6076,6 +6098,8 @@ impl AgentSession {
                     "opendan.session[{}]: outbound message conversion failed: {err}",
                     self.session_id
                 );
+                self.post_delivery_failure_notice(&msg_center, fallback_msg)
+                    .await;
                 return;
             }
         };
@@ -6096,6 +6120,36 @@ impl AgentSession {
                 "opendan.session[{}]: outbound post_send failed: {err}",
                 self.session_id
             ),
+        }
+    }
+
+    async fn post_delivery_failure_notice(
+        &self,
+        msg_center: &buckyos_api::MsgCenterClient,
+        mut msg: ndn_lib::MsgObject,
+    ) {
+        msg.content = ndn_lib::MsgContent {
+            format: Some(ndn_lib::MsgContentFormat::TextPlain),
+            content: self
+                .agent_config
+                .i18n
+                .render("response.delivery_failed", &[]),
+            ..Default::default()
+        };
+        msg.meta.remove("delivery_failure_notice");
+        msg.meta.insert(
+            "delivery_failure_fallback".to_string(),
+            serde_json::Value::Bool(true),
+        );
+        let idempotency_key = Some(format!(
+            "delivery-failure:{}:{}",
+            self.session_id, msg.created_at_ms
+        ));
+        if let Err(err) = msg_center.post_send(msg, idempotency_key).await {
+            warn!(
+                "opendan.session[{}]: delivery failure notice post_send failed: {err}",
+                self.session_id
+            );
         }
     }
 

--- a/src/frame/opendan/src/agent_session.rs
+++ b/src/frame/opendan/src/agent_session.rs
@@ -302,7 +302,7 @@ pub struct AgentSession {
     /// caused the parent LLM to think a forward was needed". §8.4 of the
     /// design doc calls this the "本轮 origin user 消息". Per-turn ephemeral
     /// state — not persisted, simply overwritten each turn.
-    current_origin_msg: Arc<std::sync::Mutex<Option<String>>>,
+    current_origin_msg: Arc<std::sync::Mutex<Option<AiMessage>>>,
 
     /// Interrupt handle of the LLMContext currently inside a `run()` call.
     /// `Some` while an inference is in flight; `None` between turns or when
@@ -1019,7 +1019,7 @@ impl AgentSession {
             user_messages: messages.clone(),
             system_events: Vec::new(),
         };
-        self.set_current_origin_msg(messages.first().map(|message| message.text_content()));
+        self.set_current_origin_msg(messages.first().cloned());
         self.run_one_round(messages, Vec::new(), Some(seed), false)
             .await
     }
@@ -1324,11 +1324,7 @@ impl AgentSession {
                         self.set_status(SessionStatus::WaitingInput).await;
                         continue;
                     }
-                    self.set_current_origin_msg(
-                        bootstrap_messages
-                            .first()
-                            .map(|message| message.text_content()),
-                    );
+                    self.set_current_origin_msg(bootstrap_messages.first().cloned());
                     let seed = RoundSeed {
                         trigger: RoundTrigger::SystemEvent {
                             source: "bootstrap".to_string(),
@@ -1556,7 +1552,7 @@ impl AgentSession {
             let mut task_completions: Vec<(String, Observation, String, String)> = Vec::new();
             let mut latest_peer_did: Option<String> = None;
             let mut latest_peer_tunnel: Option<String> = None;
-            let mut latest_origin_msg: Option<String> = None;
+            let mut latest_origin_msg: Option<AiMessage> = None;
             // Parallel collections destined for the round-history seed. We
             // mirror the per-input visit so user-msg ordering & system-event
             // payloads are captured intact rather than the post-formatted
@@ -1592,7 +1588,7 @@ impl AgentSession {
                                     if first_msg_preview.is_none() {
                                         first_msg_preview = Some(trigger_preview(&preview_text));
                                     }
-                                    latest_origin_msg = Some(preview_text);
+                                    latest_origin_msg = Some(message.clone());
                                     hist_user_messages.push(message.clone());
                                     msg_count += 1;
                                 }
@@ -5634,14 +5630,18 @@ impl AgentSession {
         self.current_origin_msg
             .lock()
             .ok()
-            .and_then(|g| g.clone())
+            .and_then(|g| g.as_ref().map(AiMessage::text_content))
             .filter(|s| !s.trim().is_empty())
     }
 
+    pub fn current_origin_user_ai_message(&self) -> Option<AiMessage> {
+        self.current_origin_msg.lock().ok().and_then(|g| g.clone())
+    }
+
     /// Worker-internal: stash / clear the per-turn origin message. Pass
-    /// `Some(text)` right before running a turn; `None` to clear (e.g. on
+    /// `Some(message)` right before running a turn; `None` to clear (e.g. on
     /// session exit).
-    fn set_current_origin_msg(&self, value: Option<String>) {
+    fn set_current_origin_msg(&self, value: Option<AiMessage>) {
         if let Ok(mut g) = self.current_origin_msg.lock() {
             *g = value;
         }

--- a/src/frame/opendan/src/ai_runtime.rs
+++ b/src/frame/opendan/src/ai_runtime.rs
@@ -615,6 +615,12 @@ mod policy_tests {
     }
 
     #[test]
+    fn fork_status_uses_parent_turn_nonce() {
+        assert_eq!(ui_status_nonce("ui-session-7::fork-1"), "ui-session-7");
+        assert_eq!(ui_status_nonce("ui-session-8"), "ui-session-8");
+    }
+
+    #[test]
     fn exec_bash_provider_tool_uses_tool_whitelist() {
         let policy = AgentPolicy::new(Vec::new());
         let request = request_with_policy(ToolPolicy {
@@ -702,6 +708,14 @@ impl OpenDanWorklogSink {
             sink.set_with_nonce(line, nonce);
         }
     }
+}
+
+pub(crate) fn ui_status_nonce(trace_id: &str) -> String {
+    trace_id
+        .split_once("::fork-")
+        .map(|(parent, _)| parent)
+        .unwrap_or(trace_id)
+        .to_string()
 }
 
 #[async_trait]
@@ -843,7 +857,7 @@ impl WorklogSink for OpenDanWorklogSink {
         let status_nonce = payload
             .get("trace_id")
             .and_then(Value::as_str)
-            .map(str::to_string);
+            .map(ui_status_nonce);
         self.update_status(status_line, status_nonce);
 
         let record = json!({

--- a/src/frame/opendan/src/ai_runtime.rs
+++ b/src/frame/opendan/src/ai_runtime.rs
@@ -25,7 +25,7 @@ use buckyos_api::{
     ai_methods, features, get_buckyos_api_runtime, value_to_object_map, AiMethodRequest,
     AiMethodStatus, AiPayload, AiResponse, AiToolCall, AiToolSpec, AiccClient, Capability,
     KEventClient, ModelSpec, MsgCenterClient, Requirements, RespFormat, TaskDispatcherClient,
-    ListTasksReq, TaskManagerClient, TaskOutcome, TypedTaskData,
+    TaskManagerClient, TaskOutcome, TypedTaskData,
 };
 use log::warn;
 use serde_json::{json, Value};
@@ -209,9 +209,9 @@ impl LlmClient for AiccLlmClient {
 /// `behavior::do_inference_once` used, but reuses
 /// `BuckyOSRuntime::wait_for_task_end_kevent` so the wait is kevent-
 /// accelerated with a sweep fallback.
-async fn resolve_async_aicc_result(external_task_id: &str) -> Result<AiResponse, LLMComputeError> {
-    let external_task_id = external_task_id.trim();
-    if external_task_id.is_empty() {
+async fn resolve_async_aicc_result(task_id: &str) -> Result<AiResponse, LLMComputeError> {
+    let task_id = task_id.trim();
+    if task_id.is_empty() {
         return Err(LLMComputeError::Provider(
             "aicc response status=running but task_id is empty".to_string(),
         ));
@@ -219,21 +219,15 @@ async fn resolve_async_aicc_result(external_task_id: &str) -> Result<AiResponse,
 
     let runtime = get_buckyos_api_runtime()
         .map_err(|err| LLMComputeError::Internal(format!("load buckyos runtime failed: {err}")))?;
-    let taskmgr = runtime.get_task_mgr_client().await.map_err(|err| {
-        LLMComputeError::Provider(format!("init task-manager client failed: {err}"))
-    })?;
-
-    let id = resolve_aicc_task_id(&taskmgr, external_task_id).await?;
-
     let task = runtime
-        .wait_for_task_end_kevent(&id)
+        .wait_for_task_end_kevent(task_id)
         .await
         .map_err(|err| LLMComputeError::Provider(err.to_string()))?;
 
     if task.outcome != Some(TaskOutcome::Succeeded) {
         return Err(LLMComputeError::Provider(format!(
             "aicc task {} ended with outcome {:?}",
-            id, task.outcome
+            task_id, task.outcome
         )));
     }
 
@@ -247,7 +241,7 @@ async fn resolve_async_aicc_result(external_task_id: &str) -> Result<AiResponse,
         _ => {
             return Err(LLMComputeError::Provider(format!(
                 "aicc task {} terminated without typed aicc.compute payload",
-                id
+                task_id
             )))
         }
     };
@@ -257,59 +251,16 @@ async fn resolve_async_aicc_result(external_task_id: &str) -> Result<AiResponse,
         .ok_or_else(|| {
             LLMComputeError::Provider(format!(
                 "aicc task {} terminated without aicc output payload",
-                id
+                task_id
             ))
         })?;
     let summary_value = output.get("summary").cloned().unwrap_or(output);
     serde_json::from_value::<AiResponse>(summary_value).map_err(|err| {
         LLMComputeError::Provider(format!(
             "decode AiResponse from aicc task {} output failed: {err}",
-            id
+            task_id
         ))
     })
-}
-
-/// AICC's `external_task_id` is always shaped like `aicc-{ts}-{seq}` and is
-/// not a task-manager id. Walk task-manager listings filtered by the AICC
-/// app to find the row whose `data.aicc.external_task_id` matches.
-async fn resolve_aicc_task_id(
-    taskmgr: &TaskManagerClient,
-    external_task_id: &str,
-) -> Result<String, LLMComputeError> {
-    if external_task_id.starts_with("t-") {
-        return Ok(external_task_id.to_string());
-    }
-
-    let page = taskmgr
-        .list_tasks(ListTasksReq {
-            schema_id: Some("aicc.compute/v1".to_string()),
-            ..Default::default()
-        })
-        .await
-        .map_err(|err| LLMComputeError::Provider(err.to_string()))?;
-
-    for summary in page.tasks {
-        let Ok(task) = taskmgr.get_task(&summary.task_id).await else {
-            continue;
-        };
-        let payload = task
-            .result
-            .clone()
-            .or_else(|| task.progress.clone())
-            .unwrap_or_else(|| task.input.clone());
-        let matched = matches!(
-            buckyos_api::parse_typed_task_data("aicc.compute", payload),
-            Ok(TypedTaskData::AiccCompute(data))
-                if data.request.external_task_id.as_deref() == Some(external_task_id)
-        );
-        if matched {
-            return Ok(task.task_id);
-        }
-    }
-    Err(LLMComputeError::Provider(format!(
-        "aicc task_id '{}' is not a task id and no task-manager row references it",
-        external_task_id
-    )))
 }
 
 // =====================================================================

--- a/src/frame/opendan/src/i18n.rs
+++ b/src/frame/opendan/src/i18n.rs
@@ -162,6 +162,8 @@ fn flatten_toml(prefix: &str, value: &toml::Value, out: &mut BTreeMap<String, St
 fn default_messages(language: &str) -> BTreeMap<String, String> {
     let entries = match language {
         "zh" => [
+            ("status.aicc_running", "AICC 正在执行 {method}（{seconds} 秒）"),
+            ("status.aicc_finalizing", "AICC 已完成 {method}，正在整理结果"),
             ("response.delivery_failed", "结果投递失败，请重试。"),
             ("response.failed", "任务失败：{error}"),
             ("status.llm_started", "正在思考 ({model})"),
@@ -185,6 +187,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "zh-TW" => [
+            ("status.aicc_running", "AICC 正在執行 {method}（{seconds} 秒）"),
+            ("status.aicc_finalizing", "AICC 已完成 {method}，正在整理結果"),
             ("response.delivery_failed", "結果傳送失敗，請重試。"),
             ("response.failed", "任務失敗：{error}"),
             ("status.llm_started", "正在思考 ({model})"),
@@ -208,6 +212,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "es" => [
+            ("status.aicc_running", "AICC ejecutando {method} ({seconds} s)"),
+            ("status.aicc_finalizing", "AICC completó {method}; preparando el resultado"),
             ("response.delivery_failed", "No se pudo entregar el resultado. Inténtalo de nuevo."),
             ("response.failed", "La tarea falló: {error}"),
             ("status.llm_started", "LLM pensando ({model})"),
@@ -234,6 +240,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "fr" => [
+            ("status.aicc_running", "AICC exécute {method} ({seconds} s)"),
+            ("status.aicc_finalizing", "AICC a terminé {method} ; préparation du résultat"),
             ("response.delivery_failed", "Échec de l’envoi du résultat. Veuillez réessayer."),
             ("response.failed", "La tâche a échoué : {error}"),
             ("status.llm_started", "LLM en réflexion ({model})"),
@@ -260,6 +268,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "de" => [
+            ("status.aicc_running", "AICC führt {method} aus ({seconds} s)"),
+            ("status.aicc_finalizing", "AICC hat {method} abgeschlossen; Ergebnis wird vorbereitet"),
             ("response.delivery_failed", "Das Ergebnis konnte nicht zugestellt werden. Bitte erneut versuchen."),
             ("response.failed", "Aufgabe fehlgeschlagen: {error}"),
             ("status.llm_started", "LLM denkt nach ({model})"),
@@ -289,6 +299,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "ko" => [
+            ("status.aicc_running", "AICC가 {method} 실행 중 ({seconds}초)"),
+            ("status.aicc_finalizing", "AICC가 {method} 완료; 결과 정리 중"),
             ("response.delivery_failed", "결과를 전송하지 못했습니다. 다시 시도해 주세요."),
             ("response.failed", "작업 실패: {error}"),
             ("status.llm_started", "LLM 생각 중 ({model})"),
@@ -312,6 +324,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "ja" => [
+            ("status.aicc_running", "AICC が {method} を実行中（{seconds} 秒）"),
+            ("status.aicc_finalizing", "AICC が {method} を完了、結果を準備中"),
             ("response.delivery_failed", "結果を配信できませんでした。もう一度お試しください。"),
             ("response.failed", "タスクに失敗しました: {error}"),
             ("status.llm_started", "LLM 思考中 ({model})"),
@@ -338,6 +352,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "ru" => [
+            ("status.aicc_running", "AICC выполняет {method} ({seconds} с)"),
+            ("status.aicc_finalizing", "AICC завершил {method}; подготовка результата"),
             ("response.delivery_failed", "Не удалось доставить результат. Повторите попытку."),
             ("response.failed", "Ошибка задачи: {error}"),
             ("status.llm_started", "LLM думает ({model})"),
@@ -367,6 +383,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         _ => [
+            ("status.aicc_running", "AICC running {method} ({seconds}s)"),
+            ("status.aicc_finalizing", "AICC finished {method}; preparing result"),
             ("response.delivery_failed", "Failed to deliver the result. Please try again."),
             ("response.failed", "Task failed: {error}"),
             ("status.llm_started", "LLM thinking ({model})"),

--- a/src/frame/opendan/src/i18n.rs
+++ b/src/frame/opendan/src/i18n.rs
@@ -162,6 +162,8 @@ fn flatten_toml(prefix: &str, value: &toml::Value, out: &mut BTreeMap<String, St
 fn default_messages(language: &str) -> BTreeMap<String, String> {
     let entries = match language {
         "zh" => [
+            ("response.delivery_failed", "结果投递失败，请重试。"),
+            ("response.failed", "任务失败：{error}"),
             ("status.llm_started", "正在思考 ({model})"),
             ("status.llm_finished", "思考完成"),
             ("status.llm_failed", "思考失败"),
@@ -183,6 +185,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "zh-TW" => [
+            ("response.delivery_failed", "結果傳送失敗，請重試。"),
+            ("response.failed", "任務失敗：{error}"),
             ("status.llm_started", "正在思考 ({model})"),
             ("status.llm_finished", "思考完成"),
             ("status.llm_failed", "思考失敗"),
@@ -204,6 +208,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "es" => [
+            ("response.delivery_failed", "No se pudo entregar el resultado. Inténtalo de nuevo."),
+            ("response.failed", "La tarea falló: {error}"),
             ("status.llm_started", "LLM pensando ({model})"),
             ("status.llm_finished", "LLM finalizado"),
             ("status.llm_failed", "LLM falló"),
@@ -228,6 +234,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "fr" => [
+            ("response.delivery_failed", "Échec de l’envoi du résultat. Veuillez réessayer."),
+            ("response.failed", "La tâche a échoué : {error}"),
             ("status.llm_started", "LLM en réflexion ({model})"),
             ("status.llm_finished", "LLM terminé"),
             ("status.llm_failed", "LLM échoué"),
@@ -252,6 +260,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "de" => [
+            ("response.delivery_failed", "Das Ergebnis konnte nicht zugestellt werden. Bitte erneut versuchen."),
+            ("response.failed", "Aufgabe fehlgeschlagen: {error}"),
             ("status.llm_started", "LLM denkt nach ({model})"),
             ("status.llm_finished", "LLM abgeschlossen"),
             ("status.llm_failed", "LLM fehlgeschlagen"),
@@ -279,6 +289,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "ko" => [
+            ("response.delivery_failed", "결과를 전송하지 못했습니다. 다시 시도해 주세요."),
+            ("response.failed", "작업 실패: {error}"),
             ("status.llm_started", "LLM 생각 중 ({model})"),
             ("status.llm_finished", "LLM 완료"),
             ("status.llm_failed", "LLM 실패"),
@@ -300,6 +312,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "ja" => [
+            ("response.delivery_failed", "結果を配信できませんでした。もう一度お試しください。"),
+            ("response.failed", "タスクに失敗しました: {error}"),
             ("status.llm_started", "LLM 思考中 ({model})"),
             ("status.llm_finished", "LLM 完了"),
             ("status.llm_failed", "LLM 失敗"),
@@ -324,6 +338,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         "ru" => [
+            ("response.delivery_failed", "Не удалось доставить результат. Повторите попытку."),
+            ("response.failed", "Ошибка задачи: {error}"),
             ("status.llm_started", "LLM думает ({model})"),
             ("status.llm_finished", "LLM завершил работу"),
             ("status.llm_failed", "Сбой LLM"),
@@ -351,6 +367,8 @@ fn default_messages(language: &str) -> BTreeMap<String, String> {
             ),
         ],
         _ => [
+            ("response.delivery_failed", "Failed to deliver the result. Please try again."),
+            ("response.failed", "Task failed: {error}"),
             ("status.llm_started", "LLM thinking ({model})"),
             ("status.llm_finished", "LLM finished"),
             ("status.llm_failed", "LLM failed"),
@@ -389,6 +407,10 @@ mod tests {
         assert_eq!(
             i18n.render("status.tool_planned", &[("tool", "read".to_string())]),
             "准备使用工具: read"
+        );
+        assert_eq!(
+            i18n.render("response.failed", &[("error", "超时".to_string())]),
+            "任务失败：超时"
         );
     }
 

--- a/src/frame/opendan/src/worksession_tools.rs
+++ b/src/frame/opendan/src/worksession_tools.rs
@@ -474,8 +474,21 @@ impl TypedTool for ForwardMsgTool {
                 })?
             }
         };
+        let forwarded_message = build_forwarded_message(
+            agent
+                .get_session(&self.source_session_id)
+                .await
+                .and_then(|session| session.current_origin_user_ai_message()),
+            &body,
+        );
+        let forwarded_text = forwarded_message.text_content();
         let record_id = agent
-            .forward_message(&args.target_worksession_id, &self.source_session_id, &body)
+            .forward_ai_message(
+                &args.target_worksession_id,
+                &self.source_session_id,
+                &forwarded_text,
+                forwarded_message,
+            )
             .await
             .map_err(|err| AgentToolError::ExecFailed(format!("{err:#}")))?;
         Ok(ForwardMsgOutput {
@@ -484,6 +497,18 @@ impl TypedTool for ForwardMsgTool {
             record_id,
         })
     }
+}
+
+fn build_forwarded_message(origin: Option<AiMessage>, override_text: &str) -> AiMessage {
+    let mut message =
+        origin.unwrap_or_else(|| AiMessage::text(AiRole::User, override_text.to_string()));
+    if message.text_content().trim() != override_text {
+        message.content.push(AiContent::Text {
+            text: format!("Forwarding context:\n{override_text}"),
+        });
+    }
+    message.role = AiRole::User;
+    message
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -1301,6 +1326,22 @@ mod tests {
         assert_eq!(TOOL_FORWARD_MSG, "forward_msg");
         assert_eq!(TOOL_TRY_CREATE_WORKSESSION, "try_create_worksession");
         assert_eq!(TOOL_UPDATE_SESSION_TOPIC, "update_session_topic");
+    }
+
+    #[test]
+    fn forwarded_override_preserves_origin_attachment_marker() {
+        let marker = "[image attachment; obj_id=\"cyfile:abc\"; label=\"image/jpeg\"]";
+        let origin = AiMessage::text(
+            AiRole::User,
+            format!("Use this image to make a video\n{marker}"),
+        );
+
+        let forwarded = build_forwarded_message(Some(origin), "Create a five second video");
+        let text = forwarded.text_content();
+
+        assert_eq!(forwarded.role, AiRole::User);
+        assert!(text.contains(marker));
+        assert!(text.contains("Create a five second video"));
     }
 
     #[test]

--- a/src/kernel/buckyos-api/src/aicc_client.rs
+++ b/src/kernel/buckyos-api/src/aicc_client.rs
@@ -1544,6 +1544,8 @@ pub enum AiMethodStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AiMethodResponse {
+    /// For `running`, this is the stable TaskMgr task id and can be passed
+    /// directly to `task-manager.get_task({ task_id })`.
     pub task_id: String,
     pub status: AiMethodStatus,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/tools/buckyos-agent/commands/gen_image.ts
+++ b/src/tools/buckyos-agent/commands/gen_image.ts
@@ -135,7 +135,7 @@ export async function run(argv: string[]): Promise<never> {
   // callAicc 会:
   //   • 用 modelAlias / capability / policy 包成完整 AiMethodRequest
   //   • 一次性走 aicc.<method> RPC，拿到 succeeded / running / failed
-  //   • 如果是 running，按 external_task_id 在 task-manager 里轮询到终态
+  //   • 如果是 running，按返回的 TaskMgr task_id 直接轮询到终态
   let call;
   try {
     call = await textToImage(runtime, {

--- a/src/tools/buckyos-agent/lib/aicc.ts
+++ b/src/tools/buckyos-agent/lib/aicc.ts
@@ -200,8 +200,6 @@ async function waitForFinalTask(
   taskMgr: RpcClient,
   externalTaskId: string,
   method: string,
-  appId: string,
-  userId: string,
   deadlineMs: number,
 ): Promise<TaskRecord> {
   const startedAt = Date.now();
@@ -216,10 +214,7 @@ async function waitForFinalTask(
   while (Date.now() < deadlineMs) {
     reportRunning();
     const raw = await taskMgr.call("list_tasks", {
-      app_id: appId,
       task_type: "aicc.compute",
-      source_user_id: userId,
-      source_app_id: appId,
     });
     const tasks = normalizeTaskList(raw).sort(
       (a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0),
@@ -285,8 +280,6 @@ export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise
     taskMgr,
     response.task_id,
     opts.method,
-    runtime.appId,
-    runtime.userId,
     deadline,
   );
   if (finalTask.status === "Completed") {

--- a/src/tools/buckyos-agent/lib/aicc.ts
+++ b/src/tools/buckyos-agent/lib/aicc.ts
@@ -10,7 +10,7 @@ import {
   Profile,
   ResourceRef,
 } from "./types.ts";
-import { AiccRuntime } from "./runtime.ts";
+import type { AiccRuntime } from "./runtime.ts";
 
 // deno-lint-ignore no-explicit-any
 type RpcClient = { call: (method: string, params: Record<string, unknown>) => Promise<any> };
@@ -76,12 +76,17 @@ interface TaskRecord {
   message?: string | null;
   updated_at?: number;
   data?: {
-    aicc?: {
+    request?: {
       external_task_id?: string;
-      output?: JsonValue;
-      error?: JsonValue;
+    };
+    progress?: {
       status?: string;
     };
+    result?: {
+      output?: JsonValue;
+      provider_output?: JsonValue;
+    };
+    error?: JsonValue;
   };
 }
 
@@ -219,7 +224,7 @@ async function waitForFinalTask(
     const tasks = normalizeTaskList(raw).sort(
       (a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0),
     );
-    const matched = tasks.find((t) => t.data?.aicc?.external_task_id === externalTaskId);
+    const matched = tasks.find((t) => t.data?.request?.external_task_id === externalTaskId);
     if (matched) {
       while (Date.now() < deadlineMs) {
         reportRunning();
@@ -288,7 +293,7 @@ export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise
     return {
       taskId: response.task_id,
       status: "succeeded",
-      summary: asAiResponse(finalTask.data?.aicc?.output ?? null),
+      summary: asAiResponse(finalTask.data?.result?.output ?? null),
       rawResponse: response,
       finalTask,
     };
@@ -296,7 +301,7 @@ export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise
   return {
     taskId: response.task_id,
     status: "failed",
-    summary: asAiResponse(finalTask.data?.aicc?.output ?? null),
+    summary: asAiResponse(finalTask.data?.result?.output ?? null),
     rawResponse: response,
     finalTask,
   };
@@ -365,7 +370,7 @@ export function textToImage(runtime: AiccRuntime, opts: TextToImageOptions): Pro
 
 export function describeFailure(result: CallResult): string {
   if (result.finalTask) {
-    const err = result.finalTask.data?.aicc?.error ?? result.finalTask.message;
+    const err = result.finalTask.data?.error ?? result.finalTask.message;
     if (err) return typeof err === "string" ? err : JSON.stringify(err);
     return `task ended with ${result.finalTask.status}`;
   }

--- a/src/tools/buckyos-agent/lib/aicc.ts
+++ b/src/tools/buckyos-agent/lib/aicc.ts
@@ -89,6 +89,24 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+const AGENT_TOOL_PROGRESS_PREFIX = "__BUCKYOS_AGENT_PROGRESS__";
+
+function emitAiccProgress(
+  method: string,
+  stage: "running" | "finalizing",
+  externalTaskId: string,
+  elapsedMs: number,
+): void {
+  console.error(`${AGENT_TOOL_PROGRESS_PREFIX}${JSON.stringify({
+    agent_tool_progress: "1",
+    kind: "aicc",
+    method,
+    stage,
+    task_id: externalTaskId,
+    elapsed_ms: elapsedMs,
+  })}`);
+}
+
 function envNumber(name: string, fallback: number): number {
   const raw = Deno.env.get(name);
   if (!raw) return fallback;
@@ -176,11 +194,22 @@ function asAiResponse(value: unknown): AiResponse | null {
 async function waitForFinalTask(
   taskMgr: RpcClient,
   externalTaskId: string,
+  method: string,
   appId: string,
   userId: string,
   deadlineMs: number,
 ): Promise<TaskRecord> {
+  const startedAt = Date.now();
+  let lastProgressAt = 0;
+  const reportRunning = () => {
+    const now = Date.now();
+    if (now - lastProgressAt >= 5_000) {
+      emitAiccProgress(method, "running", externalTaskId, now - startedAt);
+      lastProgressAt = now;
+    }
+  };
   while (Date.now() < deadlineMs) {
+    reportRunning();
     const raw = await taskMgr.call("list_tasks", {
       app_id: appId,
       task_type: "aicc.compute",
@@ -193,8 +222,12 @@ async function waitForFinalTask(
     const matched = tasks.find((t) => t.data?.aicc?.external_task_id === externalTaskId);
     if (matched) {
       while (Date.now() < deadlineMs) {
+        reportRunning();
         const next = normalizeTask(await taskMgr.call("get_task", { id: matched.id }));
-        if (["Completed", "Failed", "Canceled"].includes(next.status)) return next;
+        if (["Completed", "Failed", "Canceled"].includes(next.status)) {
+          emitAiccProgress(method, "finalizing", externalTaskId, Date.now() - startedAt);
+          return next;
+        }
         await sleep(1000);
       }
       throw new Error(`timed out while waiting for AICC task ${matched.id} to finish`);
@@ -246,6 +279,7 @@ export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise
   const finalTask = await waitForFinalTask(
     taskMgr,
     response.task_id,
+    opts.method,
     runtime.appId,
     runtime.userId,
     deadline,

--- a/src/tools/buckyos-agent/lib/aicc.ts
+++ b/src/tools/buckyos-agent/lib/aicc.ts
@@ -71,11 +71,12 @@ export interface CallResult {
 }
 
 interface TaskRecord {
-  id: number;
-  status: string;
+  task_id: string;
+  phase: string;
+  outcome?: string | null;
   message?: string | null;
   updated_at?: number;
-  data?: {
+  result?: {
     request?: {
       external_task_id?: string;
     };
@@ -88,6 +89,7 @@ interface TaskRecord {
     };
     error?: JsonValue;
   };
+  error?: JsonValue;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -171,14 +173,6 @@ function rpcMethodForCall(method: string): string {
   return method;
 }
 
-function normalizeTaskList(result: unknown): TaskRecord[] {
-  if (Array.isArray(result)) return result as TaskRecord[];
-  if (result && typeof result === "object" && Array.isArray((result as { tasks?: unknown }).tasks)) {
-    return (result as { tasks: TaskRecord[] }).tasks;
-  }
-  return [];
-}
-
 function normalizeTask(result: unknown): TaskRecord {
   if (result && typeof result === "object" && "task" in result) {
     return (result as { task: TaskRecord }).task;
@@ -198,7 +192,7 @@ function asAiResponse(value: unknown): AiResponse | null {
 
 async function waitForFinalTask(
   taskMgr: RpcClient,
-  externalTaskId: string,
+  taskId: string,
   method: string,
   deadlineMs: number,
 ): Promise<TaskRecord> {
@@ -207,34 +201,22 @@ async function waitForFinalTask(
   const reportRunning = () => {
     const now = Date.now();
     if (now - lastProgressAt >= 5_000) {
-      emitAiccProgress(method, "running", externalTaskId, now - startedAt);
+      emitAiccProgress(method, "running", taskId, now - startedAt);
       lastProgressAt = now;
     }
   };
   while (Date.now() < deadlineMs) {
     reportRunning();
-    const raw = await taskMgr.call("list_tasks", {
-      task_type: "aicc.compute",
-    });
-    const tasks = normalizeTaskList(raw).sort(
-      (a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0),
+    const next = normalizeTask(
+      await taskMgr.call("get_task", { task_id: taskId }),
     );
-    const matched = tasks.find((t) => t.data?.request?.external_task_id === externalTaskId);
-    if (matched) {
-      while (Date.now() < deadlineMs) {
-        reportRunning();
-        const next = normalizeTask(await taskMgr.call("get_task", { id: matched.id }));
-        if (["Completed", "Failed", "Canceled"].includes(next.status)) {
-          emitAiccProgress(method, "finalizing", externalTaskId, Date.now() - startedAt);
-          return next;
-        }
-        await sleep(1000);
-      }
-      throw new Error(`timed out while waiting for AICC task ${matched.id} to finish`);
+    if (next.phase === "Terminal") {
+      emitAiccProgress(method, "finalizing", taskId, Date.now() - startedAt);
+      return next;
     }
     await sleep(1000);
   }
-  throw new Error(`timed out while locating AICC task for external_task_id=${externalTaskId}`);
+  throw new Error(`timed out while waiting for AICC task ${taskId} to finish`);
 }
 
 export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise<CallResult> {
@@ -244,7 +226,7 @@ export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise
   const taskMgr = (runtime.buckyos as any).getServiceRpcClient("task-manager") as RpcClient;
 
   const request = buildRequest(opts);
-  const waitTimeoutMs = opts.waitTimeoutMs ?? envNumber("AICC_DEFAULT_TIMEOUT", 180_000);
+  const waitTimeoutMs = opts.waitTimeoutMs ?? envNumber("AICC_DEFAULT_TIMEOUT", 900_000);
 
   let response: AiccMethodResponse;
   try {
@@ -282,11 +264,11 @@ export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise
     opts.method,
     deadline,
   );
-  if (finalTask.status === "Completed") {
+  if (finalTask.outcome === "Succeeded") {
     return {
       taskId: response.task_id,
       status: "succeeded",
-      summary: asAiResponse(finalTask.data?.result?.output ?? null),
+      summary: asAiResponse(finalTask.result?.result?.output ?? null),
       rawResponse: response,
       finalTask,
     };
@@ -294,7 +276,7 @@ export async function callAicc(runtime: AiccRuntime, opts: CallOptions): Promise
   return {
     taskId: response.task_id,
     status: "failed",
-    summary: asAiResponse(finalTask.data?.result?.output ?? null),
+    summary: asAiResponse(finalTask.result?.result?.output ?? null),
     rawResponse: response,
     finalTask,
   };
@@ -363,9 +345,10 @@ export function textToImage(runtime: AiccRuntime, opts: TextToImageOptions): Pro
 
 export function describeFailure(result: CallResult): string {
   if (result.finalTask) {
-    const err = result.finalTask.data?.error ?? result.finalTask.message;
+    const err = result.finalTask.error ?? result.finalTask.result?.error ??
+      result.finalTask.message;
     if (err) return typeof err === "string" ? err : JSON.stringify(err);
-    return `task ended with ${result.finalTask.status}`;
+    return `task ended with ${result.finalTask.outcome ?? result.finalTask.phase}`;
   }
   if (result.rawResponse?.result) {
     return JSON.stringify(result.rawResponse.result);

--- a/src/tools/buckyos-agent/lib/aicc_test.ts
+++ b/src/tools/buckyos-agent/lib/aicc_test.ts
@@ -14,8 +14,11 @@ function runtimeWithTask(task: Record<string, unknown>): AiccRuntime {
     call: () => Promise.resolve({ task_id: "aicc-1", status: "running" }),
   };
   const taskMgr = {
-    call: (method: string) => {
-      if (method === "list_tasks") return Promise.resolve({ tasks: [task] });
+    call: (method: string, params: Record<string, unknown>) => {
+      if (method === "list_tasks") {
+        assertEquals(params, { task_type: "aicc.compute" });
+        return Promise.resolve({ tasks: [task] });
+      }
       if (method === "get_task") return Promise.resolve({ task });
       throw new Error(`unexpected method: ${method}`);
     },

--- a/src/tools/buckyos-agent/lib/aicc_test.ts
+++ b/src/tools/buckyos-agent/lib/aicc_test.ts
@@ -1,0 +1,78 @@
+import { callAicc, describeFailure } from "./aicc.ts";
+import type { AiccRuntime } from "./runtime.ts";
+
+function assertEquals(actual: unknown, expected: unknown): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function runtimeWithTask(task: Record<string, unknown>): AiccRuntime {
+  const aiccRpc = {
+    call: () => Promise.resolve({ task_id: "aicc-1", status: "running" }),
+  };
+  const taskMgr = {
+    call: (method: string) => {
+      if (method === "list_tasks") return Promise.resolve({ tasks: [task] });
+      if (method === "get_task") return Promise.resolve({ task });
+      throw new Error(`unexpected method: ${method}`);
+    },
+  };
+  return {
+    buckyos: {
+      getServiceRpcClient: (service: string) =>
+        service === "aicc" ? aiccRpc : taskMgr,
+    },
+    userId: "devtest",
+    ownerUserId: "devtest",
+    zoneHost: "test.buckyos.io",
+    appId: "buckyos_jarvis",
+  };
+}
+
+Deno.test("callAicc resolves a completed beta2.2 task", async () => {
+  const output = {
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+    },
+  };
+  const task = {
+    id: 7,
+    status: "Completed",
+    data: {
+      request: { external_task_id: "aicc-1" },
+      result: { output },
+    },
+  };
+
+  const result = await callAicc(runtimeWithTask(task), {
+    capability: "video",
+    method: "video.img2video",
+  });
+
+  assertEquals(result.status, "succeeded");
+  assertEquals(result.summary, output);
+});
+
+Deno.test("describeFailure reads a beta2.2 task error", async () => {
+  const error = { code: "provider_failed", message: "video failed" };
+  const task = {
+    id: 8,
+    status: "Failed",
+    data: {
+      request: { external_task_id: "aicc-1" },
+      error,
+    },
+  };
+
+  const result = await callAicc(runtimeWithTask(task), {
+    capability: "video",
+    method: "video.img2video",
+  });
+
+  assertEquals(result.status, "failed");
+  assertEquals(describeFailure(result), JSON.stringify(error));
+});

--- a/src/tools/buckyos-agent/lib/aicc_test.ts
+++ b/src/tools/buckyos-agent/lib/aicc_test.ts
@@ -11,15 +11,14 @@ function assertEquals(actual: unknown, expected: unknown): void {
 
 function runtimeWithTask(task: Record<string, unknown>): AiccRuntime {
   const aiccRpc = {
-    call: () => Promise.resolve({ task_id: "aicc-1", status: "running" }),
+    call: () => Promise.resolve({ task_id: "t-aicc-1", status: "running" }),
   };
   const taskMgr = {
     call: (method: string, params: Record<string, unknown>) => {
-      if (method === "list_tasks") {
-        assertEquals(params, { task_type: "aicc.compute" });
-        return Promise.resolve({ tasks: [task] });
+      if (method === "get_task") {
+        assertEquals(params, { task_id: "t-aicc-1" });
+        return Promise.resolve(task);
       }
-      if (method === "get_task") return Promise.resolve({ task });
       throw new Error(`unexpected method: ${method}`);
     },
   };
@@ -43,9 +42,10 @@ Deno.test("callAicc resolves a completed beta2.2 task", async () => {
     },
   };
   const task = {
-    id: 7,
-    status: "Completed",
-    data: {
+    task_id: "t-aicc-1",
+    phase: "Terminal",
+    outcome: "Succeeded",
+    result: {
       request: { external_task_id: "aicc-1" },
       result: { output },
     },
@@ -63,9 +63,10 @@ Deno.test("callAicc resolves a completed beta2.2 task", async () => {
 Deno.test("describeFailure reads a beta2.2 task error", async () => {
   const error = { code: "provider_failed", message: "video failed" };
   const task = {
-    id: 8,
-    status: "Failed",
-    data: {
+    task_id: "t-aicc-1",
+    phase: "Terminal",
+    outcome: "Failed",
+    result: {
       request: { external_task_id: "aicc-1" },
       error,
     },

--- a/src/tools/buckyos-agent/readme.md
+++ b/src/tools/buckyos-agent/readme.md
@@ -102,6 +102,9 @@ deno run --config /opt/buckyos/bin/opendan/buckyos-agent/deno.json \
 
 CLI 始终将 `AgentToolResult` JSON 写到 stdout（与 `src/frame/agent_tool` 的协议一致，`agent_tool_protocol: "1"`），stderr 用于进度日志。退出码遵循 doc §2.5：
 
+异步 AICC 任务等待期间，CLI 每 5 秒向 stderr 写一行以
+`__BUCKYOS_AGENT_PROGRESS__` 开头的结构化心跳。OpenDAN 会消费该心跳以更新会话状态并续租 `exec_bash` 的空闲超时；它不属于最终 `AgentToolResult`。
+
 - `0` 成功
 - `1` 参数错误
 - `2` AICC 调用失败

--- a/test/aicc_test/aicc_smoke.ts
+++ b/test/aicc_test/aicc_smoke.ts
@@ -64,12 +64,17 @@ type TaskRecord = {
   message?: string | null;
   updated_at?: number;
   data?: {
-    aicc?: {
+    request?: {
       external_task_id?: string;
-      output?: JsonValue;
-      error?: JsonValue;
+    };
+    progress?: {
       status?: string;
     };
+    result?: {
+      output?: JsonValue;
+      provider_output?: JsonValue;
+    };
+    error?: JsonValue;
   };
 };
 
@@ -1094,11 +1099,11 @@ async function saveArtifacts(
 }
 
 function extractTaskResponse(task: TaskRecord): AiResponse | null {
-  return asAiResponse(task.data?.aicc?.output ?? null);
+  return asAiResponse(task.data?.result?.output ?? null);
 }
 
 function extractTaskError(task: TaskRecord): unknown {
-  return task.data?.aicc?.error ?? task.message ?? null;
+  return task.data?.error ?? task.message ?? null;
 }
 
 function isSkippableError(message: string): boolean {
@@ -1134,7 +1139,7 @@ async function findTaskByExternalId(
       (left, right) => (right.updated_at ?? 0) - (left.updated_at ?? 0),
     );
     const matched = tasks.find(
-      (task) => task.data?.aicc?.external_task_id === externalTaskId,
+      (task) => task.data?.request?.external_task_id === externalTaskId,
     );
     if (matched) {
       return matched;
@@ -1616,7 +1621,7 @@ async function runCase(args: {
         status: "failed",
         task_id: response.task_id,
         error: message,
-        task_output: finalTask.data?.aicc?.output ?? null,
+        task_output: finalTask.data?.result?.output ?? null,
       });
       return {
         status: "failed",

--- a/test/aicc_test/test_fal.ts
+++ b/test/aicc_test/test_fal.ts
@@ -64,12 +64,17 @@ type TaskRecord = {
   message?: string | null;
   updated_at?: number;
   data?: {
-    aicc?: {
+    request?: {
       external_task_id?: string;
-      output?: JsonValue;
-      error?: JsonValue;
+    };
+    progress?: {
       status?: string;
     };
+    result?: {
+      output?: JsonValue;
+      provider_output?: JsonValue;
+    };
+    error?: JsonValue;
   };
 };
 
@@ -159,7 +164,7 @@ async function findTaskByExternalId(
       (a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0),
     );
     const matched = tasks.find(
-      (task) => task.data?.aicc?.external_task_id === externalTaskId,
+      (task) => task.data?.request?.external_task_id === externalTaskId,
     );
     if (matched) return matched;
     await sleep(1000);
@@ -239,12 +244,12 @@ function aiResponseArtifacts(response: AiResponse): AiArtifact[] {
 }
 
 function pickAiResponseFromTask(task: TaskRecord): AiResponse | null {
-  const output = task.data?.aicc?.output;
+  const output = task.data?.result?.output;
   return asAiResponse(output ?? null);
 }
 
 function pickErrorFromTask(task: TaskRecord): string {
-  const error = task.data?.aicc?.error ?? task.message ?? null;
+  const error = task.data?.error ?? task.message ?? null;
   return typeof error === "string" ? error : JSON.stringify(error ?? "<empty>");
 }
 


### PR DESCRIPTION
## 背景

本 PR 汇总 beta2.2 上围绕 Jarvis 图生视频链路的阶段性修复，主要解决 AICC 缺少可用视频 provider、同步等待长任务导致超时，以及 Telegram 端缺少进度/失败反馈的问题。

主要关联：

- Resolves #546
- Partially addresses #548
- Partially addresses #550
- AIOS 打包前置 #537 已合入 `beta2.2`

## 已完成

### AICC provider 与能力路由

- 接入 OpenAI Videos/Sora 的异步视频生成与图生视频请求。
- 接入 Gemini 视频生成的异步提交、状态轮询与结果归一化。
- 补齐 Fal 等视频 provider 的长任务异步执行路径。
- 将 OpenAI OCR/caption 能力接入候选模型路由；保留 caption，不处理 Jarvis 的 OCR/caption 冗余调用策略。
- 规范 OpenAI 图生视频 reference image 的输入格式和上传处理。
- 更新 OpenAI/Gemini driver metadata 与 provider 文档。

### 长任务与用户反馈

- AICC 对长耗时视频任务返回 running，并在后台推进 Task Manager 状态，避免 provider 调用占满同步 RPC 窗口。
- AIOS CLI 在等待异步 AICC 任务期间输出结构化心跳，OpenDAN 用其续租工具执行时间并更新会话进度。
- Telegram 过程状态改为更新当前状态，减少重复罗列工具步骤。
- 增加运行失败、超时及消息投递失败的最终用户提示，避免只停留在“思考完成/正在思考”。
- 保留会话媒体上下文，避免后续步骤丢失输入图片。

### beta2.2 Task 数据适配

- AIOS CLI 按 beta2.2 的 `aicc.compute` typed task data 读取任务状态、结果和错误。
- 修复异步任务定位时使用错误 app/source 过滤的问题：查询候选任务仅使用协议支持的 `task_type`，再按 `external_task_id` 精确匹配；任务可见性仍由 Task Manager 根据 session token 强制控制。

## 明确未处理 / 遗留问题

- #549：模型在不同 ApiType/应用场景下的软权重应由 metadata 表达。本 PR 不加入硬编码 provider 优先级。
- #561：长任务仍需要可恢复的任务状态管理、查询/取消/重连语义，不能长期依赖统一硬超时。
- #555：服务 token 经 verify-hub 交换后丢失 zone-trusted 语义，Task Dispatcher target instance 可能无法续租。本 PR 未放宽安全检查，也已回退 runtime 全局缓存/延迟交换类 workaround，等待凭证生命周期设计。
- #562：重启窗口 scheduler 可能短暂发布空 ServiceInfo，并因 refresh throttle/cache 延迟恢复。本 PR 不在 runtime 中缓存历史本地 URL 掩盖该问题。
- #560：生成文件使用相对附件路径时缺少 workspace anchor 的问题独立处理。
- #548 中 Jarvis 重复调用 OCR/caption 的策略问题不在本 PR 范围；这里只修候选能力与调用失败。
- #551 原始“AppService 容器内错误依赖用户私钥”已由 `beta2.2` 中 PR #543 / commit `bcaf99e11` 解决，不是本 PR 遗留项。

## 验证

已完成：

- `cargo test -p buckyos-api`：128 passed。
- `cargo check -p opendan`：通过；仅有一个既有 `unused_mut` warning。
- `git diff --check`：通过。
- provider adapter、任务协议及任务数据读取均包含新增/更新测试。

本地未完成：

- 当前 Windows 环境没有 Deno，`src/tools/buckyos-agent/lib/aicc_test.ts` 未在本机执行。
- `cargo test -p aicc` 两次均停留在编译阶段超过执行窗口，未观察到测试失败，但不能视为完整通过。
- 仍需在合入 #537 后生成的最新 AIOS 镜像中做真实 Telegram img2video 端到端验证。

## Review 提示

本 PR 跨 AICC provider、OpenDAN/msg-center 状态反馈及 AIOS CLI，建议按上述三个部分分别 review。尤其请确认：

1. provider 异步响应与 Task Manager typed data 的状态转换；
2. OpenAI/Gemini metadata 暴露的 capability 是否符合实际 API；
3. CLI 去掉 app filter 后仍由 Task Manager 的 token 可见性约束，不依赖客户端过滤实现授权；
4. #555、#561、#562 不应通过扩大 timeout、缓存历史 endpoint 或放宽鉴权在本 PR 中临时绕过。