### PR TITLE
修复 AICC 异步视频生成与 Jarvis 任务进度反馈

### DIFF
--- a/src/frame/opendan/src/agent.rs
+++ b/src/frame/opendan/src/agent.rs
@@ -273,6 +273,9 @@ async fn resolve_appclient_session_token() -> Result<String> {
             }
         }
     };
+    runtime.renew_token_from_verify_hub().await.map_err(|err| {
+        anyhow!("renew appclient session token before building session tools: {err}")
+    })?;
     let token = runtime.get_session_token().await;
     if token.trim().is_empty() {
         #[cfg(test)]

--- a/src/frame/opendan/src/agent_bash.rs
+++ b/src/frame/opendan/src/agent_bash.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use async_trait::async_trait;
+use buckyos_api::get_buckyos_api_runtime;
 use log::warn;
 use tokio::fs;
 use tokio::process::Command;
@@ -373,7 +374,11 @@ impl BashRunner for TmuxBashRunner {
         let exit_code_path = self.runtime_dir.join(format!("{run_id}.exit.code"));
         let script_path = self.runtime_dir.join(format!("{run_id}.exec.sh"));
 
-        let env = runtime_exec_env(&req.env, &self.base_env, ctx);
+        let mut env = runtime_exec_env(&req.env, &self.base_env, ctx);
+        if let Ok(runtime) = get_buckyos_api_runtime() {
+            let token = runtime.get_session_token().await;
+            set_current_appclient_session_token(&mut env, &token);
+        }
         let script = build_exec_script(
             &run_id,
             &stdout_path,
@@ -657,6 +662,17 @@ fn runtime_exec_env(
     set_env_value(&mut env, OPENDAN_TRACE_ID_ENV, ctx.trace_id.clone());
     set_env_value(&mut env, OPENDAN_SESSION_ID_ENV, ctx.session_id.clone());
     env
+}
+
+fn set_current_appclient_session_token(env: &mut Vec<(String, String)>, token: &str) {
+    let token = token.trim();
+    if !token.is_empty() {
+        set_env_value(
+            env,
+            agent_tool::BUCKYOS_APPCLIENT_SESSION_TOKEN_ENV,
+            token.to_string(),
+        );
+    }
 }
 
 fn is_agent_tool_context_override_env(key: &str) -> bool {
@@ -1439,6 +1455,23 @@ mod tests {
             "runtime-token"
         );
         assert!(value("OPENDAN_AGENT_TOOL").is_empty());
+    }
+
+    #[test]
+    fn current_appclient_session_token_replaces_session_snapshot() {
+        let mut env = vec![(
+            agent_tool::BUCKYOS_APPCLIENT_SESSION_TOKEN_ENV.to_string(),
+            "stale-token".to_string(),
+        )];
+
+        set_current_appclient_session_token(&mut env, " current-token ");
+
+        assert_eq!(
+            env.iter()
+                .find(|(key, _)| key == agent_tool::BUCKYOS_APPCLIENT_SESSION_TOKEN_ENV)
+                .map(|(_, value)| value.as_str()),
+            Some("current-token")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

本 PR 汇总 beta2.2 上围绕图片生成视频、OCR/caption 候选路由、长耗时 AICC 任务以及 Telegram/Jarvis 状态反馈的一组修复，主要解决 #546，并缓解 #548、#550 中已经确认的失败路径。OCR/caption 冗余调用策略不在本 PR 范围内。

## 已完成

### AICC provider

- 为 OpenAI 接入异步 Videos API，并补充视频 capability/model metadata。
- 为 Gemini 接入异步视频生成和任务轮询。
- 对齐 Fal、OpenAI、Gemini 的长视频任务返回语义。
- 规范化 OpenAI image-to-video 参考图片输入。
- 为 OpenAI 补充 OCR/caption 路由能力，避免存在 provider 却没有候选模型。
- 更新 provider plan 和 adapter protocol tests。

### 长任务与 Jarvis 反馈

- 视频生成改为 AICC/Task Manager 异步任务，避免同步阻塞完整 provider 调用。
- AIOS CLI 等待期间输出结构化 progress heartbeat；OpenDAN 消费 heartbeat、延续工具执行超时并更新当前进度状态。
- Telegram 过程状态改为更新展示，减少连续工具完成消息堆叠。
- runtime/tool/delivery 失败时发送明确最终失败消息。
- 保留会话媒体输入，避免后续工具阶段丢失图片上下文。

### beta2.2 Task 数据与 CLI

- AIOS CLI 按 beta2.2 `aicc.compute` typed task data 读取结果和错误。
- 修复异步任务查询中过度使用 app/source 过滤导致 `external_task_id` 无法匹配的问题。
- Task Manager 仍根据请求 token 强制过滤可见任务。

## 当前边界

- #548 中缺少候选模型的问题已处理，Jarvis 重复调用 OCR/caption 未处理。
- #550 的同步 60 秒超时路径已改为异步任务，但可恢复状态、断线重连和取消语义仍待 #561。
- CLI 当前仅按 `task_type=aicc.compute` 获取 token 可见任务后匹配 `external_task_id`；后续更严格的实现应从已验证 token claims 获取 owner `appid`，而非环境变量。
- 没有加入硬编码 provider 权重；场景软权重应由 metadata 表达，见 #549。

## 遗留问题

- #549：按 ApiType/场景配置模型软权重。
- #551：AIOS CLI 在 AppService 容器中的用户私钥依赖。
- #555：服务 token 经 verify-hub 交换后丢失 zone-trusted 语义，导致 TaskMgr/Dispatcher 权限失败。
- #560：相对附件路径缺少 workspace anchor。
- #561：长耗时异步任务需要可恢复状态管理。
- #562：重启窗口 scheduler 暂时发布空 ServiceInfo，并因 throttle/cache 延迟恢复。
- #547：部分 provider/quota RPC 方法尚未实现。

服务身份问题曾尝试在 `runtime.rs` 延迟 token 交换，但 AppService 没有设备私钥，只能把问题推迟到初始 token 过期且影响所有 runtime 类型；该修改已回退，留待 #555 讨论。

## 验证

- `cargo test -p buckyos-api`：128 passed。
- `cargo check -p opendan`：通过，仅有一个已有 `unused_mut` warning。
- `git diff --check`：通过。
- `cargo test -p aicc`：两次在本机编译阶段分别超过 120 秒和 180 秒超时，未得到测试结果，也未观察到测试失败。
- 当前 Windows 环境没有 Deno，AIOS TS 单元测试未执行。

Closes #546

Partially addresses #548
Partially addresses #550

Related: #537, #547, #549, #551, #555, #560, #561, #562

## 最新日志诊断与待处理项

最近一轮日志表明，请求在 OpenDAN 启动后约 4 秒进入；`llm_understand_media` 已正常返回，但随后 AICC `create_task` 以及 OpenDAN 的状态/失败消息投递均因 `ServiceInfo` 尚未就绪而返回 403（`local node ood1 is not found`）。路由稍后恢复，但缺少重试，因此 Telegram 停留在“准备使用工具...”状态。

本 PR **尚未实现 Agent 启动 readiness gate**，不会将该问题标记为已修复。后续建议在开始读取入站消息前，确认 msg-center、AICC、TaskMgr 的鉴权 RPC 已可用；同时仍需分别处理底层 ServiceInfo 发布竞态（#562）和失败消息/状态更新的重试与兜底。Token 生命周期问题继续由 #555 独立跟踪。
