### PR TITLE
fix(build): 恢复 PackageId Result 处理

### DIFF
--- a/src/kernel/buckyos-api/src/app_doc.rs
+++ b/src/kernel/buckyos-api/src/app_doc.rs
@@ -842,7 +842,11 @@ impl AppDoc {
                     "AppDoc package `{sub_pkg_name}` has invalid PackageId: {error}"
                 ))
             })?;
-            let unique_name = parsed.get_unique_name();
+            let unique_name = parsed.get_unique_name().map_err(|error| {
+                RPCErrors::ReasonError(format!(
+                    "AppDoc package `{sub_pkg_name}` has invalid package name: {error}"
+                ))
+            })?;
             let unique_name = unique_name.strip_prefix("all.").unwrap_or(&unique_name);
             let is_root_package = unique_name == app_id.as_str();
             let is_sub_package = unique_name

--- a/src/kernel/buckyos-api/src/test_config.rs
+++ b/src/kernel/buckyos-api/src/test_config.rs
@@ -421,11 +421,11 @@ pub fn gen_kernel_service_docs() -> HashMap<DID, EncodedDocument> {
     let mut docs = HashMap::new();
     let verify_hub_doc = crate::generate_verify_hub_service_doc();
     let verify_hub_json = serde_json::to_string(&verify_hub_doc).unwrap();
-    let verify_hub_did = PackageId::unique_name_to_did(VERIFY_HUB_UNIQUE_ID);
+    let verify_hub_did = PackageId::unique_name_to_did(VERIFY_HUB_UNIQUE_ID).unwrap();
 
     let scheduler_doc = crate::generate_scheduler_service_doc();
     let scheduler_json = serde_json::to_string(&scheduler_doc).unwrap();
-    let scheduler_did = PackageId::unique_name_to_did(SCHEDULER_SERVICE_UNIQUE_ID);
+    let scheduler_did = PackageId::unique_name_to_did(SCHEDULER_SERVICE_UNIQUE_ID).unwrap();
 
     // let repo_doc = crate::generate_repo_service_doc();
     // let repo_did = PackageId::unique_name_to_did(REPO_SERVICE_UNIQUE_ID);
@@ -433,19 +433,19 @@ pub fn gen_kernel_service_docs() -> HashMap<DID, EncodedDocument> {
 
     let smb_doc = crate::generate_smb_service_doc();
     let smb_json = serde_json::to_string(&smb_doc).unwrap();
-    let smb_did = PackageId::unique_name_to_did(SMB_SERVICE_UNIQUE_ID);
+    let smb_did = PackageId::unique_name_to_did(SMB_SERVICE_UNIQUE_ID).unwrap();
 
     let msg_center_doc = crate::generate_msg_center_service_doc();
     let msg_center_json = serde_json::to_string(&msg_center_doc).unwrap();
-    let msg_center_did = PackageId::unique_name_to_did(MSG_CENTER_SERVICE_UNIQUE_ID);
+    let msg_center_did = PackageId::unique_name_to_did(MSG_CENTER_SERVICE_UNIQUE_ID).unwrap();
 
     let opendan_doc = crate::generate_opendan_service_doc();
     let opendan_json = serde_json::to_string(&opendan_doc).unwrap();
-    let opendan_did = PackageId::unique_name_to_did(OPENDAN_SERVICE_UNIQUE_ID);
+    let opendan_did = PackageId::unique_name_to_did(OPENDAN_SERVICE_UNIQUE_ID).unwrap();
 
     let workflow_doc = crate::generate_workflow_service_doc();
     let workflow_json = serde_json::to_string(&workflow_doc).unwrap();
-    let workflow_did = PackageId::unique_name_to_did(WORKFLOW_SERVICE_UNIQUE_ID);
+    let workflow_did = PackageId::unique_name_to_did(WORKFLOW_SERVICE_UNIQUE_ID).unwrap();
     docs.insert(
         verify_hub_did,
         EncodedDocument::from_str(verify_hub_json).unwrap(),

--- a/src/kernel/scheduler/src/main.rs
+++ b/src/kernel/scheduler/src/main.rs
@@ -660,7 +660,7 @@ mod test {
 
         let mut docs = buckyos_api::test_config::gen_kernel_service_docs();
         docs.insert(
-            PackageId::unique_name_to_did("buckyos_filebrowser"),
+            PackageId::unique_name_to_did("buckyos_filebrowser").unwrap(),
             get_filebrowser_doc(),
         );
         let docs = docs


### PR DESCRIPTION
## 背景

PR #586 合并时未包含其后的构建修复提交，导致 `main` 将 `package-lib::PackageId` 的返回值按非 `Result` 类型使用。标准 `buckyos-build` 所使用的依赖 API 仍返回 `Result`，因此 `buckyos-api` 出现 `HashMap<Result<DID, PkgError>, ...>` 与 `HashMap<DID, ...>` 类型不匹配等编译错误。

## 修复内容

仅恢复以下 3 个文件原有的 `Result` 处理：

- `kernel/buckyos-api/src/app_doc.rs`：恢复 `get_unique_name()` 的错误映射和 `?`。
- `kernel/buckyos-api/src/test_config.rs`：恢复 `PackageId::unique_name_to_did(...).unwrap()`。
- `kernel/scheduler/src/main.rs`：恢复测试代码中的 DID 解包。

不涉及 SN Provider 逻辑，不引入依赖，也不修改协议或数据结构。

## 验证

- 分支基于合并 PR #586 后的最新 `buckyos/main` 创建。
- PR diff 仅包含上述 3 个文件、1 个提交。
- `rustfmt --check`：通过。
- `git diff --check`：通过。
- 等待 CI 在标准依赖环境中执行完整构建。