### PR TITLE
fix(desktop): avoid private virtualizer scroll state

### DIFF
--- a/src/frame/desktop/src/app/messagehub/conversation/history/ConversationHistoryPane.tsx
+++ b/src/frame/desktop/src/app/messagehub/conversation/history/ConversationHistoryPane.tsx
@@ -340,7 +340,7 @@ const ConversationHistoryPaneInner = forwardRef<ConversationHistoryPaneHandle, {
     virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => (
       !filterAnchor.current
       && scrollModeRef.current === 'free-scroll'
-      && item.end <= (instance.scrollOffset ?? 0) + instance.scrollAdjustments
+      && item.end <= (instance.scrollElement?.scrollTop ?? instance.scrollOffset ?? 0)
     )
   }, [virtualizer])
 


### PR DESCRIPTION
## 原因
ConversationHistoryPane.tsx:343 访问 Virtualizer 的私有属性 scrollAdjustments。仓库锁定的 @tanstack/virtual-core 3.14.0 将其声明为 private，导致 tsc -b 报 TS2341；这是源码与依赖的兼容性问题，不是特定机器的环境问题。

## 修复
改为读取滚动容器公开的 scrollTop，无容器时回退到公开的 scrollOffset。保留自由滚动与过滤锚点判断，不降级依赖、不绕过类型检查。仅修改一行源码。

## 验证
- 修改前 pnpm run check 复现 TS2341。
- 修改后 pnpm run build 通过（TypeScript + Vite）。
- 修改文件 ESLint 通过。
- Playwright 滚动位置及长历史过滤锚点回归：1440px 和 375px，共 4 项通过。

未部署或重启运行服务。