### PR TITLE
Decouple Scheduler from SN AI authentication

### DIFF
--- a/src/kernel/scheduler/Cargo.toml
+++ b/src/kernel/scheduler/Cargo.toml
@@ -36,7 +36,6 @@ buckyos-http-server = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
-reqwest = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src/kernel/scheduler/src/system_config_builder.rs
+++ b/src/kernel/scheduler/src/system_config_builder.rs
@@ -1,5 +1,5 @@
-use ::kRPC::{RPCSessionToken, RPCSessionTokenType};
 use anyhow::{anyhow, Result};
+use buckyos_api::load_local_node_identity_config;
 use buckyos_api::msg_queue::{
     generate_kmsg_service_doc, KMSG_SERVICE_MAIN_PORT, KMSG_SERVICE_UNIQUE_ID,
 };
@@ -15,23 +15,22 @@ use buckyos_api::{
     UserTunnelBinding, UserType, ZoneConfig, OPENDAN_SERVICE_PORT, OPENDAN_SERVICE_UNIQUE_ID,
     SCHEDULER_SERVICE_UNIQUE_ID, VERIFY_HUB_UNIQUE_ID,
 };
-use buckyos_api::{load_local_device_private_key, load_local_node_identity_config};
 use buckyos_api::{
     AICC_SERVICE_SERVICE_PORT, AICC_SERVICE_UNIQUE_ID, CONTROL_PANEL_SERVICE_PORT,
     CONTROL_PANEL_SERVICE_UNIQUE_ID, MSG_CENTER_SERVICE_PORT, MSG_CENTER_SERVICE_UNIQUE_ID,
     REPO_SERVICE_UNIQUE_ID, SMB_SERVICE_UNIQUE_ID, TASK_MANAGER_SERVICE_PORT,
     TASK_MANAGER_SERVICE_UNIQUE_ID, WORKFLOW_SERVICE_PORT, WORKFLOW_SERVICE_UNIQUE_ID,
 };
-use buckyos_kit::{buckyos_get_unix_timestamp, get_buckyos_system_etc_dir};
+use buckyos_kit::get_buckyos_system_etc_dir;
 use jsonwebtoken::jwk::Jwk;
 use log::{debug, info, warn};
 use name_lib::{generate_ed25519_key_pair, AgentDocument, OwnerDocument, VerifyHubInfo, DID};
 use package_lib::PackageId;
-use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use url::Url;
 
 const DEFAULT_OOD_ID: &str = "ood1";
 const PROFILE_SYSTEM_CONTACT_KEY: &str = "system_contact";
@@ -41,7 +40,6 @@ const DEFAULT_SN_AI_PROVIDER_IMAGE_MODELS: &[&str] = &["dall-e-3", "dall-e-2"];
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct SnAiProviderEndpoints {
-    pub models_url: String,
     pub responses_url: String,
 }
 
@@ -76,18 +74,11 @@ pub(crate) fn derive_sn_ai_provider_endpoints(
     }
 
     origin.set_path("/");
-    let models_url = origin
-        .join("api/v1/ai/models")
-        .map_err(|err| anyhow!("failed to derive SN AI models URL: {err}"))?
-        .to_string();
     let responses_url = origin
         .join("api/v1/ai/")
         .map_err(|err| anyhow!("failed to derive SN AI responses URL: {err}"))?
         .to_string();
-    Ok(SnAiProviderEndpoints {
-        models_url,
-        responses_url,
-    })
+    Ok(SnAiProviderEndpoints { responses_url })
 }
 
 pub(crate) fn reconcile_managed_sn_ai_provider(
@@ -480,16 +471,8 @@ impl SystemConfigBuilder {
         } else {
             None
         };
-        let sn_ai_provider_models = if let Some(endpoints) = sn_ai_provider_endpoints.as_ref() {
-            fetch_sn_ai_provider_models(config.user_name.as_str(), endpoints).await
-        } else {
-            None
-        };
-        let settings = build_aicc_settings_with_endpoints(
-            config,
-            sn_ai_provider_endpoints.as_ref(),
-            sn_ai_provider_models.as_deref(),
-        );
+        let settings =
+            build_aicc_settings_with_endpoints(config, sn_ai_provider_endpoints.as_ref());
         self.insert_json_if_absent("services/aicc/settings", &settings)?;
         Ok(self)
     }
@@ -837,23 +820,14 @@ fn build_zone_user_contact_settings(
 
 #[cfg(test)]
 fn build_aicc_settings(config: &StartConfigSummary) -> Value {
-    build_aicc_settings_with_sn_models(config, None)
-}
-
-#[cfg(test)]
-fn build_aicc_settings_with_sn_models(
-    config: &StartConfigSummary,
-    sn_ai_provider_models: Option<&[String]>,
-) -> Value {
     let endpoints = derive_sn_ai_provider_endpoints(Some("sn.buckyos.ai"))
         .expect("test SN AI endpoint must be valid");
-    build_aicc_settings_with_endpoints(config, Some(&endpoints), sn_ai_provider_models)
+    build_aicc_settings_with_endpoints(config, Some(&endpoints))
 }
 
 fn build_aicc_settings_with_endpoints(
     config: &StartConfigSummary,
     sn_ai_provider_endpoints: Option<&SnAiProviderEndpoints>,
-    sn_ai_provider_models: Option<&[String]>,
 ) -> Value {
     const DEFAULT_PROVIDER_TIMEOUT_MS: u64 = 600_000;
     let mut settings = serde_json::Map::new();
@@ -883,7 +857,7 @@ fn build_aicc_settings_with_endpoints(
     if config.llm_router_enabled() {
         let endpoints = sn_ai_provider_endpoints
             .expect("SN AI endpoints are validated before building enabled provider settings");
-        let sn_model_settings = build_sn_ai_provider_model_settings(sn_ai_provider_models);
+        let sn_model_settings = build_sn_ai_provider_model_settings();
         if !sn_ai_provider_alias_map.contains_key("llm.default") {
             sn_ai_provider_alias_map.insert(
                 "llm.default".to_string(),
@@ -1018,22 +992,11 @@ struct SnAIProviderModelSettings {
     default_image_model: String,
 }
 
-fn build_sn_ai_provider_model_settings(
-    sn_ai_provider_models: Option<&[String]>,
-) -> SnAIProviderModelSettings {
-    let mut models = sn_ai_provider_models
-        .unwrap_or(&[])
+fn build_sn_ai_provider_model_settings() -> SnAIProviderModelSettings {
+    let models = DEFAULT_SN_AI_PROVIDER_MODELS
         .iter()
-        .map(|item| item.trim())
-        .filter(|item| !item.is_empty())
         .map(|item| item.to_string())
         .collect::<Vec<_>>();
-    if models.is_empty() {
-        models = DEFAULT_SN_AI_PROVIDER_MODELS
-            .iter()
-            .map(|item| item.to_string())
-            .collect::<Vec<_>>();
-    }
 
     let default_model = pick_preferred_model(models.as_slice(), &["gpt-5.4-mini", "gpt-5.4"])
         .unwrap_or_else(|| models[0].clone());
@@ -1081,122 +1044,12 @@ fn is_image_model(model_id: &str) -> bool {
         || value.contains("vision")
 }
 
-async fn fetch_sn_ai_provider_models(
-    user_name: &str,
-    endpoints: &SnAiProviderEndpoints,
-) -> Option<Vec<String>> {
-    match fetch_sn_ai_provider_models_impl(user_name, endpoints).await {
-        Ok(models) => Some(models),
-        Err(err) => {
-            warn!(
-                "fetch sn-ai-provider models from {} failed: {}",
-                endpoints.models_url, err
-            );
-            None
-        }
-    }
-}
-
-async fn fetch_sn_ai_provider_models_impl(
-    user_name: &str,
-    endpoints: &SnAiProviderEndpoints,
-) -> Result<Vec<String>> {
-    let token = build_device_jwt_token_for_sn(user_name)?;
-    let client = Client::new();
-    let response = client
-        .get(endpoints.models_url.as_str())
-        .bearer_auth(token)
-        .send()
-        .await
-        .map_err(|err| anyhow!("request failed: {}", err))?;
-    let status = response.status();
-    if !status.is_success() {
-        return Err(anyhow!("request failed with status {}", status));
-    }
-    let response_text = response
-        .text()
-        .await
-        .map_err(|err| anyhow!("failed to read models response body: {}", err))?;
-    info!(
-        "sn-ai-provider models endpoint raw response: {}",
-        response_text
-    );
-    let body: Value = serde_json::from_str(response_text.as_str())
-        .map_err(|err| anyhow!("invalid models response json: {}", err))?;
-    let models = extract_model_ids_from_response(&body);
-    if models.is_empty() {
-        return Err(anyhow!("models response does not contain model ids"));
-    }
-
-    info!(
-        "fetched {} sn-ai-provider models: {:?}",
-        models.len(),
-        models
-    );
-    Ok(models)
-}
-
-fn build_device_jwt_token_for_sn(user_name: &str) -> Result<String> {
-    let node_identity_path = get_buckyos_system_etc_dir().join("node_identity.json");
-    let node_identity = load_local_node_identity_config(node_identity_path.as_path())
-        .map_err(|err| anyhow!("failed to load node identity: {}", err))?;
-    let device_name = node_identity.device_name.clone();
-    let private_key = load_local_device_private_key(&node_identity.device_did)
-        .map_err(|err| anyhow!("failed to load device private key: {}", err))?;
-    let now = buckyos_get_unix_timestamp();
-    let claims = RPCSessionToken {
-        token_type: RPCSessionTokenType::JWT,
-        token: None,
-        aud: None,
-        exp: Some(now + 60 * 15),
-        iss: Some(device_name),
-        jti: None,
-        sub: Some(user_name.to_string()),
-        appid: Some("aicc".to_string()),
-        sudo: false,
-        extra: HashMap::new(),
-    };
-    claims
-        .generate_jwt(None, &private_key)
-        .map_err(|err| anyhow!("generate sn models jwt failed: {}", err))
-}
-
 fn read_default_device_subject() -> String {
     let node_identity_path = get_buckyos_system_etc_dir().join("node_identity.json");
     if let Ok(node_identity) = load_local_node_identity_config(node_identity_path.as_path()) {
         return node_identity.device_name;
     }
     DEFAULT_OOD_ID.to_string()
-}
-
-fn extract_model_ids_from_response(payload: &Value) -> Vec<String> {
-    let mut result = Vec::<String>::new();
-
-    if let Some(items) = payload.get("items").and_then(|value| value.as_array()) {
-        for item in items {
-            if let Some(model_id) = item
-                .get("model")
-                .and_then(|value| value.as_str())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            {
-                result.push(model_id.to_string());
-            }
-        }
-    }
-
-    if let Some(default_model) = payload
-        .get("default_model")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        result.push(default_model.to_string());
-    }
-
-    result.sort_unstable();
-    result.dedup();
-    result
 }
 
 fn build_msg_center_settings(config: &StartConfigSummary) -> Result<Value> {
@@ -1411,10 +1264,9 @@ impl StartConfigSummary {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_aicc_settings, build_aicc_settings_with_sn_models, build_default_jarvis_agent_spec,
-        build_kernel_service_spec, build_msg_center_settings, build_zone_user_contact_settings,
-        extract_model_ids_from_response, StartConfigSummary, SystemConfigBuilder,
-        TELEGRAM_TUNNEL_INSTANCE_ID,
+        build_aicc_settings, build_default_jarvis_agent_spec, build_kernel_service_spec,
+        build_msg_center_settings, build_zone_user_contact_settings, StartConfigSummary,
+        SystemConfigBuilder, TELEGRAM_TUNNEL_INSTANCE_ID,
     };
     use buckyos_api::{
         generate_verify_hub_service_doc, AppDoc, AppServiceSpec, AppType, OPENDAN_SERVICE_PORT,
@@ -1635,24 +1487,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_model_ids_from_response_supports_items_models_and_data_shapes() {
-        let payload = json!({
-            "items": [
-                { "provider": "openai", "model": "gpt-5.4" },
-                { "provider": "openai", "model": "gpt-5.4-mini" }
-            ],
-            "default_model": "gpt-5.4-mini",
-            "models": ["legacy-ignored"],
-            "data": [{ "model_id": "legacy-ignored" }]
-        });
-        let models = extract_model_ids_from_response(&payload);
-        assert!(models.iter().any(|m| m == "gpt-5.4"));
-        assert!(models.iter().any(|m| m == "gpt-5.4-mini"));
-        assert!(!models.iter().any(|m| m == "legacy-ignored"));
-    }
-
-    #[test]
-    fn build_aicc_settings_uses_fetched_sn_model_list() {
+    fn build_aicc_settings_uses_static_sn_model_fallback() {
         let value = json!({
             "user_name": "alice",
             "admin_password_hash": "hashed",
@@ -1661,21 +1496,15 @@ mod tests {
             "sn_active_code": "invite-code-001"
         });
         let summary = StartConfigSummary::from_value(&value).expect("parse start config");
-        let sn_models = vec![
-            "gpt-5".to_string(),
-            "gpt-5-mini".to_string(),
-            "gpt-image-1".to_string(),
-        ];
-
-        let settings = build_aicc_settings_with_sn_models(&summary, Some(sn_models.as_slice()));
+        let settings = build_aicc_settings(&summary);
 
         assert_eq!(
             settings["sn-ai-provider"]["instances"][0]["models"],
-            json!(["gpt-5", "gpt-5-mini", "gpt-image-1"])
+            json!(["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro"])
         );
         assert_eq!(
             settings["sn-ai-provider"]["instances"][0]["default_image_model"],
-            "gpt-image-1"
+            "dall-e-3"
         );
     }
 

--- a/src/kernel/scheduler/tests/sn_ai_routing.rs
+++ b/src/kernel/scheduler/tests/sn_ai_routing.rs
@@ -34,14 +34,9 @@ fn managed_settings(enabled: bool, base_url: &str) -> Value {
 #[test]
 fn task009_derives_endpoints_from_bare_host_and_https_origin() {
     let bare = derive_sn_ai_provider_endpoints(Some(" sn.buckyos.io ")).unwrap();
-    assert_eq!(bare.models_url, "https://sn.buckyos.io/api/v1/ai/models");
     assert_eq!(bare.responses_url, "https://sn.buckyos.io/api/v1/ai/");
 
     let origin = derive_sn_ai_provider_endpoints(Some("https://sn.example:8443/")).unwrap();
-    assert_eq!(
-        origin.models_url,
-        "https://sn.example:8443/api/v1/ai/models"
-    );
     assert_eq!(origin.responses_url, "https://sn.example:8443/api/v1/ai/");
 }
 

--- a/test/aicc_test/README.md
+++ b/test/aicc_test/README.md
@@ -80,6 +80,23 @@ pnpm run test:fal
 
 退出码：`0` 全部通过；`1` 有失败；`2` 全部 skipped（未配置 fal）。
 
+## 运行 Issue #24 SN SSO E2E
+
+```bash
+cd test/aicc_test
+pnpm run test:issue24-sso
+```
+
+该入口严格使用标准 AppClient 和 Gateway，依次验证 SN Provider inventory、
+`provider.refresh_models`、两次连续 `llm.chat` 以及不存在 Provider 的错误路径。
+默认实例名为 `sn-ai-provider-default`，可用 `ISSUE24_PROVIDER_NAME` 和
+`ISSUE24_MODEL_ALIAS` 覆盖。报告写入 `reports/issue24-sn-sso-*.json`。
+
+连续推理通过只能证明同一会话窗口内链路可用，不能单独证明 Token 缓存命中。如果新
+Provider 在脱敏响应元数据中暴露 cache/reuse/login_count 等证据，可设置
+`ISSUE24_REQUIRE_CACHE_EVIDENCE=1` 将“有缓存证据”升级为强制断言。Refresh Token
+轮换、并发合并和首次 401 重试仍由 Mock SN 请求计数器验证。
+
 smoke 用例会通过 `../test_helpers/buckyos_client.ts` 的 `initTestRuntime()` 初始化标准 AppClient runtime，然后从 runtime 获取 AICC 和 task-manager client。
 
 ## 运行多模态 LLM 推理

--- a/test/aicc_test/issue24_sn_sso_e2e.ts
+++ b/test/aicc_test/issue24_sn_sso_e2e.ts
@@ -1,0 +1,306 @@
+import { initTestRuntime } from "../test_helpers/buckyos_client.ts";
+
+type RpcClient = {
+  call: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+};
+
+type ModelEntry = {
+  exact_model: string;
+  api_types?: string[];
+  logical_mounts?: string[];
+};
+
+type ProviderEntry = {
+  provider_instance_name: string;
+  inventory_revision?: string | null;
+  models?: ModelEntry[];
+};
+
+type ModelsListResponse = { providers?: ProviderEntry[] };
+
+type AiccResponse = {
+  task_id?: string;
+  status?: string;
+  result?: unknown;
+};
+
+type TaskRecord = {
+  id: number;
+  status: string;
+  message?: string | null;
+  data?: {
+    request?: { external_task_id?: string };
+    result?: { output?: unknown };
+    error?: unknown;
+  };
+};
+
+const PROVIDER_NAME = env("ISSUE24_PROVIDER_NAME") ?? "sn-ai-provider-default";
+const MODEL_ALIAS_OVERRIDE = env("ISSUE24_MODEL_ALIAS");
+const WAIT_TIMEOUT_MS = Number(env("ISSUE24_WAIT_TIMEOUT_MS") ?? "90000");
+const REQUIRE_CACHE_EVIDENCE = env("ISSUE24_REQUIRE_CACHE_EVIDENCE") === "1";
+const REPORT_PATH =
+  env("ISSUE24_REPORT_PATH") ??
+  `reports/issue24-sn-sso-${Date.now().toString(36)}.json`;
+
+function env(name: string): string | undefined {
+  const value = Deno.env.get(name)?.trim();
+  return value ? value : undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function taskList(value: unknown): TaskRecord[] {
+  if (Array.isArray(value)) return value as TaskRecord[];
+  if (!value || typeof value !== "object") return [];
+  const record = value as Record<string, unknown>;
+  for (const key of ["tasks", "items", "data", "result"]) {
+    if (Array.isArray(record[key])) return record[key] as TaskRecord[];
+  }
+  return [];
+}
+
+function taskRecord(value: unknown): TaskRecord | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const candidate = record.task ?? record.data ?? record.result ?? value;
+  if (!candidate || typeof candidate !== "object") return null;
+  const task = candidate as TaskRecord;
+  return typeof task.id === "number" && typeof task.status === "string"
+    ? task
+    : null;
+}
+
+async function awaitTask(
+  taskManager: RpcClient,
+  externalTaskId: string,
+  appId: string,
+  userId: string,
+): Promise<unknown> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  let task: TaskRecord | undefined;
+  while (Date.now() < deadline && !task) {
+    const raw = await taskManager.call("list_tasks", {
+      app_id: appId,
+      task_type: "aicc.compute",
+      source_user_id: userId,
+      source_app_id: appId,
+    });
+    task = taskList(raw).find(
+      (item) => item.data?.request?.external_task_id === externalTaskId,
+    );
+    if (!task) await sleep(1000);
+  }
+  if (!task) throw new Error(`AICC task not found: ${externalTaskId}`);
+
+  while (Date.now() < deadline) {
+    const latest = taskRecord(
+      await taskManager.call("get_task", { id: task.id }),
+    );
+    if (!latest) throw new Error(`Invalid task response for ${task.id}`);
+    if (latest.status === "Completed") return latest.data?.result?.output;
+    if (["Failed", "Canceled"].includes(latest.status)) {
+      throw new Error(
+        `AICC task ${task.id} ${latest.status}: ${JSON.stringify(
+          latest.data?.error ?? latest.message,
+        )}`,
+      );
+    }
+    await sleep(1000);
+  }
+  throw new Error(`AICC task timed out: ${externalTaskId}`);
+}
+
+async function invokeChat(
+  aicc: RpcClient,
+  taskManager: RpcClient,
+  modelAlias: string,
+  appId: string,
+  userId: string,
+  runId: string,
+): Promise<unknown> {
+  const raw = (await aicc.call("llm.chat", {
+    capability: "llm",
+    model: { alias: modelAlias },
+    requirements: {},
+    payload: {
+      input_json: {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Reply with exactly: issue24-ok" }],
+          },
+        ],
+        temperature: 0,
+        max_output_tokens: 32,
+      },
+      resources: [],
+      options: { session_id: "issue24-sso-cache-window", rootid: runId },
+    },
+    idempotency_key: runId,
+  })) as AiccResponse;
+  if (!raw?.task_id || !raw.status) {
+    throw new Error(`Invalid AICC response: ${JSON.stringify(raw)}`);
+  }
+  if (raw.status === "failed") {
+    throw new Error(`AICC inference failed: ${JSON.stringify(raw.result)}`);
+  }
+  if (raw.status === "succeeded" && raw.result) return raw.result;
+  return await awaitTask(taskManager, raw.task_id, appId, userId);
+}
+
+function cacheEvidence(value: unknown): Record<string, unknown> {
+  const evidence: Record<string, unknown> = {};
+  function visit(node: unknown, path: string): void {
+    if (!node || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      node.forEach((item, index) => visit(item, `${path}[${index}]`));
+      return;
+    }
+    for (const [key, child] of Object.entries(
+      node as Record<string, unknown>,
+    )) {
+      const next = path ? `${path}.${key}` : key;
+      if (/cache|reuse|refresh|login_count/i.test(key)) {
+        evidence[next] =
+          child === null || typeof child !== "object" ? child : "<present>";
+      }
+      if (!/token|authorization|secret|private.?key/i.test(key))
+        visit(child, next);
+    }
+  }
+  visit(value, "");
+  return evidence;
+}
+
+function chooseModel(provider: ProviderEntry): string {
+  if (MODEL_ALIAS_OVERRIDE) return MODEL_ALIAS_OVERRIDE;
+  for (const model of provider.models ?? []) {
+    if (model.api_types?.includes("llm.chat")) {
+      const logical = model.logical_mounts?.find((item) =>
+        item.startsWith("llm."),
+      );
+      return logical ?? model.exact_model;
+    }
+  }
+  throw new Error(`${PROVIDER_NAME} has no llm.chat model`);
+}
+
+async function main(): Promise<void> {
+  const { buckyos, userId, zoneHost } = await initTestRuntime();
+  const appId =
+    buckyos.getAppId?.() ?? env("BUCKYOS_TEST_APP_ID") ?? "buckycli";
+  const aicc = buckyos.getServiceRpcClient("aicc") as RpcClient;
+  const taskManager = buckyos.getServiceRpcClient("task-manager") as RpcClient;
+  const report: Record<string, unknown> = {
+    issue: "buckyos/sn-business#24",
+    zone_host: zoneHost,
+    app_id: appId,
+    user_id: userId,
+    provider_instance_name: PROVIDER_NAME,
+  };
+  const reportDir = REPORT_PATH.includes("/")
+    ? REPORT_PATH.slice(0, REPORT_PATH.lastIndexOf("/"))
+    : ".";
+
+  try {
+    const before = (await aicc.call("models.list", {})) as ModelsListResponse;
+    const providerBefore = before.providers?.find(
+      (item) => item.provider_instance_name === PROVIDER_NAME,
+    );
+    if (!providerBefore)
+      throw new Error(`Provider not found: ${PROVIDER_NAME}`);
+    if (!providerBefore.models?.length) {
+      throw new Error(`${PROVIDER_NAME} inventory is empty before refresh`);
+    }
+
+    const refresh = (await aicc.call("provider.refresh_models", {
+      provider_instance_name: PROVIDER_NAME,
+    })) as Record<string, unknown>;
+    if (refresh.ok !== true)
+      throw new Error(`Refresh failed: ${JSON.stringify(refresh)}`);
+
+    const after = (await aicc.call("models.list", {})) as ModelsListResponse;
+    const providerAfter = after.providers?.find(
+      (item) => item.provider_instance_name === PROVIDER_NAME,
+    );
+    if (!providerAfter?.models?.length) {
+      throw new Error(`${PROVIDER_NAME} inventory is empty after refresh`);
+    }
+    const modelAlias = chooseModel(providerAfter);
+    report.inventory = {
+      before_revision: providerBefore.inventory_revision ?? null,
+      refresh_revision: refresh.inventory_revision ?? null,
+      after_revision: providerAfter.inventory_revision ?? null,
+      model_count: providerAfter.models.length,
+      selected_model_alias: modelAlias,
+    };
+
+    const first = await invokeChat(
+      aicc,
+      taskManager,
+      modelAlias,
+      appId,
+      userId,
+      `issue24-first-${crypto.randomUUID()}`,
+    );
+    const second = await invokeChat(
+      aicc,
+      taskManager,
+      modelAlias,
+      appId,
+      userId,
+      `issue24-second-${crypto.randomUUID()}`,
+    );
+    const evidence = { ...cacheEvidence(first), ...cacheEvidence(second) };
+    if (REQUIRE_CACHE_EVIDENCE && Object.keys(evidence).length === 0) {
+      throw new Error("Provider response exposed no cache reuse evidence");
+    }
+    report.inference = {
+      consecutive_requests: 2,
+      cache_evidence: evidence,
+      cache_evidence_status: Object.keys(evidence).length
+        ? "observed"
+        : "not_exposed",
+    };
+
+    let invalidProviderRejected = false;
+    try {
+      await aicc.call("provider.refresh_models", {
+        provider_instance_name: `${PROVIDER_NAME}-missing-issue24`,
+      });
+    } catch {
+      invalidProviderRejected = true;
+    }
+    if (!invalidProviderRejected) {
+      throw new Error("Unknown provider refresh was not rejected");
+    }
+    report.error_path = { unknown_provider_refresh_rejected: true };
+    report.status = "passed";
+    await Deno.mkdir(reportDir, { recursive: true });
+    await Deno.writeTextFile(
+      REPORT_PATH,
+      `${JSON.stringify(report, null, 2)}\n`,
+    );
+    console.log(`Issue #24 SN SSO E2E passed: ${REPORT_PATH}`);
+  } catch (error) {
+    report.status = "failed";
+    report.error = error instanceof Error ? error.message : String(error);
+    await Deno.mkdir(reportDir, { recursive: true });
+    await Deno.writeTextFile(
+      REPORT_PATH,
+      `${JSON.stringify(report, null, 2)}\n`,
+    );
+    throw error;
+  } finally {
+    buckyos.logout(false);
+  }
+}
+
+main().catch((error) => {
+  console.error("Issue #24 SN SSO E2E failed");
+  console.error(error instanceof Error ? error.message : String(error));
+  Deno.exit(1);
+});

--- a/test/aicc_test/package.json
+++ b/test/aicc_test/package.json
@@ -6,6 +6,7 @@
     "smoke": "deno run --allow-net --allow-read --allow-write --allow-env --unsafely-ignore-certificate-errors aicc_smoke.ts",
     "test:fal": "deno run --allow-net --allow-read --allow-env --unsafely-ignore-certificate-errors test_fal.ts",
     "test:models": "deno run --allow-net --allow-read --allow-env --unsafely-ignore-certificate-errors test_list_models.ts",
+    "test:issue24-sso": "deno run --allow-net --allow-read --allow-write --allow-env --unsafely-ignore-certificate-errors issue24_sn_sso_e2e.ts",
     "remote": "node --experimental-strip-types aicc_remote_runner.ts",
     "test": "pnpm run smoke"
   },


### PR DESCRIPTION
## Summary

- remove Scheduler-side Device JWT generation and direct SN `/models` requests
- keep Scheduler responsible only for deriving and reconciling the managed SN AI inference endpoint
- use static startup model fallbacks and leave dynamic inventory refresh to the AICC Provider lifecycle
- add an AppClient-based Issue #24 E2E entry for inventory listing, provider refresh, consecutive inference, and an unknown-provider error path

## Why

The current SN SSO contract requires Device JWT to be exchanged through `sn-user-api` for an `sn-sso` session. Scheduler must not read the device private key or send a Device JWT directly to `sn-aicc`.

This implements the non-conflicting Scheduler and E2E preparation work tracked by [sn-business#24](https://github.com/buckyos/sn-business/issues/24), without modifying the concurrently evolving `sn-ai-provider` implementation.

## Impact

- AICC bootstrap no longer performs network model discovery
- Scheduler no longer directly depends on `reqwest` for SN AI setup
- managed provider endpoint reconciliation remains unchanged
- dynamic models continue through `Provider::refresh_inventory()` / `provider.refresh_models`
- the new E2E command is `pnpm run test:issue24-sso`

Cache reuse, refresh-token rotation, concurrent-login coalescing, and first-401 retry still require the new provider's redacted observability or Mock SN counters before they can become strict E2E assertions.

## Validation

- `cargo fmt -p scheduler -- --check`
- `cargo test --offline -p scheduler --test sn_ai_routing` — 20 passed
- `cargo test --offline -p scheduler` — 71 unit tests and 20 integration tests passed
- TypeScript syntax check for `issue24_sn_sso_e2e.ts`
- `package.json` parse check
- `git diff --check`

The real Deno/DV E2E has not run yet because Deno is not installed on the current development host.
