### PR TITLE
fix(desktop): keep launcher visible on narrow screens

### DIFF
--- a/src/frame/desktop/src/desktop/DesktopRoute.tsx
+++ b/src/frame/desktop/src/desktop/DesktopRoute.tsx
@@ -70,7 +70,6 @@ import {
   GRID_GAP,
   rowsForHeight,
   effectiveRowHeight,
-  desktopMinCanvasSize,
   mapPageToGrid,
   normalizeViewportProgress,
   getPageIndex,
@@ -568,10 +567,7 @@ export function DesktopRoute() {
       safeArea.bottom,
     360,
   )
-  const shouldLockDesktopViewport =
-    formFactor === 'desktop' &&
-    viewportSize.width >= desktopMinCanvasSize.width &&
-    viewportSize.height >= desktopMinCanvasSize.height
+  const shouldLockDesktopViewport = formFactor === 'desktop'
   const systemSidebarModel = store.getSystemSidebarDataModel(activeMobileApp?.id)
 
   const trayState = useMemo(() => {
@@ -742,8 +738,6 @@ export function DesktopRoute() {
                 className="relative overflow-hidden"
                 data-density={density}
                 style={{
-                  minWidth: isMobile ? undefined : desktopMinCanvasSize.width,
-                  minHeight: isMobile ? undefined : desktopMinCanvasSize.height,
                   paddingTop: workspaceTopPadding,
                   paddingBottom: resolvedDeadZone.bottom + safeArea.bottom,
                   paddingLeft: resolvedDeadZone.left + safeArea.left,
@@ -1180,10 +1174,12 @@ function DesktopTile({
             <AppIcon iconKey={app.iconKey} className="text-white" />
           </span>
           <span
-            className="max-w-full overflow-hidden px-0.5 font-display font-semibold text-[color:var(--cp-text)]"
+            className="max-w-full break-words overflow-hidden px-0.5 font-display font-semibold text-[color:var(--cp-text)]"
             style={{
               paddingTop: 'var(--label-padding-top)',
-              fontSize: 'var(--font-size-label)',
+              fontSize: isDesktop
+                ? 'clamp(12px,1.1vw,var(--font-size-label))'
+                : 'var(--font-size-label)',
               lineHeight: 'var(--line-height-label)',
               display: '-webkit-box',
               WebkitLineClamp: 2,

--- a/src/frame/desktop/src/desktop/widgets/ClockWidget.tsx
+++ b/src/frame/desktop/src/desktop/widgets/ClockWidget.tsx
@@ -1,8 +1,7 @@
 import { useI18n } from '../../i18n/provider'
 import { useMinuteClock } from '../shell'
-import type { DesktopWidgetProps } from './types'
 
-export function ClockWidget(_: DesktopWidgetProps) {
+export function ClockWidget() {
   const { locale } = useI18n()
   const now = useMinuteClock()
 
@@ -16,7 +15,7 @@ export function ClockWidget(_: DesktopWidgetProps) {
         </span>
       </div>
       <div className="-mt-1">
-        <p className="font-display whitespace-nowrap text-[1.72rem] font-semibold leading-[0.94] tracking-[-0.05em] text-[color:var(--cp-text)] sm:text-[2.8rem] lg:text-5xl">
+        <p className="font-display whitespace-nowrap text-[clamp(1.6rem,3.2vw,3rem)] font-semibold leading-[0.94] tracking-[-0.05em] text-[color:var(--cp-text)]">
           {new Intl.DateTimeFormat(locale, {
             hour: '2-digit',
             minute: '2-digit',

--- a/src/frame/desktop/src/models/DesktopUIDataModel.ts
+++ b/src/frame/desktop/src/models/DesktopUIDataModel.ts
@@ -867,7 +867,20 @@ export class DesktopUIStore {
     const nextWindows = this.snapshot.runtime.windows.map((w, i) => {
       const app = findDesktopAppById(this.snapshot.apps, w.appId)
       if (!app) return w
-      const geometry = this.normalizeWindowGeometry(app, w, i, bounds)
+      const normalizedGeometry = this.normalizeWindowGeometry(app, w, i, bounds)
+      const geometry = {
+        ...normalizedGeometry,
+        x: clamp(
+          normalizedGeometry.x,
+          bounds.minX,
+          bounds.maxRight - normalizedGeometry.width,
+        ),
+        y: clamp(
+          normalizedGeometry.y,
+          bounds.minY,
+          bounds.maxBottom - normalizedGeometry.height,
+        ),
+      }
       if (sameWindowGeometry(w, geometry)) return w
       changed = true
       this.persistWindowGeometry(w.appId, geometry)

--- a/src/frame/desktop/tests/e2e/pages/desktop.spec.ts
+++ b/src/frame/desktop/tests/e2e/pages/desktop.spec.ts
@@ -33,6 +33,59 @@ async function getScrollMetrics(locator: Locator) {
   }))
 }
 
+test('narrow desktop keeps widgets and launcher items fully visible', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 960, height: 720 })
+  await page.goto('/?scenario=normal')
+
+  const clockTime = page
+    .getByTestId('desktop-item-widget-clock')
+    .locator('p')
+    .first()
+  await expect(clockTime).toBeVisible()
+  await expect.poll(async () =>
+    clockTime.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true)
+
+  const launcherLabels = page.locator(
+    '.swiper-slide-active [data-testid^="desktop-app-"] > span:last-child',
+  )
+  await expect(launcherLabels.first()).toBeVisible()
+  expect(
+    await launcherLabels.evaluateAll((elements) =>
+      elements.every((element) => element.scrollWidth <= element.clientWidth),
+    ),
+  ).toBe(true)
+
+  await page.setViewportSize({ width: 780, height: 560 })
+
+  const activePageItems = page.locator(
+    '.swiper-slide-active [data-testid^="desktop-item-"]',
+  )
+  await expect(activePageItems.first()).toBeVisible()
+  await expect.poll(async () =>
+    activePageItems.evaluateAll((elements) =>
+      elements.every((element) => {
+        const rect = element.getBoundingClientRect()
+        return (
+          rect.left >= 0 &&
+          rect.top >= 0 &&
+          rect.right <= document.documentElement.clientWidth &&
+          rect.bottom <= document.documentElement.clientHeight
+        )
+      }),
+    ),
+  ).toBe(true)
+
+  const overflow = await page.evaluate(() => ({
+    horizontal: document.documentElement.scrollWidth > window.innerWidth,
+    vertical: document.documentElement.scrollHeight > window.innerHeight,
+  }))
+  expect(overflow.horizontal).toBeFalsy()
+  expect(overflow.vertical).toBeFalsy()
+})
+
 test('desktop flow opens settings window and supports locale switch', async ({
   page,
 }) => {
@@ -152,6 +205,7 @@ test('desktop flow opens settings window and supports locale switch', async ({
     .boundingBox()
   expect((constrainedWindow?.x ?? 0) + (constrainedWindow?.width ?? 0)).toBeLessThanOrEqual(780)
   expect(constrainedWindow?.y ?? 0).toBeGreaterThanOrEqual(0)
+  expect((constrainedWindow?.y ?? 0) + (constrainedWindow?.height ?? 0)).toBeLessThanOrEqual(560)
   expect((closeButtonBox?.x ?? 0) + (closeButtonBox?.width ?? 0)).toBeLessThanOrEqual(780)
   expect(closeButtonBox?.y ?? 0).toBeLessThanOrEqual(560)
   const hasPageOverflow = await page.evaluate(() => ({


### PR DESCRIPTION
## Summary
- keep desktop widgets and launcher items inside narrow desktop viewports
- scale long launcher labels and the clock for constrained widths
- clamp restored window geometry to the current viewport bounds
- add Playwright coverage for narrow desktop layout and bottom window bounds

## Verification
- `npm run check` — passed
- `npm run test:e2e -- tests/e2e/pages/desktop.spec.ts` — 11 passed, 1 failed
  - the new narrow desktop regression test passed
  - existing `window modal only blocks its owner window` timed out waiting for the Settings `Language` combobox after the window was dragged; reproduced with a single-worker rerun
- `git diff --check` — passed

Draft while the window-modal failure is investigated.
